### PR TITLE
fix: explicitly declare widget surface in manifest to support dankbar

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -8,9 +8,13 @@
     "icon": "photo_camera",
     "type": "daemon",
     "capabilities": [
-        "control-center"
+        "control-center",
+        "dankbar-widget"
     ],
-    "component": "./QuickCaptureWidget.qml",
+    "components": {
+        "daemon": "./QuickCaptureWidget.qml",
+        "widget": "./QuickCaptureWidget.qml"
+    },
     "settings": "./QuickCaptureSettings.qml",
     "requires_dms": ">=1.2.0",
     "requires": [],

--- a/plugin.json
+++ b/plugin.json
@@ -11,6 +11,7 @@
         "control-center",
         "dankbar-widget"
     ],
+    "component": "./QuickCaptureWidget.qml",
     "components": {
         "daemon": "./QuickCaptureWidget.qml",
         "widget": "./QuickCaptureWidget.qml"


### PR DESCRIPTION
The plugin aims to be available both as a daemon and a widget in the dankbar. However, it was previously only declaring a `component` of type `daemon` and lacked the `dankbar-widget` capability.

While `QuickCaptureWidget.qml` attempts to dynamically register itself as a widget surface on load, DankMaterialShell requires the widget surface to be explicitly declared in the manifest (via the `components` object) in order to populate the dankbar's available widget list correctly at startup.

This fix replaces the single `component` property with a `components` object that explicitly defines both the `daemon` and `widget` surfaces, along with adding the `dankbar-widget` capability. This ensures the plugin correctly appears as an option for the dankbar.

## Summary by Sourcery

Declare the plugin as both a daemon and a dankbar widget in the manifest so it appears correctly as a selectable widget surface in DankMaterialShell.

New Features:
- Expose the plugin as a dankbar widget surface via the manifest components configuration.

Bug Fixes:
- Ensure the widget surface is explicitly declared with the dankbar-widget capability so it is listed as an available dankbar widget at startup.