### PR TITLE
fix: image editor still pops up when region selection is interrupted

### DIFF
--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -72,32 +72,45 @@ PluginComponent {
     }
 
     function startActualCapture() {
-        // 0ms debounce (execute instantly)
-        // 60 seconds timeout
-
-        Proc.runCommand("screenshot-trigger", root.screenshotArgs(), (stdout, exitCode) => {
-            if (exitCode === 0) {
-                root.isCapturing = false;
-                root.activeIpcMode = "";
-                root.resolvedDmsPath = "dms"; // reset to default path on success
-                modal.shouldBeVisible = true;
-                modal.openCentered();
-            } else {
-                if (root.resolvedDmsPath === "dms") {
-                    root.resolvedDmsPath = "/usr/local/bin/dms";
-                    root.startActualCapture();
-                } else if (root.resolvedDmsPath === "/usr/local/bin/dms") {
-                    root.resolvedDmsPath = "/usr/bin/dms";
-                    root.startActualCapture();
+        // Delete any existing capture file before taking the screenshot.
+        // This lets us detect ESC cancellation when `dms screenshot region`
+        // incorrectly returns exit code 0 without writing a new file.
+        Proc.runCommand("pre-capture-cleanup", ["rm", "-f", "/tmp/dms_capture_bg.png"], () => {
+            Proc.runCommand("screenshot-trigger", root.screenshotArgs(), (stdout, exitCode) => {
+                if (exitCode === 0) {
+                    // Verify the file was actually written before opening the editor.
+                    // If the user pressed ESC, dms may return 0 but write no file.
+                    Proc.runCommand("verify-capture", ["test", "-f", "/tmp/dms_capture_bg.png"], (_, fileExists) => {
+                        if (fileExists === 0) {
+                            root.isCapturing = false;
+                            root.activeIpcMode = "";
+                            root.resolvedDmsPath = "dms"; // reset to default path on success
+                            modal.shouldBeVisible = true;
+                            modal.openCentered();
+                        } else {
+                            // File not written — user cancelled with ESC. Reset silently.
+                            root.isCapturing = false;
+                            root.activeIpcMode = "";
+                            root.resolvedDmsPath = "dms";
+                        }
+                    });
                 } else {
-                    root.isCapturing = false;
-                    root.activeIpcMode = "";
-                    root.resolvedDmsPath = "dms"; // reset to default path for next attempts
-                    if (typeof ToastService !== "undefined" && ToastService)
-                        ToastService.showError("Screenshot canceled or failed.");
+                    if (root.resolvedDmsPath === "dms") {
+                        root.resolvedDmsPath = "/usr/local/bin/dms";
+                        root.startActualCapture();
+                    } else if (root.resolvedDmsPath === "/usr/local/bin/dms") {
+                        root.resolvedDmsPath = "/usr/bin/dms";
+                        root.startActualCapture();
+                    } else {
+                        root.isCapturing = false;
+                        root.activeIpcMode = "";
+                        root.resolvedDmsPath = "dms"; // reset to default path for next attempts
+                        if (typeof ToastService !== "undefined" && ToastService)
+                            ToastService.showError("Screenshot canceled or failed.");
+                    }
                 }
-            }
-        }, 0, 60000);
+            }, 0, 60000);
+        });
     }
 
     function closeOverlay() {


### PR DESCRIPTION
Old behavior: when selecting region, if I press esc to interrupt, image editor still open (with last success capture)
The cause is that the temp image doesn't get deleted

I think this is a bug? At least it doesn't match my intuition
If it's not, maybe there could be a setting option for this

Coded by Sonnet 4.6, this fix works fine on my PC (arch + niri)

## Summary by Sourcery

Bug Fixes:
- Prevent the image editor from opening when a region capture is cancelled via ESC by ensuring no stale screenshot file is reused.