### PR TITLE
fix (floaty): multiple floating images now work correctly

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -247,12 +247,33 @@ PluginComponent {
         }
 
         function openImage(path: string) : string {
-            if (path.startsWith("file://"))
+            if (path.startsWith("file://")) {
                 path = path.substring(7);
-            root.restoringFromFloat = (path === "/tmp/dms_capture_float.png");
-            if (path === "/tmp/dms_capture_bg.png" || path === "/tmp/dms_capture_float.png") {
+            }
+            if (path === "/tmp/dms_capture_bg.png") {
+                root.restoringFromFloat = false;
                 root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
+            } else if (path.startsWith("/tmp/dms_capture_float/")) {
+                const floatBase = path.replace(/\.png$/, "");
+                const bgPath = floatBase + "_bg.png";
+                const strokesPath = floatBase + "_strokes.json";
+                Proc.runCommand("check-float-bg", ["test", "-f", bgPath], (_, bgExists) => {
+                    if (bgExists === 0) {
+                        Proc.runCommand("cp-float-bg", ["cp", "-f", bgPath, "/tmp/dms_capture_bg.png"], () => {
+                            Proc.runCommand("cp-float-strokes", ["cp", "-f", strokesPath, "/tmp/dms_capture_strokes.json"], () => {
+                                root.restoringFromFloat = true;
+                                root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
+                            });
+                        });
+                    } else {
+                        Proc.runCommand("cp-float-img", ["cp", "-f", path, "/tmp/dms_capture_bg.png"], () => {
+                            root.restoringFromFloat = false;
+                            root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
+                        });
+                    }
+                });
             } else {
+                root.restoringFromFloat = false;
                 root.loadImageFromUri(path);
             }
             return "SUCCESS";

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -337,16 +337,23 @@ QtObject {
                     }
                     
                     // 4. Float the baked image
-                    const cmd = "cp -f -- " + shellPathExpression(finalPath) + " /tmp/dms_capture_float.png" +
-                                " && dms ipc call floaty floatFromUrl file:///tmp/dms_capture_float.png";
-                    Proc.runCommand("float-capture", ["sh", "-c", cmd], (stdout, exitCode) => {
-                        if (exitCode === 0) {
-                            root.closeRequested();
-                        } else {
-                            notifyError("Failed to float image (make sure dms-floaty is running).");
-                        }
-                        cleanupTemp(finalPath);
-                        if (originalPng) cleanupTemp(originalPng);
+                    const floatDest = "/tmp/dms_capture_float/" + Date.now() + ".png";
+                    const floatBase = floatDest.replace(/\.png$/, "");
+
+                    Proc.runCommand("mkdir-float-dir", ["mkdir", "-p", "/tmp/dms_capture_float"], () => {
+                        Proc.runCommand("cp-float", ["cp", "-f", finalPath, floatDest], () => {
+                            Proc.runCommand("cp-float-bg", ["cp", "-f", "/tmp/dms_capture_bg.png", floatBase + "_bg.png"]);
+                            Proc.runCommand("cp-float-strokes", ["cp", "-f", "/tmp/dms_capture_strokes.json", floatBase + "_strokes.json"]);
+                            Proc.runCommand("float-capture", ["dms", "ipc", "call", "floaty", "floatFromUrl", "file://" + floatDest], (stdout, exitCode) => {
+                                if (exitCode === 0) {
+                                    root.closeRequested();
+                                } else {
+                                    notifyError("Failed to float image (make sure dms-floaty is running).");
+                                }
+                                cleanupTemp(finalPath);
+                                if (originalPng) cleanupTemp(originalPng);
+                            });
+                        });
                     });
                 });
             });


### PR DESCRIPTION
Old behavior: creating multiple float images just doesn't work, they will become same (sharing same filename?)

After yesterday's refactoring, my dms 1.4.6 refuses to load `plugin.json`, so I only tested with a local version with a few things overwritten (made by AI), I guess it doesn't matter?
```json
    "type": "daemon",
    "component": "./QuickCaptureDaemon.qml",
    "components": {
        "daemon": "./QuickCaptureDaemon.qml",
        "widget": "./QuickCaptureDaemon.qml"
    },
```

and still, coded by Sonnet 4.6

## Summary by Sourcery

Support multiple independent floating images and restore their editing state when reopened.

Bug Fixes:
- Fix floating captures overwriting each other by storing each float image under a unique timestamp-based path.

Enhancements:
- Preserve and restore background and stroke data per floating image when reopening for editing.
- Normalize file URLs and handle missing float image resources gracefully with user-facing error feedback.