### PR TITLE
fix: restore editable vectors after float round-trip

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -247,6 +247,8 @@ PluginComponent {
         }
 
         function openImage(path: string) : string {
+            if (path.startsWith("file://"))
+                path = path.substring(7);
             root.restoringFromFloat = (path === "/tmp/dms_capture_float.png");
             if (path === "/tmp/dms_capture_bg.png" || path === "/tmp/dms_capture_float.png") {
                 root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -786,6 +786,10 @@ DankModal {
                                 if (s.isItalic !== undefined) stroke.isItalic = s.isItalic;
                                 if (s.isUnderline !== undefined) stroke.isUnderline = s.isUnderline;
                                 if (s.counter !== undefined) stroke.counter = s.counter;
+                                if (s.format !== undefined) stroke.format = s.format;
+                                if (s.hasBackground !== undefined) stroke.hasBackground = s.hasBackground;
+                                if (s.cornerRadius !== undefined) stroke.cornerRadius = s.cornerRadius;
+                                if (s.borderWidth !== undefined) stroke.borderWidth = s.borderWidth;
                                 restoredStrokes.push(stroke);
                             }
                             window.strokes = restoredStrokes;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -10,6 +10,7 @@ import "./dms-common"
 import "components"
 import "components/Helpers.js" as Helpers
 import "components/DrawingRenderer.js" as DrawingRenderer
+import "components/StrokeProperties.js" as StrokeProps
 
 DankModal {
     id: window
@@ -310,10 +311,9 @@ DankModal {
             tool: window.copiedStroke.tool,
             color: window.copiedStroke.color,
             width: window.copiedStroke.width,
-            points: newPoints,
-            counter: window.copiedStroke.counter
+            points: newPoints
         };
-        
+        StrokeProps.copyStrokeProperties(window.copiedStroke, pasted);
         window.pushStroke(pasted);
         
         if (window.currentTool === "select") {
@@ -610,9 +610,9 @@ DankModal {
                     tool: window.selectedStroke.tool,
                     color: window.selectedStroke.color.toString(),
                     width: window.selectedStroke.width,
-                    points: window.selectedStroke.points.map(p => Qt.point(p.x, p.y)),
-                    counter: window.selectedStroke.counter
+                    points: window.selectedStroke.points.map(p => Qt.point(p.x, p.y))
                 };
+                StrokeProps.copyStrokeProperties(window.selectedStroke, window.copiedStroke);
                 window.performPasteAction();
                 event.accepted = true;
                 return;
@@ -779,17 +779,7 @@ DankModal {
                                         stroke.points.push(Qt.point(s.points[j].x, s.points[j].y));
                                     }
                                 }
-                                if (s.text !== undefined) stroke.text = s.text;
-                                if (s.isMonospace !== undefined) stroke.isMonospace = s.isMonospace;
-                                if (s.fontFamily !== undefined) stroke.fontFamily = s.fontFamily;
-                                if (s.isBold !== undefined) stroke.isBold = s.isBold;
-                                if (s.isItalic !== undefined) stroke.isItalic = s.isItalic;
-                                if (s.isUnderline !== undefined) stroke.isUnderline = s.isUnderline;
-                                if (s.counter !== undefined) stroke.counter = s.counter;
-                                if (s.format !== undefined) stroke.format = s.format;
-                                if (s.hasBackground !== undefined) stroke.hasBackground = s.hasBackground;
-                                if (s.cornerRadius !== undefined) stroke.cornerRadius = s.cornerRadius;
-                                if (s.borderWidth !== undefined) stroke.borderWidth = s.borderWidth;
+                                StrokeProps.copyStrokeProperties(s, stroke);
                                 restoredStrokes.push(stroke);
                             }
                             window.strokes = restoredStrokes;

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import qs.Common
 import qs.Services
+import "StrokeProperties.js" as StrokeProps
 
 QtObject {
     id: root
@@ -310,17 +311,7 @@ QtObject {
                             newStroke.points.push({ x: s.points[j].x, y: s.points[j].y });
                         }
                     }
-                    if (s.text !== undefined) newStroke.text = s.text;
-                    if (s.isMonospace !== undefined) newStroke.isMonospace = s.isMonospace;
-                    if (s.fontFamily !== undefined) newStroke.fontFamily = s.fontFamily;
-                    if (s.isBold !== undefined) newStroke.isBold = s.isBold;
-                    if (s.isItalic !== undefined) newStroke.isItalic = s.isItalic;
-                    if (s.isUnderline !== undefined) newStroke.isUnderline = s.isUnderline;
-                    if (s.counter !== undefined) newStroke.counter = s.counter;
-                    if (s.format !== undefined) newStroke.format = s.format;
-                    if (s.hasBackground !== undefined) newStroke.hasBackground = s.hasBackground;
-                    if (s.cornerRadius !== undefined) newStroke.cornerRadius = s.cornerRadius;
-                    if (s.borderWidth !== undefined) newStroke.borderWidth = s.borderWidth;
+                    StrokeProps.copyStrokeProperties(s, newStroke);
                     serializedStrokes.push(newStroke);
                 }
 

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -317,6 +317,10 @@ QtObject {
                     if (s.isItalic !== undefined) newStroke.isItalic = s.isItalic;
                     if (s.isUnderline !== undefined) newStroke.isUnderline = s.isUnderline;
                     if (s.counter !== undefined) newStroke.counter = s.counter;
+                    if (s.format !== undefined) newStroke.format = s.format;
+                    if (s.hasBackground !== undefined) newStroke.hasBackground = s.hasBackground;
+                    if (s.cornerRadius !== undefined) newStroke.cornerRadius = s.cornerRadius;
+                    if (s.borderWidth !== undefined) newStroke.borderWidth = s.borderWidth;
                     serializedStrokes.push(newStroke);
                 }
 

--- a/components/StrokeProperties.js
+++ b/components/StrokeProperties.js
@@ -1,0 +1,15 @@
+.pragma library
+
+function copyStrokeProperties(source, target) {
+    if (source.text !== undefined) target.text = source.text;
+    if (source.isMonospace !== undefined) target.isMonospace = source.isMonospace;
+    if (source.fontFamily !== undefined) target.fontFamily = source.fontFamily;
+    if (source.isBold !== undefined) target.isBold = source.isBold;
+    if (source.isItalic !== undefined) target.isItalic = source.isItalic;
+    if (source.isUnderline !== undefined) target.isUnderline = source.isUnderline;
+    if (source.counter !== undefined) target.counter = source.counter;
+    if (source.format !== undefined) target.format = source.format;
+    if (source.hasBackground !== undefined) target.hasBackground = source.hasBackground;
+    if (source.cornerRadius !== undefined) target.cornerRadius = source.cornerRadius;
+    if (source.borderWidth !== undefined) target.borderWidth = source.borderWidth;
+}


### PR DESCRIPTION
## Summary

Two bugs were preventing strokes from being editable after the float → return-to-editor round-trip:

### Bug 1: `file://` prefix stripped in daemon refactor (critical)

Commit `08fd05f` refactored `openImage()` and removed the `file://` prefix stripping. When Floaty sends `file:///tmp/dms_capture_float.png`:

1. `restoringFromFloat` stays `false` (string mismatch due to `file://`)
2. Falls through to `loadImageFromUri("file:///tmp/dms_capture_float.png")`
3. `loadImageFromUri` copies the baked float image **over** `/tmp/dms_capture_bg.png`
4. JSON strokes are **not restored** → user sees flattened image, no editable vectors

**Fix**: Restored the `file://` stripping before path comparison.

### Bug 2: Missing stroke property serialization

Four stroke properties were not serialized/restored:
- `format` (stamp counter format)
- `hasBackground`, `cornerRadius` (text background)
- `borderWidth` (callout border)

### Refactoring

Extracted `copyStrokeProperties()` into `components/StrokeProperties.js` (pragma library) used by all three code paths — float serialization, float restore, and copy/duplicate. Also fixed the copy/duplicate (C key) path which was previously missing text style and stamp format properties.