### PR TITLE
feat: smart callout destination placement toward canvas center

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1156,6 +1156,8 @@ DankModal {
                                 bgImageItem: window.bgImageItem,
                                 canvasWidth: window.canvasWidth,
                                 canvasHeight: window.canvasHeight,
+                                canvasMinX: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.x : 0,
+                                canvasMinY: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.y : 0,
                             });
                         }
 
@@ -1515,33 +1517,38 @@ DankModal {
                                         const dw = rw * zoom;
                                         const dh = rh * zoom;
 
-                                        // Smart placement: place destination on the opposite side
-                                        // of the source relative to the canvas center
+                                        // Visible canvas bounds in absolute coordinates
+                                        const visX = (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.x : 0;
+                                        const visY = (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.y : 0;
+                                        const visW = window.canvasWidth;
+                                        const visH = window.canvasHeight;
+
+                                        // Smart placement: opposite side of source relative to visible area center
                                         const srcMinX = Math.min(p0.x, p1.x);
                                         const srcMaxX = Math.max(p0.x, p1.x);
                                         const srcMinY = Math.min(p0.y, p1.y);
                                         const srcMaxY = Math.max(p0.y, p1.y);
                                         const srcCx = (srcMinX + srcMaxX) / 2;
                                         const srcCy = (srcMinY + srcMaxY) / 2;
-                                        const canvasCx = window.canvasWidth / 2;
-                                        const canvasCy = window.canvasHeight / 2;
+                                        const visCx = visX + visW / 2;
+                                        const visCy = visY + visH / 2;
 
-                                        // Direction from source center toward canvas center
-                                        const dirX = canvasCx - srcCx >= 0 ? 1 : -1; // 1 = right, -1 = left
-                                        const dirY = canvasCy - srcCy >= 0 ? 1 : -1; // 1 = down,  -1 = up
+                                        const dirX = visCx - srcCx >= 0 ? 1 : -1;
+                                        const dirY = visCy - srcCy >= 0 ? 1 : -1;
 
                                         let dx = dirX > 0 ? srcMaxX + margin : srcMinX - dw - margin;
                                         let dy = dirY > 0 ? srcMaxY + margin : srcMinY - dh - margin;
 
-                                        // Clamp to canvas bounds
-                                        dx = Math.max(margin, Math.min(dx, window.canvasWidth - dw - margin));
-                                        dy = Math.max(margin, Math.min(dy, window.canvasHeight - dh - margin));
+                                        const rightBound = visX + visW - dw - margin;
+                                        const bottomBound = visY + visH - dh - margin;
+                                        dx = Math.max(visX + margin, Math.min(dx, rightBound));
+                                        dy = Math.max(visY + margin, Math.min(dy, bottomBound));
                                         
                                         stroke.points = [
-                                            Qt.point(srcMinX, srcMinY), // Source TL
-                                            Qt.point(srcMaxX, srcMaxY), // Source BR
-                                            Qt.point(dx, dy), // Dest TL
-                                            Qt.point(dx + dw, dy + dh) // Dest BR
+                                            Qt.point(srcMinX, srcMinY),
+                                            Qt.point(srcMaxX, srcMaxY),
+                                            Qt.point(dx, dy),
+                                            Qt.point(dx + dw, dy + dh)
                                         ];
                                     } else {
                                         window.currentStroke = null;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1154,6 +1154,8 @@ DankModal {
                                 roundRect: window.roundRect,
                                 roundHighlighter: window.roundHighlighter,
                                 bgImageItem: window.bgImageItem,
+                                canvasWidth: window.canvasWidth,
+                                canvasHeight: window.canvasHeight,
                             });
                         }
 
@@ -1508,16 +1510,36 @@ DankModal {
                                     const rh = Math.abs(p1.y - p0.y);
                                     
                                     if (rw > 5 && rh > 5) {
-                                        // Create destination rect using current zoom factor
+                                        const margin = 50;
                                         const zoom = stroke.width / 100.0;
                                         const dw = rw * zoom;
                                         const dh = rh * zoom;
-                                        const dx = Math.max(p0.x, p1.x) + 50;
-                                        const dy = Math.max(p0.y, p1.y) + 50;
+
+                                        // Smart placement: place destination on the opposite side
+                                        // of the source relative to the canvas center
+                                        const srcMinX = Math.min(p0.x, p1.x);
+                                        const srcMaxX = Math.max(p0.x, p1.x);
+                                        const srcMinY = Math.min(p0.y, p1.y);
+                                        const srcMaxY = Math.max(p0.y, p1.y);
+                                        const srcCx = (srcMinX + srcMaxX) / 2;
+                                        const srcCy = (srcMinY + srcMaxY) / 2;
+                                        const canvasCx = window.canvasWidth / 2;
+                                        const canvasCy = window.canvasHeight / 2;
+
+                                        // Direction from source center toward canvas center
+                                        const dirX = canvasCx - srcCx >= 0 ? 1 : -1; // 1 = right, -1 = left
+                                        const dirY = canvasCy - srcCy >= 0 ? 1 : -1; // 1 = down,  -1 = up
+
+                                        let dx = dirX > 0 ? srcMaxX + margin : srcMinX - dw - margin;
+                                        let dy = dirY > 0 ? srcMaxY + margin : srcMinY - dh - margin;
+
+                                        // Clamp to canvas bounds
+                                        dx = Math.max(margin, Math.min(dx, window.canvasWidth - dw - margin));
+                                        dy = Math.max(margin, Math.min(dy, window.canvasHeight - dh - margin));
                                         
                                         stroke.points = [
-                                            Qt.point(Math.min(p0.x, p1.x), Math.min(p0.y, p1.y)), // Source TL
-                                            Qt.point(Math.max(p0.x, p1.x), Math.max(p0.y, p1.y)), // Source BR
+                                            Qt.point(srcMinX, srcMinY), // Source TL
+                                            Qt.point(srcMaxX, srcMaxY), // Source BR
                                             Qt.point(dx, dy), // Dest TL
                                             Qt.point(dx + dw, dy + dh) // Dest BR
                                         ];

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -246,8 +246,20 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 const zoom = stroke.width / 100.0;
                 const dw = rw * zoom;
                 const dh = rh * zoom;
-                const dx = srcP1.x + 50;
-                const dy = srcP1.y + 50;
+
+                // Smart placement: opposite side of source relative to canvas center
+                const srcCx = (srcP0.x + srcP1.x) / 2;
+                const srcCy = (srcP0.y + srcP1.y) / 2;
+                const cvW = config.canvasWidth || 1920;
+                const cvH = config.canvasHeight || 1080;
+                const dirX = (cvW / 2) - srcCx >= 0 ? 1 : -1;
+                const dirY = (cvH / 2) - srcCy >= 0 ? 1 : -1;
+                const margin = 50;
+
+                let dx = dirX > 0 ? srcP1.x + margin : srcP0.x - dw - margin;
+                let dy = dirY > 0 ? srcP1.y + margin : srcP0.y - dh - margin;
+                dx = Math.max(margin, Math.min(dx, cvW - dw - margin));
+                dy = Math.max(margin, Math.min(dy, cvH - dh - margin));
                 
                 dstP0 = { x: dx, y: dy };
                 dstP1 = { x: dx + dw, y: dy + dh };

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -247,19 +247,25 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 const dw = rw * zoom;
                 const dh = rh * zoom;
 
-                // Smart placement: opposite side of source relative to canvas center
+                // Smart placement: opposite side of source relative to visible area center
                 const srcCx = (srcP0.x + srcP1.x) / 2;
                 const srcCy = (srcP0.y + srcP1.y) / 2;
-                const cvW = config.canvasWidth || 1920;
-                const cvH = config.canvasHeight || 1080;
-                const dirX = (cvW / 2) - srcCx >= 0 ? 1 : -1;
-                const dirY = (cvH / 2) - srcCy >= 0 ? 1 : -1;
+                const visX = config.canvasMinX || 0;
+                const visY = config.canvasMinY || 0;
+                const visW = config.canvasWidth || 1920;
+                const visH = config.canvasHeight || 1080;
+                const visCx = visX + visW / 2;
+                const visCy = visY + visH / 2;
+                const dirX = visCx - srcCx >= 0 ? 1 : -1;
+                const dirY = visCy - srcCy >= 0 ? 1 : -1;
                 const margin = 50;
 
                 let dx = dirX > 0 ? srcP1.x + margin : srcP0.x - dw - margin;
                 let dy = dirY > 0 ? srcP1.y + margin : srcP0.y - dh - margin;
-                dx = Math.max(margin, Math.min(dx, cvW - dw - margin));
-                dy = Math.max(margin, Math.min(dy, cvH - dh - margin));
+                const rightBound = visX + visW - dw - margin;
+                const bottomBound = visY + visH - dh - margin;
+                dx = Math.max(visX + margin, Math.min(dx, rightBound));
+                dy = Math.max(visY + margin, Math.min(dy, bottomBound));
                 
                 dstP0 = { x: dx, y: dy };
                 dstP1 = { x: dx + dw, y: dy + dh };


### PR DESCRIPTION
## Summary
- Callout destination (Z tool) always placed at bottom-right of source → overflows when source near canvas edge
- Smart placement: detect source position relative to canvas center, place destination on **opposite side**
- Dest clamped to canvas bounds to prevent overflow
- Preview during drag now matches final position (both DrawingRenderer.js and QuickCaptureModal.qml use same logic)

## Behavior
| Source location | Dest placement |
|---|---|
| Top-left → | Bottom-right (same as before) |
| Top-right → | Bottom-left |
| Bottom-left → | Top-right |
| Bottom-right → | Top-left |
| Center → | Bottom-right (dirX=1, dirY=1) |

## Summary by Sourcery

Implement smart, canvas-aware placement for callout destination rectangles and keep preview behavior consistent between the QML UI and the drawing renderer.

New Features:
- Place callout destinations on the side of the source facing the canvas center instead of always bottom-right, with automatic clamping to canvas bounds to avoid overflow.

Enhancements:
- Pass canvas dimensions through to the drawing logic and unify destination placement calculations between QuickCaptureModal and DrawingRenderer for consistent previews and final renders.