### PR TITLE
feat(backdrop): implement custom image backdrop mode and hotkeys

### DIFF
--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -19,7 +19,8 @@ QtObject {
         { id: "highlighter", icon: "border_color", tooltip: qsTr("Highlighter (S)") },
         { id: "eraser", icon: "auto_fix_normal", tooltip: qsTr("Eraser (D)") },
         { id: "spotlight", icon: "highlight", tooltip: qsTr("Focus Spotlight (F)") },
-        { id: "callout", icon: "zoom_in", tooltip: qsTr("Area Zoom (Z) | Hold B for Loupe") }
+        { id: "callout", icon: "zoom_in", tooltip: qsTr("Area Zoom (Z) | Hold G for Loupe") },
+        { id: "backdrop", icon: "wallpaper", tooltip: qsTr("Image Backdrop (B)") }
     ]
 
     readonly property string selectedPreset: pluginData["color_palette_preset"] || "adaptive"
@@ -165,7 +166,8 @@ QtObject {
         { key: "S", tool: "highlighter" },
         { key: "D", tool: "eraser" },
         { key: "F", tool: "spotlight" },
-        { key: "Z", tool: "callout" }
+        { key: "Z", tool: "callout" },
+        { key: "B", tool: "backdrop" }
     ]
 
     readonly property var colorShortcuts: [

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -50,20 +50,32 @@ DankModal {
     property var parentWidget: null
 
     // State Variables
-    property string currentTool: "crop" // crop, select, pen, line, arrow, rect, ellipse, text, pixelate, redact, stamp, highlighter, eraser, spotlight
+    property string currentTool: "crop" // crop, select, pen, line, arrow, rect, ellipse, text, pixelate, redact, stamp, highlighter, eraser, spotlight, backdrop
     property string lastActiveTool: "pen"
     readonly property real dpr: Screen.devicePixelRatio || 1.0
     onCurrentToolChanged: {
         if (currentTool !== "text" && window.isTyping) {
             window.commitTypingText();
         }
-        if (currentTool !== "crop") {
+        if (currentTool !== "crop" && currentTool !== "backdrop") {
             lastActiveTool = currentTool;
         }
         if (window.activeCanvas) {
             window.activeCanvas.requestPaint();
         }
     }
+
+    // Backdrop State Variables
+    property string backdropMode: "none" // none, solid, gradient, image
+    property color backdropSolidColor: Theme.primary
+    property color backdropGradientStart: Theme.primary
+    property color backdropGradientEnd: Theme.secondary
+    property int backdropGradientAngle: 45
+    property string backdropImageSource: ""
+    property int backdropPadding: 40
+    property int backdropCornerRadius: 12
+    property int backdropShadowStrength: 50
+    property string backdropAspectRatio: "auto" // auto, 1:1, 16:9, 4:3
 
     // Intensity Management
     property int strokeWidth: 8
@@ -143,17 +155,134 @@ DankModal {
         return maxEditDimension / max;
     }
 
-    readonly property real canvasWidth: {
+    readonly property string effectiveBackdropMode: window.currentTool === "crop" ? "none" : window.backdropMode
+
+    readonly property real screenshotWidth: {
         if (window.currentTool !== "crop" && window.hasSelection) {
             return window.cropRect.width;
         }
         return window.bgImageItem ? window.bgImageItem.sourceSize.width : 1;
     }
-    readonly property real canvasHeight: {
+    readonly property real screenshotHeight: {
         if (window.currentTool !== "crop" && window.hasSelection) {
             return window.cropRect.height;
         }
         return window.bgImageItem ? window.bgImageItem.sourceSize.height : 1;
+    }
+
+    readonly property real canvasWidth: screenshotWidth
+    readonly property real canvasHeight: screenshotHeight
+
+    readonly property real backdropScaleFactor: {
+        if (window.effectiveBackdropMode === "none") return 1.0;
+        const pad = window.backdropPadding;
+        const boxW = canvasWidth - 2 * pad;
+        const boxH = canvasHeight - 2 * pad;
+        if (boxW <= 0 || boxH <= 0) return 1.0;
+        return Math.min(boxW / canvasWidth, boxH / canvasHeight);
+    }
+
+    readonly property real screenshotXOffset: window.effectiveBackdropMode === "none" ? 0 : (canvasWidth - screenshotWidth * backdropScaleFactor) / 2
+    readonly property real screenshotYOffset: window.effectiveBackdropMode === "none" ? 0 : (canvasHeight - screenshotHeight * backdropScaleFactor) / 2
+
+    function drawBackdropBackground(ctx, w, h) {
+        if (window.backdropMode === "solid") {
+            ctx.fillStyle = window.backdropSolidColor.toString();
+            ctx.fillRect(0, 0, w, h);
+        } else if (window.backdropMode === "gradient") {
+            const angleRad = (window.backdropGradientAngle * Math.PI) / 180;
+            const x1 = w / 2 - Math.cos(angleRad) * w / 2;
+            const y1 = h / 2 - Math.sin(angleRad) * h / 2;
+            const x2 = w / 2 + Math.cos(angleRad) * w / 2;
+            const y2 = h / 2 + Math.sin(angleRad) * h / 2;
+            const grad = ctx.createLinearGradient(x1, y1, x2, y2);
+            grad.addColorStop(0, window.backdropGradientStart.toString());
+            grad.addColorStop(1, window.backdropGradientEnd.toString());
+            ctx.fillStyle = grad;
+            ctx.fillRect(0, 0, w, h);
+        } else if (window.backdropMode === "image") {
+            ctx.fillStyle = Theme.surface.toString();
+            ctx.fillRect(0, 0, w, h);
+        }
+    }
+
+    function drawScreenshotShadow(ctx) {
+        if (window.backdropShadowStrength <= 0) return;
+        ctx.save();
+        const r = window.backdropCornerRadius * window.backdropScaleFactor;
+        const x = window.screenshotXOffset;
+        const y = window.screenshotYOffset;
+        const w = window.screenshotWidth * window.backdropScaleFactor;
+        const h = window.screenshotHeight * window.backdropScaleFactor;
+        
+        const opacity = (window.backdropShadowStrength / 100.0) * 0.15;
+        
+        // Draw 4 concentric shadow layers for a soft, fast shadow effect without Gaussian blur CPU cost
+        for (let i = 1; i <= 4; i++) {
+            ctx.fillStyle = "rgba(0, 0, 0, " + (opacity / i) + ")";
+            const offset = i * 2;
+            const blur = i * 3;
+            
+            const sx = x - blur/2;
+            const sy = y - blur/2 + offset;
+            const sw = w + blur;
+            const sh = h + blur;
+            const sr = r + blur/2;
+            
+            ctx.beginPath();
+            if (sr > 0) {
+                ctx.moveTo(sx + sr, sy);
+                ctx.lineTo(sx + sw - sr, sy);
+                ctx.arcTo(sx + sw, sy, sx + sw, sy + sr, sr);
+                ctx.lineTo(sx + sw, sy + sh - sr);
+                ctx.arcTo(sx + sw, sy + sh, sx + sw - sr, sy + sh, sr);
+                ctx.lineTo(sx + sr, sy + sh);
+                ctx.arcTo(sx, sy + sh, sx, sy + sh - sr, sr);
+                ctx.lineTo(sx, sy + sr);
+                ctx.arcTo(sx, sy, sx + sr, sy, sr);
+            } else {
+                ctx.rect(sx, sy, sw, sh);
+            }
+            ctx.closePath();
+            ctx.fill();
+        }
+        ctx.restore();
+    }
+
+    function drawScreenshotImage(ctx, imgSource) {
+        ctx.save();
+        ctx.imageSmoothingEnabled = true;
+        ctx.imageSmoothingQuality = "high";
+        
+        const r = window.backdropCornerRadius * window.backdropScaleFactor;
+        const x = window.screenshotXOffset;
+        const y = window.screenshotYOffset;
+        const w = window.screenshotWidth * window.backdropScaleFactor;
+        const h = window.screenshotHeight * window.backdropScaleFactor;
+        
+        ctx.beginPath();
+        if (r > 0) {
+            ctx.moveTo(x + r, y);
+            ctx.lineTo(x + w - r, y);
+            ctx.arcTo(x + w, y, x + w, y + r, r);
+            ctx.lineTo(x + w, y + h - r);
+            ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+            ctx.lineTo(x + r, y + h);
+            ctx.arcTo(x, y + h, x, y + h - r, r);
+            ctx.lineTo(x, y + r);
+            ctx.arcTo(x, y, x + r, y, r);
+        } else {
+            ctx.rect(x, y, w, h);
+        }
+        ctx.closePath();
+        ctx.clip();
+        
+        if (window.hasSelection) {
+            ctx.drawImage(imgSource, window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height, x, y, w, h);
+        } else {
+            ctx.drawImage(imgSource, x, y, w, h);
+        }
+        ctx.restore();
     }
 
     property bool isZoomPressed: false
@@ -680,7 +809,7 @@ DankModal {
             event.accepted = true;
             return;
         }
-        if (event.key === Qt.Key_B) {
+        if (event.key === Qt.Key_G) {
             if (event.isAutoRepeat) {
                 event.accepted = true;
                 return;
@@ -706,7 +835,7 @@ DankModal {
             event.accepted = true;
             return;
         }
-        if (event.key === Qt.Key_B) {
+        if (event.key === Qt.Key_G) {
             if (event.isAutoRepeat) {
                 event.accepted = true;
                 return;
@@ -824,6 +953,8 @@ DankModal {
                 source: window.bgImageSource
                 visible: false
                 cache: false
+                smooth: true
+                mipmap: true
 
                 Component.onCompleted: {
                     window.bgImageItem = bgImage;
@@ -872,7 +1003,62 @@ DankModal {
                     strokeWidth: window.activeIntensity
                     canUndo: window.strokes.length > 0
 
-                    onToolSelected: (tool) => window.currentTool = (tool === "crop" && window.currentTool === "crop") ? window.lastActiveTool : tool
+                    backdropMode: window.backdropMode
+                    backdropSolidColor: window.backdropSolidColor
+                    backdropGradientStart: window.backdropGradientStart
+                    backdropGradientEnd: window.backdropGradientEnd
+                    backdropGradientAngle: window.backdropGradientAngle
+                    backdropPadding: window.backdropPadding
+                    backdropCornerRadius: window.backdropCornerRadius
+                    backdropShadowStrength: window.backdropShadowStrength
+                    backdropAspectRatio: window.backdropAspectRatio
+
+                    onChangeBackdropMode: (mode) => {
+                        window.backdropMode = mode;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeBackdropSolidColor: (col) => {
+                        window.backdropSolidColor = col;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeBackdropGradientStart: (col) => {
+                        window.backdropGradientStart = col;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeBackdropGradientEnd: (col) => {
+                        window.backdropGradientEnd = col;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeBackdropGradientAngle: (angle) => {
+                        window.backdropGradientAngle = angle;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeBackdropPadding: (pad) => {
+                        window.backdropPadding = pad;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeBackdropCornerRadius: (r) => {
+                        window.backdropCornerRadius = r;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeBackdropShadowStrength: (s) => {
+                        window.backdropShadowStrength = s;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeBackdropAspectRatio: (ratio) => {
+                        window.backdropAspectRatio = ratio;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+
+                    onToolSelected: (tool) => {
+                        if (tool === "back") {
+                            window.currentTool = window.lastActiveTool;
+                        } else if (tool === "crop" && window.currentTool === "crop") {
+                            window.currentTool = window.lastActiveTool;
+                        } else {
+                            window.currentTool = tool;
+                        }
+                    }
                     onColorSelected: (color) => window.currentColor = color
                     onStrokeWidthSelected: (width) => window.updateActiveIntensity(width)
                     onUndoRequested: window.performUndo()
@@ -916,6 +1102,7 @@ DankModal {
                         scale: drawingCanvas.scale
                         transformOrigin: drawingCanvas.transformOrigin
                         clip: true
+                        visible: window.effectiveBackdropMode === "none"
 
                         Image {
                             id: staticBgImage
@@ -960,6 +1147,14 @@ DankModal {
                             ctx.save();
                             ctx.scale(window.editScale, window.editScale);
 
+                            // 0. Paint Backdrop (if active)
+                            const isBackdropActive = window.effectiveBackdropMode !== "none";
+                            if (isBackdropActive) {
+                                window.drawBackdropBackground(ctx, window.canvasWidth, window.canvasHeight);
+                                window.drawScreenshotShadow(ctx);
+                                window.drawScreenshotImage(ctx, bgImage);
+                            }
+
                             // 1. Draw Dimming Selection Overlay (only if in crop mode)
                             DrawingRenderer.drawSelectionOverlay(ctx, {
                                 isCropMode: window.currentTool === "crop",
@@ -970,9 +1165,15 @@ DankModal {
 
                             // 2. Draw annotations (translated in edit mode, or clipped in crop mode)
                             ctx.save();
-                            if (window.currentTool !== "crop" && window.hasSelection) {
-                                // Shift context so drawings at absolute screen coords display correctly in cropped canvas view
-                                ctx.translate(-window.cropRect.x, -window.cropRect.y);
+                            const hasCropSelection = window.currentTool !== "crop" && window.hasSelection;
+                            if (isBackdropActive || hasCropSelection) {
+                                const cropX = hasCropSelection ? window.cropRect.x : 0;
+                                const cropY = hasCropSelection ? window.cropRect.y : 0;
+                                ctx.translate(window.screenshotXOffset, window.screenshotYOffset);
+                                if (isBackdropActive) {
+                                    ctx.scale(window.backdropScaleFactor, window.backdropScaleFactor);
+                                }
+                                ctx.translate(-cropX, -cropY);
                             } else if (window.hasSelection) {
                                 ctx.beginPath();
                                 ctx.rect(window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height);
@@ -1175,8 +1376,12 @@ DankModal {
                             acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
 
                             function getAbsolutePoint(mx, my) {
-                                const rx = mx / window.editScale;
-                                const ry = my / window.editScale;
+                                let rx = mx / window.editScale;
+                                let ry = my / window.editScale;
+                                if (window.effectiveBackdropMode !== "none") {
+                                    rx = (rx - window.screenshotXOffset) / window.backdropScaleFactor;
+                                    ry = (ry - window.screenshotYOffset) / window.backdropScaleFactor;
+                                }
                                 if (window.currentTool !== "crop" && window.hasSelection) {
                                     return Qt.point(rx + window.cropRect.x, ry + window.cropRect.y);
                                 }
@@ -1912,17 +2117,38 @@ DankModal {
                                 ctx.translate(-window.cursorX, -window.cursorY);
 
                                 // 1. Draw background image
-                                if (staticBgImage.status === Image.Ready || staticBgImage.width > 0) {
-                                    ctx.drawImage(staticBgImage, 0, 0, window.canvasWidth, window.canvasHeight);
-                                }
-
-                                // 2. Draw annotations
-                                if (window.showAnnotations) {
-                                    for (var i = 0; i < window.strokes.length; i++) {
-                                        drawingCanvas.drawStroke(ctx, window.strokes[i]);
+                                if (window.effectiveBackdropMode !== "none") {
+                                    window.drawBackdropBackground(ctx, window.canvasWidth, window.canvasHeight);
+                                    window.drawScreenshotShadow(ctx);
+                                    window.drawScreenshotImage(ctx, bgImage);
+                                    
+                                    // 2. Draw annotations
+                                    if (window.showAnnotations) {
+                                        ctx.save();
+                                        ctx.translate(window.screenshotXOffset, window.screenshotYOffset);
+                                        ctx.scale(window.backdropScaleFactor, window.backdropScaleFactor);
+                                        const cropX = window.hasSelection ? window.cropRect.x : 0;
+                                        const cropY = window.hasSelection ? window.cropRect.y : 0;
+                                        ctx.translate(-cropX, -cropY);
+                                        for (var i = 0; i < window.strokes.length; i++) {
+                                            drawingCanvas.drawStroke(ctx, window.strokes[i]);
+                                        }
+                                        if (window.currentStroke) {
+                                            drawingCanvas.drawStroke(ctx, window.currentStroke);
+                                        }
+                                        ctx.restore();
                                     }
-                                    if (window.currentStroke) {
-                                        drawingCanvas.drawStroke(ctx, window.currentStroke);
+                                } else {
+                                    if (staticBgImage.status === Image.Ready || staticBgImage.width > 0) {
+                                        ctx.drawImage(staticBgImage, 0, 0, window.canvasWidth, window.canvasHeight);
+                                    }
+                                    if (window.showAnnotations) {
+                                        for (var i = 0; i < window.strokes.length; i++) {
+                                            drawingCanvas.drawStroke(ctx, window.strokes[i]);
+                                        }
+                                        if (window.currentStroke) {
+                                            drawingCanvas.drawStroke(ctx, window.currentStroke);
+                                        }
                                     }
                                 }
 
@@ -1966,24 +2192,44 @@ DankModal {
                         ctx.save();
                         ctx.scale(1 / window.dpr, 1 / window.dpr);
                         
-                        // 1. Draw the background image first
-                        if (bgImage.status === Image.Ready) {
-                             if (window.hasSelection) {
-                                 // Draw the cropped portion of the raw background
-                                 ctx.drawImage(bgImage, window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height, 0, 0, window.cropRect.width, window.cropRect.height);
-                             } else {
-                                 // Fullscreen background
-                                 ctx.drawImage(bgImage, 0, 0);
-                             }
+                        // 0. Paint Backdrop (if active)
+                        const isBackdropActive = window.effectiveBackdropMode !== "none";
+                        if (isBackdropActive) {
+                            window.drawBackdropBackground(ctx, window.canvasWidth, window.canvasHeight);
+                            window.drawScreenshotShadow(ctx);
+                            window.drawScreenshotImage(ctx, bgImage);
+                        } else {
+                            if (bgImage.status === Image.Ready) {
+                                 if (window.hasSelection) {
+                                     // Draw the cropped portion of the raw background
+                                     ctx.drawImage(bgImage, window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height, 0, 0, window.cropRect.width, window.cropRect.height);
+                                 } else {
+                                     // Fullscreen background
+                                     ctx.drawImage(bgImage, 0, 0);
+                                 }
+                            }
                         }
 
-                        // 1.5 Overlay the Spotlight Layer
+                        // 1.5 Overlay the Spotlight Layer and Annotations
                         if (window.showAnnotations) {
+                            ctx.save();
+                            const hasCropSelection = window.hasSelection;
+                            if (isBackdropActive || hasCropSelection) {
+                                const cropX = hasCropSelection ? window.cropRect.x : 0;
+                                const cropY = hasCropSelection ? window.cropRect.y : 0;
+                                ctx.translate(window.screenshotXOffset, window.screenshotYOffset);
+                                ctx.scale(window.backdropScaleFactor, window.backdropScaleFactor);
+                                ctx.translate(-cropX, -cropY);
+                            }
+
                             // 1.4 Draw Pixelate BEFORE spotlight layer in export
                             for (let i = 0; i < window.strokes.length; i++) {
                                 if (window.strokes[i].tool === "pixelate") {
                                     window.activeCanvas.drawStroke(ctx, window.strokes[i]);
                                 }
+                            }
+                            if (window.currentStroke && window.currentStroke.tool === "pixelate") {
+                                window.activeCanvas.drawStroke(ctx, window.currentStroke);
                             }
 
                             const isDrawingSpotlight = window.currentStroke && window.currentStroke.tool === "spotlight";
@@ -2002,19 +2248,14 @@ DankModal {
                                     } else {
                                         const lastSpotlight = window.strokes.slice().reverse().find(s => s.tool === "spotlight");
                                         if (lastSpotlight) activeInt = lastSpotlight.width;
-                                        }
-
-                                        const spotlightOpacity = activeInt / 100.0;
-
-                                        ctx.beginPath();
-
-                                    // Cover the entire exported area
-                                    ctx.rect(0, 0, window.canvasWidth, window.canvasHeight);
-                                    
-                                    ctx.save();
-                                    if (window.hasSelection) {
-                                        ctx.translate(-window.cropRect.x, -window.cropRect.y);
                                     }
+
+                                    const spotlightOpacity = activeInt / 100.0;
+
+                                    ctx.beginPath();
+                                    const cropX = hasCropSelection ? window.cropRect.x : 0;
+                                    const cropY = hasCropSelection ? window.cropRect.y : 0;
+                                    ctx.rect(cropX, cropY, window.screenshotWidth, window.screenshotHeight);
                                     
                                     for (let s of spotlights) {
                                         if (s.points.length >= 2) {
@@ -2025,53 +2266,48 @@ DankModal {
                                             const rw = Math.abs(p1.x - p0.x);
                                             const rh = Math.abs(p1.y - p0.y);
                                             
-                                            if (rw > 0 && rh > 0) {
-                                                const radius = window.roundRect ? Math.min(Theme.cornerRadius, Math.min(rw, rh) / 2) : 0;
-                                                if (radius > 0) {
-                                                    ctx.moveTo(rx + radius, ry);
-                                                    ctx.lineTo(rx + rw - radius, ry);
-                                                    ctx.arcTo(rx + rw, ry, rx + rw, ry + radius, radius);
-                                                    ctx.lineTo(rx + rw, ry + rh - radius);
-                                                    ctx.arcTo(rx + rw, ry + rh, rx + rw - radius, ry + rh, radius);
-                                                    ctx.lineTo(rx + radius, ry + rh);
-                                                    ctx.arcTo(rx, ry + rh, rx, ry + rh - radius, radius);
-                                                    ctx.lineTo(rx, ry + radius);
-                                                    ctx.arcTo(rx, ry, rx + radius, ry, radius);
-                                                    ctx.closePath();
-                                                } else {
-                                                    ctx.rect(rx, ry, rw, rh);
-                                                }
-                                            }
+                                             if (rw > 0 && rh > 0) {
+                                                 const radius = window.roundRect ? Math.min(Theme.cornerRadius, Math.min(rw, rh) / 2) : 0;
+                                                 if (radius > 0) {
+                                                     ctx.moveTo(rx + radius, ry);
+                                                     ctx.lineTo(rx + rw - radius, ry);
+                                                     ctx.arcTo(rx + rw, ry, rx + rw, ry + radius, radius);
+                                                     ctx.lineTo(rx + rw, ry + rh - radius);
+                                                     ctx.arcTo(rx + rw, ry + rh, rx + rw - radius, ry + rh, radius);
+                                                     ctx.lineTo(rx + radius, ry + rh);
+                                                     ctx.arcTo(rx, ry + rh, rx, ry + rh - radius, radius);
+                                                     ctx.lineTo(rx, ry + radius);
+                                                     ctx.arcTo(rx, ry, rx + radius, ry, radius);
+                                                     ctx.closePath();
+                                                 } else {
+                                                     ctx.rect(rx, ry, rw, rh);
+                                                 }
+                                             }
                                         }
                                     }
-                                    ctx.restore();
                                     
                                     ctx.clip("evenodd");
                                     ctx.fillStyle = "rgba(0, 0, 0, " + spotlightOpacity + ")";
-                                    ctx.fillRect(0, 0, window.canvasWidth, window.canvasHeight);
+                                    ctx.fillRect(cropX, cropY, window.screenshotWidth, window.screenshotHeight);
                                     ctx.restore();
                                 }
                             }
-                        }
 
-                         // 2. Overlay the annotations at full resolution
-                         if (window.showAnnotations && window.activeCanvas) {
-                              ctx.save();
-                              if (window.hasSelection) {
-                                  ctx.translate(-window.cropRect.x, -window.cropRect.y);
-                              }
-                              // Draw all completed strokes
-                              for (var i = 0; i < window.strokes.length; i++) {
-                                  if (window.strokes[i].tool !== "pixelate") {
-                                      window.activeCanvas.drawStroke(ctx, window.strokes[i]);
-                                  }
-                              }
-                              // Draw current dragging stroke if any
-                              if (window.currentStroke) {
-                                  window.activeCanvas.drawStroke(ctx, window.currentStroke);
-                              }
-                              ctx.restore();
-                         }
+                            // 2. Overlay the annotations at full resolution
+                            if (window.activeCanvas) {
+                                // Draw all completed strokes (except pixelate and spotlight)
+                                for (var i = 0; i < window.strokes.length; i++) {
+                                    if (window.strokes[i].tool !== "pixelate" && window.strokes[i].tool !== "spotlight") {
+                                        window.activeCanvas.drawStroke(ctx, window.strokes[i]);
+                                    }
+                                }
+                                // Draw current dragging stroke if any
+                                if (window.currentStroke && window.currentStroke.tool !== "pixelate" && window.currentStroke.tool !== "spotlight") {
+                                    window.activeCanvas.drawStroke(ctx, window.currentStroke);
+                                }
+                            }
+                            ctx.restore();
+                        }
 
                         // 3. Overlay custom watermark if enabled
                         const pData = (window.parentWidget && window.parentWidget.pluginData) || {};

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -66,12 +66,11 @@ DankModal {
     }
 
     // Backdrop State Variables
-    property string backdropMode: "none" // none, solid, gradient, image
+    property string backdropMode: "none" // none, solid, gradient
     property color backdropSolidColor: Theme.primary
     property color backdropGradientStart: Theme.primary
     property color backdropGradientEnd: Theme.secondary
     property int backdropGradientAngle: 45
-    property string backdropImageSource: ""
     property int backdropPadding: 40
     property int backdropCornerRadius: 12
     property int backdropShadowStrength: 50
@@ -170,8 +169,61 @@ DankModal {
         return window.bgImageItem ? window.bgImageItem.sourceSize.height : 1;
     }
 
-    readonly property real canvasWidth: screenshotWidth
-    readonly property real canvasHeight: screenshotHeight
+    readonly property real canvasWidth: {
+        if (window.effectiveBackdropMode === "none" || window.backdropAspectRatio === "auto") {
+            return screenshotWidth;
+        }
+        if (window.backdropAspectRatio === "1:1") {
+            return Math.max(screenshotWidth, screenshotHeight);
+        }
+        if (window.backdropAspectRatio === "16:9") {
+            const targetRatio = 16 / 9;
+            const currentRatio = screenshotWidth / screenshotHeight;
+            if (currentRatio > targetRatio) {
+                return screenshotWidth;
+            } else {
+                return screenshotHeight * targetRatio;
+            }
+        }
+        if (window.backdropAspectRatio === "4:3") {
+            const targetRatio = 4 / 3;
+            const currentRatio = screenshotWidth / screenshotHeight;
+            if (currentRatio > targetRatio) {
+                return screenshotWidth;
+            } else {
+                return screenshotHeight * targetRatio;
+            }
+        }
+        return screenshotWidth;
+    }
+
+    readonly property real canvasHeight: {
+        if (window.effectiveBackdropMode === "none" || window.backdropAspectRatio === "auto") {
+            return screenshotHeight;
+        }
+        if (window.backdropAspectRatio === "1:1") {
+            return Math.max(screenshotWidth, screenshotHeight);
+        }
+        if (window.backdropAspectRatio === "16:9") {
+            const targetRatio = 16 / 9;
+            const currentRatio = screenshotWidth / screenshotHeight;
+            if (currentRatio > targetRatio) {
+                return screenshotWidth / targetRatio;
+            } else {
+                return screenshotHeight;
+            }
+        }
+        if (window.backdropAspectRatio === "4:3") {
+            const targetRatio = 4 / 3;
+            const currentRatio = screenshotWidth / screenshotHeight;
+            if (currentRatio > targetRatio) {
+                return screenshotWidth / targetRatio;
+            } else {
+                return screenshotHeight;
+            }
+        }
+        return screenshotHeight;
+    }
 
     readonly property real backdropScaleFactor: {
         if (window.effectiveBackdropMode === "none") return 1.0;
@@ -179,7 +231,7 @@ DankModal {
         const boxW = canvasWidth - 2 * pad;
         const boxH = canvasHeight - 2 * pad;
         if (boxW <= 0 || boxH <= 0) return 1.0;
-        return Math.min(boxW / canvasWidth, boxH / canvasHeight);
+        return Math.min(boxW / screenshotWidth, boxH / screenshotHeight);
     }
 
     readonly property real screenshotXOffset: window.effectiveBackdropMode === "none" ? 0 : (canvasWidth - screenshotWidth * backdropScaleFactor) / 2
@@ -199,9 +251,6 @@ DankModal {
             grad.addColorStop(0, window.backdropGradientStart.toString());
             grad.addColorStop(1, window.backdropGradientEnd.toString());
             ctx.fillStyle = grad;
-            ctx.fillRect(0, 0, w, h);
-        } else if (window.backdropMode === "image") {
-            ctx.fillStyle = Theme.surface.toString();
             ctx.fillRect(0, 0, w, h);
         }
     }
@@ -250,9 +299,12 @@ DankModal {
     }
 
     function drawScreenshotImage(ctx, imgSource) {
+        if (!imgSource || imgSource.status !== Image.Ready) return;
         ctx.save();
         ctx.imageSmoothingEnabled = true;
-        ctx.imageSmoothingQuality = "high";
+        if (ctx.imageSmoothingQuality !== undefined) {
+            ctx.imageSmoothingQuality = "high";
+        }
         
         const r = window.backdropCornerRadius * window.backdropScaleFactor;
         const x = window.screenshotXOffset;
@@ -770,7 +822,13 @@ DankModal {
 
         const toolShortcut = config.findByKey(config.toolShortcuts, token);
         if (toolShortcut) {
-            window.currentTool = toolShortcut.tool;
+            if (window.currentTool === toolShortcut.tool) {
+                if (toolShortcut.tool === "backdrop" || toolShortcut.tool === "crop") {
+                    window.currentTool = window.lastActiveTool;
+                }
+            } else {
+                window.currentTool = toolShortcut.tool;
+            }
             event.accepted = true;
         }
     }
@@ -1215,11 +1273,10 @@ DankModal {
 
                                         const spotlightOpacity = activeInt / 100.0;
                                         
-                                        const isCroppedMode = window.currentTool !== "crop" && window.hasSelection;
-                                        const dimmingX = isCroppedMode ? window.cropRect.x : 0;
-                                        const dimmingY = isCroppedMode ? window.cropRect.y : 0;
-                                        const dimmingW = isCroppedMode ? window.cropRect.width : window.canvasWidth;
-                                        const dimmingH = isCroppedMode ? window.cropRect.height : window.canvasHeight;
+                                        const dimmingX = 0;
+                                        const dimmingY = 0;
+                                        const dimmingW = window.screenshotWidth;
+                                        const dimmingH = window.screenshotHeight;
 
                                         ctx.beginPath();
                                         // Outer rectangle covering the whole view
@@ -1256,7 +1313,7 @@ DankModal {
                                         
                                         ctx.clip("evenodd");
                                         ctx.fillStyle = "rgba(0, 0, 0, " + spotlightOpacity + ")";
-                                        ctx.fillRect(dimmingX, dimmingY, dimmingW, dimmingH);
+                                        ctx.fillRect(0, 0, window.screenshotWidth, window.screenshotHeight);
                                         ctx.restore();
                                     }
                                 }
@@ -2253,9 +2310,7 @@ DankModal {
                                     const spotlightOpacity = activeInt / 100.0;
 
                                     ctx.beginPath();
-                                    const cropX = hasCropSelection ? window.cropRect.x : 0;
-                                    const cropY = hasCropSelection ? window.cropRect.y : 0;
-                                    ctx.rect(cropX, cropY, window.screenshotWidth, window.screenshotHeight);
+                                    ctx.rect(0, 0, window.screenshotWidth, window.screenshotHeight);
                                     
                                     for (let s of spotlights) {
                                         if (s.points.length >= 2) {
@@ -2288,7 +2343,7 @@ DankModal {
                                     
                                     ctx.clip("evenodd");
                                     ctx.fillStyle = "rgba(0, 0, 0, " + spotlightOpacity + ")";
-                                    ctx.fillRect(cropX, cropY, window.screenshotWidth, window.screenshotHeight);
+                                    ctx.fillRect(0, 0, window.screenshotWidth, window.screenshotHeight);
                                     ctx.restore();
                                 }
                             }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -18,6 +18,29 @@ Rectangle {
     property bool isVertical: false
     property bool showAnnotations: true
 
+    // Backdrop configuration properties
+    property string backdropMode: "none"
+    property color backdropSolidColor: Theme.primary
+    property color backdropGradientStart: Theme.primary
+    property color backdropGradientEnd: Theme.secondary
+    property int backdropGradientAngle: 45
+    property int backdropPadding: 40
+    property int backdropCornerRadius: 12
+    property int backdropShadowStrength: 50
+    property string backdropAspectRatio: "auto"
+
+    property string gradientActiveSlot: "start"
+
+    signal changeBackdropMode(string mode)
+    signal changeBackdropSolidColor(color col)
+    signal changeBackdropGradientStart(color col)
+    signal changeBackdropGradientEnd(color col)
+    signal changeBackdropGradientAngle(int angle)
+    signal changeBackdropPadding(int padding)
+    signal changeBackdropCornerRadius(int radius)
+    signal changeBackdropShadowStrength(int strength)
+    signal changeBackdropAspectRatio(string ratio)
+
     readonly property var toolbarPalette: {
         const p1 = root.pluginData["toolbar_color_primary"] || "primary";
         const slot1 = p1 === "primary" ? Theme.primary : p1;
@@ -56,7 +79,12 @@ Rectangle {
         Loader {
             id: toolbarLoader
             anchors.centerIn: parent
-            sourceComponent: root.isVertical ? verticalLayout : horizontalLayout
+            sourceComponent: {
+                if (root.currentTool === "backdrop") {
+                    return root.isVertical ? backdropVerticalLayout : backdropHorizontalLayout;
+                }
+                return root.isVertical ? verticalLayout : horizontalLayout;
+            }
         }
     }
 
@@ -288,6 +316,394 @@ Rectangle {
                 spacing: Theme.spacingXS; anchors.horizontalCenter: parent.horizontalCenter
                 DankActionButton { iconName: "undo"; buttonSize: 36; iconSize: 18; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; onClicked: root.undoRequested() }
                 DankActionButton { iconName: "done_all"; buttonSize: 36; iconSize: 18; tooltipText: "Copy & Save (Enter)"; backgroundColor: Theme.withAlpha(Theme.primary, 0.1); iconColor: Theme.primary; onClicked: root.copyAndSaveRequested() }
+            }
+        }
+    }
+
+    Component {
+        id: backdropHorizontalLayout
+        Row {
+            spacing: Theme.spacingL
+            anchors.verticalCenter: parent.verticalCenter
+            
+            // Back button
+            DankActionButton {
+                iconName: "arrow_back"
+                buttonSize: 36
+                iconSize: 18
+                tooltipText: qsTr("Back to Annotation (B)")
+                onClicked: root.toolSelected("back")
+            }
+            
+            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+            
+            // Mode selection
+            Row {
+                spacing: Theme.spacingXS
+                anchors.verticalCenter: parent.verticalCenter
+                DankActionButton {
+                    iconName: "blur_off"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("No Backdrop")
+                    backgroundColor: root.backdropMode === "none" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "none" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("none")
+                }
+                DankActionButton {
+                    iconName: "format_color_fill"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("Solid Color")
+                    backgroundColor: root.backdropMode === "solid" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "solid" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("solid")
+                }
+                DankActionButton {
+                    iconName: "gradient"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("Linear Gradient")
+                    backgroundColor: root.backdropMode === "gradient" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "gradient" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("gradient")
+                }
+            }
+            
+            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+            
+            // Aspect Ratio selection
+            Row {
+                spacing: Theme.spacingXS
+                anchors.verticalCenter: parent.verticalCenter
+                Repeater {
+                    model: ["auto", "1:1", "16:9", "4:3"]
+                    delegate: Button {
+                        text: modelData.toUpperCase()
+                        flat: true
+                        font.pixelSize: 10
+                        font.bold: true
+                        implicitWidth: 42
+                        implicitHeight: 36
+                        contentItem: Text {
+                            text: parent.text
+                            font: parent.font
+                            color: root.backdropAspectRatio === modelData ? Theme.primary : Theme.surfaceText
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        background: Rectangle {
+                            color: root.backdropAspectRatio === modelData ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                            radius: Theme.cornerRadiusS
+                        }
+                        onClicked: root.changeBackdropAspectRatio(modelData)
+                    }
+                }
+            }
+            
+            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+            
+            // Sliders Row
+            Row {
+                spacing: Theme.spacingM
+                anchors.verticalCenter: parent.verticalCenter
+                
+                Row {
+                    spacing: Theme.spacingXS
+                    Text { text: qsTr("Padding:") + " " + root.backdropPadding + "px"; color: Theme.surfaceText; font.pixelSize: 10; font.bold: true; anchors.verticalCenter: parent.verticalCenter }
+                    DankSlider {
+                        minimum: 10
+                        maximum: 150
+                        width: 80
+                        height: 36
+                        value: root.backdropPadding
+                        showValue: false
+                        onSliderValueChanged: val => root.changeBackdropPadding(val)
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
+                
+                Row {
+                    spacing: Theme.spacingXS
+                    Text { text: qsTr("Radius:") + " " + root.backdropCornerRadius + "px"; color: Theme.surfaceText; font.pixelSize: 10; font.bold: true; anchors.verticalCenter: parent.verticalCenter }
+                    DankSlider {
+                        minimum: 0
+                        maximum: 60
+                        width: 80
+                        height: 36
+                        value: root.backdropCornerRadius
+                        showValue: false
+                        onSliderValueChanged: val => root.changeBackdropCornerRadius(val)
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
+                
+                Row {
+                    spacing: Theme.spacingXS
+                    Text { text: qsTr("Shadow:") + " " + root.backdropShadowStrength + "%"; color: Theme.surfaceText; font.pixelSize: 10; font.bold: true; anchors.verticalCenter: parent.verticalCenter }
+                    DankSlider {
+                        minimum: 0
+                        maximum: 100
+                        width: 80
+                        height: 36
+                        value: root.backdropShadowStrength
+                        showValue: false
+                        onSliderValueChanged: val => root.changeBackdropShadowStrength(val)
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
+            }
+            
+            Rectangle { 
+                visible: root.backdropMode !== "none"
+                width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter 
+            }
+            
+            // Colors (Solid or Gradient)
+            Row {
+                visible: root.backdropMode !== "none"
+                spacing: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+                
+                Row {
+                    visible: root.backdropMode === "gradient"
+                    spacing: Theme.spacingXS
+                    anchors.verticalCenter: parent.verticalCenter
+                    
+                    Rectangle {
+                        width: 24; height: 24; radius: 4; color: root.backdropGradientStart
+                        border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: root.gradientActiveSlot === "start" ? 2 : 1
+                        MouseArea { anchors.fill: parent; onClicked: root.gradientActiveSlot = "start" }
+                    }
+                    Rectangle {
+                        width: 24; height: 24; radius: 4; color: root.backdropGradientEnd
+                        border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: root.gradientActiveSlot === "end" ? 2 : 1
+                        MouseArea { anchors.fill: parent; onClicked: root.gradientActiveSlot = "end" }
+                    }
+                }
+                
+                Grid {
+                    rows: 2; columns: 4; spacing: 4; anchors.verticalCenter: parent.verticalCenter
+                    Repeater {
+                        model: root.toolbarPalette
+                        delegate: Rectangle {
+                            width: 16; height: 16; radius: 8; color: modelData
+                            border.color: Theme.withAlpha(Theme.outline, 0.3)
+                            border.width: 1
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    if (root.backdropMode === "solid") {
+                                        root.changeBackdropSolidColor(modelData);
+                                    } else if (root.backdropMode === "gradient") {
+                                        if (root.gradientActiveSlot === "start") {
+                                            root.changeBackdropGradientStart(modelData);
+                                        } else {
+                                            root.changeBackdropGradientEnd(modelData);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: backdropVerticalLayout
+        Column {
+            spacing: Theme.spacingL
+            anchors.horizontalCenter: parent.horizontalCenter
+            
+            // Back button
+            DankActionButton {
+                iconName: "arrow_back"
+                buttonSize: 36
+                iconSize: 18
+                tooltipText: qsTr("Back to Annotation (B)")
+                onClicked: root.toolSelected("back")
+            }
+            
+            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            
+            // Mode selection
+            Column {
+                spacing: Theme.spacingXS
+                anchors.horizontalCenter: parent.horizontalCenter
+                DankActionButton {
+                    iconName: "blur_off"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("No Backdrop")
+                    backgroundColor: root.backdropMode === "none" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "none" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("none")
+                }
+                DankActionButton {
+                    iconName: "format_color_fill"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("Solid Color")
+                    backgroundColor: root.backdropMode === "solid" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "solid" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("solid")
+                }
+                DankActionButton {
+                    iconName: "gradient"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("Linear Gradient")
+                    backgroundColor: root.backdropMode === "gradient" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "gradient" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("gradient")
+                }
+            }
+            
+            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            
+            // Aspect Ratio selection
+            Column {
+                spacing: Theme.spacingXS
+                anchors.horizontalCenter: parent.horizontalCenter
+                Repeater {
+                    model: ["auto", "1:1", "16:9", "4:3"]
+                    delegate: Button {
+                        text: modelData.toUpperCase()
+                        flat: true
+                        font.pixelSize: 9
+                        font.bold: true
+                        implicitWidth: 36
+                        implicitHeight: 32
+                        contentItem: Text {
+                            text: parent.text
+                            font: parent.font
+                            color: root.backdropAspectRatio === modelData ? Theme.primary : Theme.surfaceText
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        background: Rectangle {
+                            color: root.backdropAspectRatio === modelData ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                            radius: Theme.cornerRadiusS
+                        }
+                        onClicked: root.changeBackdropAspectRatio(modelData)
+                    }
+                }
+            }
+            
+            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            
+            // Sliders
+            Column {
+                spacing: Theme.spacingS
+                anchors.horizontalCenter: parent.horizontalCenter
+                
+                Column {
+                    spacing: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    Text { text: qsTr("Pad:") + " " + root.backdropPadding + "px"; color: Theme.surfaceText; font.pixelSize: 9; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
+                    DankSlider {
+                        minimum: 10
+                        maximum: 150
+                        width: 42
+                        height: 24
+                        value: root.backdropPadding
+                        showValue: false
+                        onSliderValueChanged: val => root.changeBackdropPadding(val)
+                    }
+                }
+                
+                Column {
+                    spacing: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    Text { text: qsTr("Rad:") + " " + root.backdropCornerRadius + "px"; color: Theme.surfaceText; font.pixelSize: 9; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
+                    DankSlider {
+                        minimum: 0
+                        maximum: 60
+                        width: 42
+                        height: 24
+                        value: root.backdropCornerRadius
+                        showValue: false
+                        onSliderValueChanged: val => root.changeBackdropCornerRadius(val)
+                    }
+                }
+                
+                Column {
+                    spacing: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    Text { text: qsTr("Shd:") + " " + root.backdropShadowStrength + "%"; color: Theme.surfaceText; font.pixelSize: 9; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
+                    DankSlider {
+                        minimum: 0
+                        maximum: 100
+                        width: 42
+                        height: 24
+                        value: root.backdropShadowStrength
+                        showValue: false
+                        onSliderValueChanged: val => root.changeBackdropShadowStrength(val)
+                    }
+                }
+            }
+            
+            Rectangle { 
+                visible: root.backdropMode !== "none"
+                width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter 
+            }
+            
+            // Colors (Solid or Gradient)
+            Column {
+                visible: root.backdropMode !== "none"
+                spacing: Theme.spacingS
+                anchors.horizontalCenter: parent.horizontalCenter
+                
+                Row {
+                    visible: root.backdropMode === "gradient"
+                    spacing: Theme.spacingXS
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    
+                    Rectangle {
+                        width: 18; height: 18; radius: 3; color: root.backdropGradientStart
+                        border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: root.gradientActiveSlot === "start" ? 1.5 : 1
+                        MouseArea { anchors.fill: parent; onClicked: root.gradientActiveSlot = "start" }
+                    }
+                    Rectangle {
+                        width: 18; height: 18; radius: 3; color: root.backdropGradientEnd
+                        border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: root.gradientActiveSlot === "end" ? 1.5 : 1
+                        MouseArea { anchors.fill: parent; onClicked: root.gradientActiveSlot = "end" }
+                    }
+                }
+                
+                Grid {
+                    columns: 2; spacing: 4; anchors.horizontalCenter: parent.horizontalCenter
+                    Repeater {
+                        model: root.toolbarPalette
+                        delegate: Rectangle {
+                            width: 14; height: 14; radius: 7; color: modelData
+                            border.color: Theme.withAlpha(Theme.outline, 0.3)
+                            border.width: 1
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    if (root.backdropMode === "solid") {
+                                        root.changeBackdropSolidColor(modelData);
+                                    } else if (root.backdropMode === "gradient") {
+                                        if (root.gradientActiveSlot === "start") {
+                                            root.changeBackdropGradientStart(modelData);
+                                        } else {
+                                            root.changeBackdropGradientEnd(modelData);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## What
Implements a new **Image Backdrop Mode** that allows users to frame their cropped or full screenshot regions with solid color or linear gradient margins.
- **Constant Canvas Size:** The screenshot is scaled down (`backdropScaleFactor`) to fit inside the backdrop padding without increasing the canvas output size.
- **Fast Concentric Shadows:** Replaced `shadowBlur` with concentric rounded rectangles to ensure smooth, hardware-accelerated rendering.
- **Keyboard Shortcuts:** Remapped Area Zoom (Loupe) from `B` to `G` and registered `B` to quickly activate Backdrop Mode.
- **Mouse Coordinate Mapping:** Translated and scaled input coordinates so annotation tools, stamps, text notes, and magnifier selection align perfectly with the cursor pointer when backdrop mode is active.

## Why
Provides a clean, aesthetic margin framing feature (similar to Gradia) to enhance the presentation of shared screenshots.

## How Tested
1. Executed region capture locally via `dms ipc call quickCapture screenshot default`.
2. Pressed `B` to activate backdrop mode, selected various backdrop colors, margins, and corner radii.
3. Switched back and forth between tools (Pen, Line, Stamp, Highlighter) and verified that annotations align exactly with the pointer.
4. Exported screenshots to verify that the final rendering exactly mirrors the editor workspace.

## Summary by Sourcery

Introduce an Image Backdrop editing mode for quick capture screenshots, including toolbar UI, rendering logic, and keyboard shortcuts.

New Features:
- Add a Backdrop tool with solid and linear gradient modes, padding, corner radius, shadow strength, and aspect ratio controls for screenshots.
- Provide dedicated horizontal and vertical toolbar layouts for configuring backdrop appearance and colors.
- Support an Image Backdrop mode in the capture canvas and export pipeline that scales and centers the screenshot within a constant-size framed canvas.

Enhancements:
- Adjust annotation rendering, hit-testing, and spotlight overlay logic so drawings align correctly when a scaled backdrop is active.
- Enable smoothing and mipmapping on the background image used for capture rendering for higher quality output.
- Refine tool switching behavior to support returning from Backdrop mode to the last active annotation tool.