### PR TITLE
feat(backdrop): expand canvas, enhance shadow and fix shortcuts

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -267,13 +267,13 @@ DankModal {
         const w = window.screenshotWidth * window.backdropScaleFactor;
         const h = window.screenshotHeight * window.backdropScaleFactor;
         
-        const opacity = (window.backdropShadowStrength / 100.0) * 0.15;
+        const opacity = (window.backdropShadowStrength / 100.0) * 0.45;
         
         // Draw 4 concentric shadow layers for a soft, fast shadow effect without Gaussian blur CPU cost
         for (let i = 1; i <= 4; i++) {
             ctx.fillStyle = "rgba(0, 0, 0, " + (opacity / i) + ")";
-            const offset = i * 2;
-            const blur = i * 3;
+            const offset = i * 3.5;
+            const blur = i * 5;
             
             const sx = x - blur/2;
             const sy = y - blur/2 + offset;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -539,8 +539,8 @@ DankModal {
         if (!activeCanvas || !bgImageItem || !boardContainerItem) return 1.0;
         const maxW = boardContainerItem.width;
         const maxH = boardContainerItem.height;
-        const targetW = (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.width : bgImageItem.sourceSize.width;
-        const targetH = (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.height : bgImageItem.sourceSize.height;
+        const targetW = window.canvasWidth;
+        const targetH = window.canvasHeight;
         if (targetW <= 0 || targetH <= 0) return 1.0;
         const scaleX = maxW / targetW;
         const scaleY = maxH / targetH;

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -379,6 +379,7 @@ Rectangle {
                 Repeater {
                     model: ["auto", "1:1", "16:9", "4:3"]
                     delegate: Button {
+                        focusPolicy: Qt.NoFocus
                         text: modelData.toUpperCase()
                         flat: true
                         font.pixelSize: 10
@@ -573,6 +574,7 @@ Rectangle {
                 Repeater {
                     model: ["auto", "1:1", "16:9", "4:3"]
                     delegate: Button {
+                        focusPolicy: Qt.NoFocus
                         text: modelData.toUpperCase()
                         flat: true
                         font.pixelSize: 9

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -372,32 +372,20 @@ Rectangle {
             
             Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
             
-            // Aspect Ratio selection
-            Row {
-                spacing: Theme.spacingXS
+            // Aspect Ratio selection (Native DankButtonGroup)
+            DankButtonGroup {
                 anchors.verticalCenter: parent.verticalCenter
-                Repeater {
-                    model: ["auto", "1:1", "16:9", "4:3"]
-                    delegate: Button {
-                        focusPolicy: Qt.NoFocus
-                        text: modelData.toUpperCase()
-                        flat: true
-                        font.pixelSize: 10
-                        font.bold: true
-                        implicitWidth: 42
-                        implicitHeight: 36
-                        contentItem: Text {
-                            text: parent.text
-                            font: parent.font
-                            color: root.backdropAspectRatio === modelData ? Theme.primary : Theme.surfaceText
-                            horizontalAlignment: Text.AlignHCenter
-                            verticalAlignment: Text.AlignVCenter
-                        }
-                        background: Rectangle {
-                            color: root.backdropAspectRatio === modelData ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                            radius: Theme.cornerRadiusS
-                        }
-                        onClicked: root.changeBackdropAspectRatio(modelData)
+                buttonHeight: 28
+                minButtonWidth: 38
+                buttonPadding: Theme.spacingS
+                checkEnabled: false
+                textSize: 10
+                model: ["AUTO", "1:1", "16:9", "4:3"]
+                currentIndex: ["auto", "1:1", "16:9", "4:3"].indexOf(root.backdropAspectRatio)
+                onSelectionChanged: (index, selected) => {
+                    if (selected) {
+                        const ratios = ["auto", "1:1", "16:9", "4:3"];
+                        root.changeBackdropAspectRatio(ratios[index]);
                     }
                 }
             }
@@ -567,32 +555,53 @@ Rectangle {
             
             Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
             
-            // Aspect Ratio selection
+            // Aspect Ratio selection (Vertical Segmented Control)
             Column {
                 spacing: Theme.spacingXS
                 anchors.horizontalCenter: parent.horizontalCenter
                 Repeater {
                     model: ["auto", "1:1", "16:9", "4:3"]
-                    delegate: Button {
-                        focusPolicy: Qt.NoFocus
-                        text: modelData.toUpperCase()
-                        flat: true
-                        font.pixelSize: 9
-                        font.bold: true
-                        implicitWidth: 36
-                        implicitHeight: 32
-                        contentItem: Text {
-                            text: parent.text
-                            font: parent.font
-                            color: root.backdropAspectRatio === modelData ? Theme.primary : Theme.surfaceText
-                            horizontalAlignment: Text.AlignHCenter
-                            verticalAlignment: Text.AlignVCenter
+                    delegate: Rectangle {
+                        id: verticalSegment
+                        width: 36
+                        height: 28
+                        
+                        property bool selected: root.backdropAspectRatio === modelData
+                        property bool hovered: verticalMouseArea.containsMouse
+                        property bool isFirst: index === 0
+                        property bool isLast: index === 3
+                        
+                        color: selected ? Theme.buttonBg : Theme.withAlpha(Theme.surfaceVariant, Theme.popupTransparency)
+                        
+                        topLeftRadius: (isFirst || selected) ? Theme.cornerRadius : Math.min(4, Theme.cornerRadius)
+                        topRightRadius: (isFirst || selected) ? Theme.cornerRadius : Math.min(4, Theme.cornerRadius)
+                        bottomLeftRadius: (isLast || selected) ? Theme.cornerRadius : Math.min(4, Theme.cornerRadius)
+                        bottomRightRadius: (isLast || selected) ? Theme.cornerRadius : Math.min(4, Theme.cornerRadius)
+
+                        Rectangle {
+                            anchors.fill: parent
+                            topLeftRadius: parent.topLeftRadius
+                            topRightRadius: parent.topRightRadius
+                            bottomLeftRadius: parent.bottomLeftRadius
+                            bottomRightRadius: parent.bottomRightRadius
+                            color: verticalMouseArea.pressed ? (selected ? Theme.buttonPressed : Theme.surfaceTextHover) : (verticalSegment.hovered ? (selected ? Theme.buttonHover : Theme.surfaceTextHover) : "transparent")
                         }
-                        background: Rectangle {
-                            color: root.backdropAspectRatio === modelData ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                            radius: Theme.cornerRadiusS
+
+                        StyledText {
+                            text: modelData.toUpperCase()
+                            font.pixelSize: 9
+                            font.weight: selected ? Font.Medium : Font.Normal
+                            color: selected ? Theme.buttonText : Theme.surfaceVariantText
+                            anchors.centerIn: parent
                         }
-                        onClicked: root.changeBackdropAspectRatio(modelData)
+
+                        MouseArea {
+                            id: verticalMouseArea
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.changeBackdropAspectRatio(modelData)
+                        }
                     }
                 }
             }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -571,20 +571,35 @@ Rectangle {
                         property bool isFirst: index === 0
                         property bool isLast: index === 3
                         
-                        color: selected ? Theme.buttonBg : Theme.withAlpha(Theme.surfaceVariant, Theme.popupTransparency)
+                        color: {
+                            if (selected) {
+                                if (verticalMouseArea.pressed) return Theme.buttonPressed;
+                                if (verticalSegment.hovered) return Theme.buttonHover;
+                                return Theme.buttonBg;
+                            } else {
+                                if (verticalMouseArea.pressed || verticalSegment.hovered) return Theme.surfaceTextHover;
+                                return Theme.withAlpha(Theme.surfaceVariant, Theme.popupTransparency);
+                            }
+                        }
                         
-                        topLeftRadius: (isFirst || selected) ? Theme.cornerRadius : Math.min(4, Theme.cornerRadius)
-                        topRightRadius: (isFirst || selected) ? Theme.cornerRadius : Math.min(4, Theme.cornerRadius)
-                        bottomLeftRadius: (isLast || selected) ? Theme.cornerRadius : Math.min(4, Theme.cornerRadius)
-                        bottomRightRadius: (isLast || selected) ? Theme.cornerRadius : Math.min(4, Theme.cornerRadius)
+                        radius: (selected || isFirst || isLast) ? Theme.cornerRadius : 0
 
+                        // Mask bottom corners of the first item when not selected
                         Rectangle {
-                            anchors.fill: parent
-                            topLeftRadius: parent.topLeftRadius
-                            topRightRadius: parent.topRightRadius
-                            bottomLeftRadius: parent.bottomLeftRadius
-                            bottomRightRadius: parent.bottomRightRadius
-                            color: verticalMouseArea.pressed ? (selected ? Theme.buttonPressed : Theme.surfaceTextHover) : (verticalSegment.hovered ? (selected ? Theme.buttonHover : Theme.surfaceTextHover) : "transparent")
+                            anchors.bottom: parent.bottom
+                            width: parent.width
+                            height: parent.radius
+                            color: parent.color
+                            visible: !verticalSegment.selected && verticalSegment.isFirst && parent.radius > 0
+                        }
+
+                        // Mask top corners of the last item when not selected
+                        Rectangle {
+                            anchors.top: parent.top
+                            width: parent.width
+                            height: parent.radius
+                            color: parent.color
+                            visible: !verticalSegment.selected && verticalSegment.isLast && parent.radius > 0
                         }
 
                         StyledText {

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -28,6 +28,9 @@ Rectangle {
     property int backdropCornerRadius: 12
     property int backdropShadowStrength: 50
     property string backdropAspectRatio: "auto"
+    
+    readonly property var aspectRatios: ["auto", "1:1", "16:9", "4:3"]
+    readonly property var aspectRatioLabels: ["AUTO", "1:1", "16:9", "4:3"]
 
     property string gradientActiveSlot: "start"
 
@@ -380,12 +383,11 @@ Rectangle {
                 buttonPadding: Theme.spacingS
                 checkEnabled: false
                 textSize: 10
-                model: ["AUTO", "1:1", "16:9", "4:3"]
-                currentIndex: ["auto", "1:1", "16:9", "4:3"].indexOf(root.backdropAspectRatio)
+                model: root.aspectRatioLabels
+                currentIndex: root.aspectRatios.indexOf(root.backdropAspectRatio)
                 onSelectionChanged: (index, selected) => {
                     if (selected) {
-                        const ratios = ["auto", "1:1", "16:9", "4:3"];
-                        root.changeBackdropAspectRatio(ratios[index]);
+                        root.changeBackdropAspectRatio(root.aspectRatios[index]);
                     }
                 }
             }
@@ -560,7 +562,8 @@ Rectangle {
                 spacing: Theme.spacingXS
                 anchors.horizontalCenter: parent.horizontalCenter
                 Repeater {
-                    model: ["auto", "1:1", "16:9", "4:3"]
+                    id: verticalRatioRepeater
+                    model: root.aspectRatios
                     delegate: Rectangle {
                         id: verticalSegment
                         width: 36
@@ -569,7 +572,7 @@ Rectangle {
                         property bool selected: root.backdropAspectRatio === modelData
                         property bool hovered: verticalMouseArea.containsMouse
                         property bool isFirst: index === 0
-                        property bool isLast: index === 3
+                        property bool isLast: index === (verticalRatioRepeater.count - 1)
                         
                         color: {
                             if (selected) {


### PR DESCRIPTION
# What
Adds a backdrop background feature (solid and gradient) to quick-capture screenshots, complete with custom aspect ratios, shadows, padding, custom hotkeys, and performance optimizations.

# Why
Allows users to export high-quality screenshots with elegant shadows and gradients (ideal for sharing on social media or documentation) without altering the sharpness of the original image.

# How tested
- Verified that horizontal and vertical toolbars display the aspect ratio selection correctly using `DankButtonGroup` styling.
- Checked that backdrop shadow, scale, and offset are properly calculated and that the editor canvas fits within the display.
- Tested keyboard shortcuts after changing ratios to ensure they work without focus theft.
- Validated on multiple screen captures to ensure no stale cache is drawn.

## Summary by Sourcery

Enhance quick capture backdrop controls and shadow rendering for improved visual quality and canvas scaling.

Enhancements:
- Replace the horizontal aspect ratio selector with a DankButtonGroup-based control aligned with native styling.
- Redesign the vertical aspect ratio selector as a segmented control with hover, pressed, and selection states for better UX.
- Adjust backdrop shadow opacity, offset, and blur parameters to produce a softer, richer shadow effect.
- Update backdrop canvas scaling to rely on overall canvas dimensions instead of crop or source image size for more accurate fitting.