### PR TITLE
feat(toolbar): add More Tools dropdown menu with Rotate and Mirror

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -424,24 +424,38 @@ DankModal {
     }
 
     function rotateScreenshot() {
-        const oldW = screenshotWidth;
-        const oldH = screenshotHeight;
+        const originalW = window.bgImageItem ? window.bgImageItem.sourceSize.width : 1;
+        const originalH = window.bgImageItem ? window.bgImageItem.sourceSize.height : 1;
 
-        Proc.runCommand("rotate-image", ["mogrify", "-rotate", "90", "/tmp/dms_capture_bg.png"], (stdout, exitCode) => {
+        let bgPath = "/tmp/dms_capture_bg.png";
+        if (window.bgImageSource) {
+            let srcStr = window.bgImageSource.toString();
+            const qIdx = srcStr.indexOf("?");
+            if (qIdx !== -1) {
+                srcStr = srcStr.substring(0, qIdx);
+            }
+            if (srcStr.startsWith("file://")) {
+                bgPath = srcStr.substring(7);
+            } else if (srcStr.startsWith("/")) {
+                bgPath = srcStr;
+            }
+        }
+
+        Proc.runCommand("rotate-image", ["mogrify", "-rotate", "90", bgPath], (stdout, exitCode) => {
             if (exitCode === 0) {
                 if (window.hasSelection) {
                     const cx = window.cropRect.x;
                     const cy = window.cropRect.y;
                     const cw = window.cropRect.width;
                     const ch = window.cropRect.height;
-                    window.cropRect = Qt.rect(oldH - (cy + ch), cx, ch, cw);
+                    window.cropRect = Qt.rect(originalH - (cy + ch), cx, ch, cw);
                 }
 
                 const list = [...window.strokes];
                 for (let s of list) {
                     if (s.points) {
                         s.points = s.points.map(p => ({
-                            x: oldH - p.y,
+                            x: originalH - p.y,
                             y: p.x
                         }));
                     }
@@ -449,29 +463,43 @@ DankModal {
                 window.strokes = list;
 
                 window.bgImageSource = "";
-                window.bgImageSource = "file:///tmp/dms_capture_bg.png";
+                window.bgImageSource = "file://" + bgPath + "?t=" + Date.now();
             }
         });
     }
 
     function mirrorScreenshot() {
-        const oldW = screenshotWidth;
+        const originalW = window.bgImageItem ? window.bgImageItem.sourceSize.width : 1;
 
-        Proc.runCommand("mirror-image", ["mogrify", "-flop", "/tmp/dms_capture_bg.png"], (stdout, exitCode) => {
+        let bgPath = "/tmp/dms_capture_bg.png";
+        if (window.bgImageSource) {
+            let srcStr = window.bgImageSource.toString();
+            const qIdx = srcStr.indexOf("?");
+            if (qIdx !== -1) {
+                srcStr = srcStr.substring(0, qIdx);
+            }
+            if (srcStr.startsWith("file://")) {
+                bgPath = srcStr.substring(7);
+            } else if (srcStr.startsWith("/")) {
+                bgPath = srcStr;
+            }
+        }
+
+        Proc.runCommand("mirror-image", ["mogrify", "-flop", bgPath], (stdout, exitCode) => {
             if (exitCode === 0) {
                 if (window.hasSelection) {
                     const cx = window.cropRect.x;
                     const cy = window.cropRect.y;
                     const cw = window.cropRect.width;
                     const ch = window.cropRect.height;
-                    window.cropRect = Qt.rect(oldW - (cx + cw), cy, cw, ch);
+                    window.cropRect = Qt.rect(originalW - (cx + cw), cy, cw, ch);
                 }
 
                 const list = [...window.strokes];
                 for (let s of list) {
                     if (s.points) {
                         s.points = s.points.map(p => ({
-                            x: oldW - p.x,
+                            x: originalW - p.x,
                             y: p.y
                         }));
                     }
@@ -479,7 +507,7 @@ DankModal {
                 window.strokes = list;
 
                 window.bgImageSource = "";
-                window.bgImageSource = "file:///tmp/dms_capture_bg.png";
+                window.bgImageSource = "file://" + bgPath + "?t=" + Date.now();
             }
         });
     }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1231,11 +1231,6 @@ DankModal {
                     onStampToolRightClicked: (globalX, globalY) => stampOptionsRadialMenu.open(globalX, globalY)
                     onRotateRequested: window.rotateScreenshot()
                     onMirrorRequested: window.mirrorScreenshot()
-                    onMenuClosed: {
-                        if (modalFocusScope) {
-                            modalFocusScope.forceActiveFocus();
-                        }
-                    }
                 }
 
                 // 2. Centered Canvas Board
@@ -1688,6 +1683,11 @@ DankModal {
                             }
 
                             onPressed: (mouse) => {
+                                if (toolbarCard.moreToolsMenuOpened) {
+                                    toolbarCard.moreToolsMenuForceClose = true;
+                                    return;
+                                }
+
                                 if (window.isTyping) {
                                     window.commitTypingText();
                                     return;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1208,6 +1208,7 @@ DankModal {
                     }
 
                     onToolSelected: (tool) => {
+                        moreToolsMenu.close();
                         if (tool === "back") {
                             window.currentTool = window.lastActiveTool;
                         } else if (tool === "crop" && window.currentTool === "crop") {
@@ -1216,21 +1217,64 @@ DankModal {
                             window.currentTool = tool;
                         }
                     }
-                    onColorSelected: (color) => window.currentColor = color
-                    onStrokeWidthSelected: (width) => window.updateActiveIntensity(width)
-                    onUndoRequested: window.performUndo()
+                    onColorSelected: (color) => {
+                        moreToolsMenu.close();
+                        window.currentColor = color;
+                    }
+                    onStrokeWidthSelected: (width) => {
+                        moreToolsMenu.close();
+                        window.updateActiveIntensity(width);
+                    }
+                    onUndoRequested: {
+                        moreToolsMenu.close();
+                        window.performUndo();
+                    }
                     onAnnotationsToggled: window.showAnnotations = !window.showAnnotations
 
-                    onFloatRequested: captureActions.performFloatAction()
-                    onSaveRequested: captureActions.performSaveOnly()
+                    onFloatRequested: {
+                        moreToolsMenu.close();
+                        captureActions.performFloatAction();
+                    }
+                    onSaveRequested: {
+                        moreToolsMenu.close();
+                        captureActions.performSaveOnly();
+                    }
 
-                    onCopyRequested: captureActions.performCopyOnly()
-                    onCopyAndSaveRequested: captureActions.performCopyAndSave()
-                    onCloseRequested: window.discardAndClose()
-                    onTextToolRightClicked: (globalX, globalY) => textOptionsRadialMenu.open(globalX, globalY)
-                    onStampToolRightClicked: (globalX, globalY) => stampOptionsRadialMenu.open(globalX, globalY)
-                    onRotateRequested: window.rotateScreenshot()
-                    onMirrorRequested: window.mirrorScreenshot()
+                    onCopyRequested: {
+                        moreToolsMenu.close();
+                        captureActions.performCopyOnly();
+                    }
+                    onCopyAndSaveRequested: {
+                        moreToolsMenu.close();
+                        captureActions.performCopyAndSave();
+                    }
+                    onCloseRequested: {
+                        moreToolsMenu.close();
+                        window.discardAndClose();
+                    }
+                    onTextToolRightClicked: (globalX, globalY) => {
+                        moreToolsMenu.close();
+                        textOptionsRadialMenu.open(globalX, globalY);
+                    }
+                    onStampToolRightClicked: (globalX, globalY) => {
+                        moreToolsMenu.close();
+                        stampOptionsRadialMenu.open(globalX, globalY);
+                    }
+                    onMoreToolsClicked: (buttonItem) => {
+                        if (moreToolsMenu.opened) {
+                            moreToolsMenu.close();
+                        } else {
+                            var pt = buttonItem.mapToItem(contentRoot, 0, 0);
+                            if (toolbarCard.isVertical) {
+                                moreToolsMenu.x = pt.x + buttonItem.width + Theme.spacingS;
+                                moreToolsMenu.y = pt.y;
+                            } else {
+                                moreToolsMenu.x = pt.x;
+                                moreToolsMenu.y = pt.y + buttonItem.height + Theme.spacingS;
+                            }
+                            moreToolsMenu.open();
+                        }
+                    }
                 }
 
                 // 2. Centered Canvas Board
@@ -1683,8 +1727,8 @@ DankModal {
                             }
 
                             onPressed: (mouse) => {
-                                if (toolbarCard.moreToolsMenuOpened) {
-                                    toolbarCard.moreToolsMenuForceClose = true;
+                                if (moreToolsMenu.opened) {
+                                    moreToolsMenu.close();
                                     return;
                                 }
 
@@ -2547,6 +2591,12 @@ DankModal {
                         window.currentTool = "stamp";
                         stampOptionsRadialMenu.close();
                     }
+                }
+
+                MoreToolsMenu {
+                    id: moreToolsMenu
+                    onRotateRequested: window.rotateScreenshot()
+                    onMirrorRequested: window.mirrorScreenshot()
                 }
 
                 Canvas {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1231,6 +1231,11 @@ DankModal {
                     onStampToolRightClicked: (globalX, globalY) => stampOptionsRadialMenu.open(globalX, globalY)
                     onRotateRequested: window.rotateScreenshot()
                     onMirrorRequested: window.mirrorScreenshot()
+                    onMenuClosed: {
+                        if (modalFocusScope) {
+                            modalFocusScope.forceActiveFocus();
+                        }
+                    }
                 }
 
                 // 2. Centered Canvas Board

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -423,6 +423,67 @@ DankModal {
         open();
     }
 
+    function rotateScreenshot() {
+        const oldW = screenshotWidth;
+        const oldH = screenshotHeight;
+
+        Proc.runCommand("rotate-image", ["mogrify", "-rotate", "90", "/tmp/dms_capture_bg.png"], (stdout, exitCode) => {
+            if (exitCode === 0) {
+                if (window.hasSelection) {
+                    const cx = window.cropRect.x;
+                    const cy = window.cropRect.y;
+                    const cw = window.cropRect.width;
+                    const ch = window.cropRect.height;
+                    window.cropRect = Qt.rect(oldH - (cy + ch), cx, ch, cw);
+                }
+
+                const list = [...window.strokes];
+                for (let s of list) {
+                    if (s.points) {
+                        s.points = s.points.map(p => ({
+                            x: oldH - p.y,
+                            y: p.x
+                        }));
+                    }
+                }
+                window.strokes = list;
+
+                window.bgImageSource = "";
+                window.bgImageSource = "file:///tmp/dms_capture_bg.png";
+            }
+        });
+    }
+
+    function mirrorScreenshot() {
+        const oldW = screenshotWidth;
+
+        Proc.runCommand("mirror-image", ["mogrify", "-flop", "/tmp/dms_capture_bg.png"], (stdout, exitCode) => {
+            if (exitCode === 0) {
+                if (window.hasSelection) {
+                    const cx = window.cropRect.x;
+                    const cy = window.cropRect.y;
+                    const cw = window.cropRect.width;
+                    const ch = window.cropRect.height;
+                    window.cropRect = Qt.rect(oldW - (cx + cw), cy, cw, ch);
+                }
+
+                const list = [...window.strokes];
+                for (let s of list) {
+                    if (s.points) {
+                        s.points = s.points.map(p => ({
+                            x: oldW - p.x,
+                            y: p.y
+                        }));
+                    }
+                }
+                window.strokes = list;
+
+                window.bgImageSource = "";
+                window.bgImageSource = "file:///tmp/dms_capture_bg.png";
+            }
+        });
+    }
+
     shouldBeVisible: false
     
     // Spacious modal dimensions occupying 90% width and 90% height of the screen
@@ -1140,6 +1201,8 @@ DankModal {
                     onCloseRequested: window.discardAndClose()
                     onTextToolRightClicked: (globalX, globalY) => textOptionsRadialMenu.open(globalX, globalY)
                     onStampToolRightClicked: (globalX, globalY) => stampOptionsRadialMenu.open(globalX, globalY)
+                    onRotateRequested: window.rotateScreenshot()
+                    onMirrorRequested: window.mirrorScreenshot()
                 }
 
                 // 2. Centered Canvas Board

--- a/components/MoreToolsMenu.qml
+++ b/components/MoreToolsMenu.qml
@@ -1,0 +1,133 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+Rectangle {
+    id: menuRoot
+    width: 120
+    height: menuColumn.implicitHeight + Theme.spacingS * 2
+    color: Theme.surfaceContainer
+    border.color: Theme.withAlpha(Theme.outline, 0.15)
+    border.width: 1
+    radius: Theme.cornerRadius
+    z: 10000
+
+    property bool opened: false
+    visible: opacity > 0
+    opacity: 0
+    scale: 0.9
+
+    signal rotateRequested()
+    signal mirrorRequested()
+
+    states: [
+        State {
+            name: "visible"
+            when: menuRoot.opened
+            PropertyChanges { target: menuRoot; opacity: 1.0; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { properties: "opacity,scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open() {
+        menuRoot.opened = true;
+    }
+
+    function close() {
+        menuRoot.opened = false;
+    }
+
+    Column {
+        id: menuColumn
+        anchors.fill: parent
+        anchors.margins: Theme.spacingS
+        spacing: 2
+
+        // Rotate Option
+        Rectangle {
+            width: parent.width
+            height: 32
+            radius: Theme.cornerRadius - 2
+            color: rotateMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+
+            Row {
+                anchors.fill: parent
+                anchors.leftMargin: Theme.spacingS
+                anchors.rightMargin: Theme.spacingS
+                spacing: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+
+                DankIcon {
+                    name: "rotate_right"
+                    size: 16
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                StyledText {
+                    text: qsTr("Rotate")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            MouseArea {
+                id: rotateMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    menuRoot.close();
+                    menuRoot.rotateRequested();
+                }
+            }
+        }
+
+        // Mirror Option
+        Rectangle {
+            width: parent.width
+            height: 32
+            radius: Theme.cornerRadius - 2
+            color: mirrorMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+
+            Row {
+                anchors.fill: parent
+                anchors.leftMargin: Theme.spacingS
+                anchors.rightMargin: Theme.spacingS
+                spacing: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+
+                DankIcon {
+                    name: "flip"
+                    size: 16
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                StyledText {
+                    text: qsTr("Mirror")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            MouseArea {
+                id: mirrorMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    menuRoot.close();
+                    menuRoot.mirrorRequested();
+                }
+            }
+        }
+    }
+}

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -33,8 +33,6 @@ Rectangle {
     readonly property var aspectRatioLabels: ["AUTO", "1:1", "16:9", "4:3"]
 
     property string gradientActiveSlot: "start"
-    property bool moreToolsMenuForceClose: false
-    property bool moreToolsMenuOpened: false
 
     signal changeBackdropMode(string mode)
     signal changeBackdropSolidColor(color col)
@@ -47,157 +45,7 @@ Rectangle {
     signal changeBackdropAspectRatio(string ratio)
     signal rotateRequested()
     signal mirrorRequested()
-
-    component MoreToolsMenu: Rectangle {
-        id: menuRoot
-        width: 100
-        height: menuColumn.implicitHeight + Theme.spacingS * 2
-        color: Theme.surfaceContainer
-        border.color: Theme.withAlpha(Theme.outline, 0.15)
-        border.width: 1
-        radius: Theme.cornerRadius
-        z: 1000
-
-        property bool opened: false
-        onOpenedChanged: {
-            if (opened) {
-                root.moreToolsMenuOpened = true;
-            } else {
-                root.moreToolsMenuOpened = false;
-            }
-        }
-
-        Component.onDestruction: {
-            if (opened) {
-                root.moreToolsMenuOpened = false;
-            }
-        }
-
-        visible: opacity > 0
-        opacity: 0
-        scale: 0.9
-
-        states: [
-            State {
-                name: "visible"
-                when: menuRoot.opened
-                PropertyChanges { target: menuRoot; opacity: 1.0; scale: 1.0 }
-            }
-        ]
-
-        transitions: [
-            Transition {
-                NumberAnimation { properties: "opacity,scale"; duration: 120; easing.type: Easing.OutQuad }
-            }
-        ]
-
-        function open() {
-            root.moreToolsMenuForceClose = false;
-            menuRoot.opened = true;
-        }
-
-        function close() {
-            menuRoot.opened = false;
-        }
-
-        Connections {
-            target: root
-            function onMoreToolsMenuForceCloseChanged() {
-                if (root.moreToolsMenuForceClose) {
-                    menuRoot.opened = false;
-                }
-            }
-        }
-
-        Column {
-            id: menuColumn
-            anchors.fill: parent
-            anchors.margins: Theme.spacingS
-            spacing: 2
-
-            // Rotate Option
-            Rectangle {
-                width: parent.width
-                height: 28
-                radius: Theme.cornerRadius - 2
-                color: rotateMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-
-                Row {
-                    anchors.fill: parent
-                    anchors.leftMargin: Theme.spacingS
-                    anchors.rightMargin: Theme.spacingS
-                    spacing: Theme.spacingS
-                    anchors.verticalCenter: parent.verticalCenter
-
-                    DankIcon {
-                        name: "rotate_right"
-                        size: 14
-                        color: Theme.surfaceText
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-
-                    StyledText {
-                        text: qsTr("Rotate")
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceText
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                }
-
-                MouseArea {
-                    id: rotateMouseArea
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        menuRoot.close();
-                        root.rotateRequested();
-                    }
-                }
-            }
-
-            // Mirror Option
-            Rectangle {
-                width: parent.width
-                height: 28
-                radius: Theme.cornerRadius - 2
-                color: mirrorMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-
-                Row {
-                    anchors.fill: parent
-                    anchors.leftMargin: Theme.spacingS
-                    anchors.rightMargin: Theme.spacingS
-                    spacing: Theme.spacingS
-                    anchors.verticalCenter: parent.verticalCenter
-
-                    DankIcon {
-                        name: "flip"
-                        size: 14
-                        color: Theme.surfaceText
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-
-                    StyledText {
-                        text: qsTr("Mirror")
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceText
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                }
-
-                MouseArea {
-                    id: mirrorMouseArea
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        menuRoot.close();
-                        root.mirrorRequested();
-                    }
-                }
-            }
-        }
-    }
+    signal moreToolsClicked(var buttonItem)
 
     readonly property var toolbarPalette: {
         const p1 = root.pluginData["toolbar_color_primary"] || "primary";
@@ -311,22 +159,12 @@ Rectangle {
                     }
                 }
                 DankActionButton {
+                    id: moreActionsBtn
                     iconName: "more_horiz"
                     buttonSize: 36
                     iconSize: 18
                     tooltipText: qsTr("More Tools")
-                    onClicked: {
-                        if (moreActionsMenu.opened) {
-                            moreActionsMenu.close();
-                        } else {
-                            moreActionsMenu.open();
-                        }
-                    }
-                    
-                    MoreToolsMenu {
-                        id: moreActionsMenu
-                        y: parent.height
-                    }
+                    onClicked: root.moreToolsClicked(moreActionsBtn)
                 }
             }
 
@@ -457,23 +295,12 @@ Rectangle {
                     }
                 }
                 DankActionButton {
+                    id: moreActionsVerticalBtn
                     iconName: "more_vert"
                     buttonSize: 36
                     iconSize: 18
                     tooltipText: qsTr("More Tools")
-                    onClicked: {
-                        if (moreActionsVerticalMenu.opened) {
-                            moreActionsVerticalMenu.close();
-                        } else {
-                            moreActionsVerticalMenu.open();
-                        }
-                    }
-                    
-                    MoreToolsMenu {
-                        id: moreActionsVerticalMenu
-                        x: parent.width
-                        y: 0
-                    }
+                    onClicked: root.moreToolsClicked(moreActionsVerticalBtn)
                 }
             }
 

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -46,6 +46,41 @@ Rectangle {
     signal rotateRequested()
     signal mirrorRequested()
 
+    component MoreToolsMenu: Menu {
+        background: Rectangle {
+            implicitWidth: 100
+            color: Theme.withAlpha(Theme.surface, Theme.popupTransparency)
+            border.color: Theme.withAlpha(Theme.outline, 0.2)
+            radius: Theme.cornerRadiusS
+        }
+
+        MenuItem {
+            text: qsTr("Rotate")
+            contentItem: StyledText {
+                text: parent.text
+                color: parent.hovered ? Theme.primary : Theme.surfaceText
+                font.pixelSize: Theme.fontSizeSmall
+            }
+            background: Rectangle {
+                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
+            }
+            onTriggered: root.rotateRequested()
+        }
+
+        MenuItem {
+            text: qsTr("Mirror")
+            contentItem: StyledText {
+                text: parent.text
+                color: parent.hovered ? Theme.primary : Theme.surfaceText
+                font.pixelSize: Theme.fontSizeSmall
+            }
+            background: Rectangle {
+                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
+            }
+            onTriggered: root.mirrorRequested()
+        }
+    }
+
     readonly property var toolbarPalette: {
         const p1 = root.pluginData["toolbar_color_primary"] || "primary";
         const slot1 = p1 === "primary" ? Theme.primary : p1;
@@ -164,42 +199,9 @@ Rectangle {
                     tooltipText: qsTr("More Tools")
                     onClicked: moreActionsMenu.open()
                     
-                    Menu {
+                    MoreToolsMenu {
                         id: moreActionsMenu
                         y: parent.height
-                        
-                        background: Rectangle {
-                            implicitWidth: 100
-                            color: Theme.withAlpha(Theme.surface, Theme.popupTransparency)
-                            border.color: Theme.withAlpha(Theme.outline, 0.2)
-                            radius: Theme.cornerRadiusS
-                        }
-
-                        MenuItem {
-                            text: qsTr("Rotate")
-                            contentItem: StyledText {
-                                text: parent.text
-                                color: parent.hovered ? Theme.primary : Theme.surfaceText
-                                font.pixelSize: Theme.fontSizeSmall
-                            }
-                            background: Rectangle {
-                                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
-                            }
-                            onTriggered: root.rotateRequested()
-                        }
-
-                        MenuItem {
-                            text: qsTr("Mirror")
-                            contentItem: StyledText {
-                                text: parent.text
-                                color: parent.hovered ? Theme.primary : Theme.surfaceText
-                                font.pixelSize: Theme.fontSizeSmall
-                            }
-                            background: Rectangle {
-                                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
-                            }
-                            onTriggered: root.mirrorRequested()
-                        }
                     }
                 }
             }
@@ -337,43 +339,10 @@ Rectangle {
                     tooltipText: qsTr("More Tools")
                     onClicked: moreActionsVerticalMenu.open()
                     
-                    Menu {
+                    MoreToolsMenu {
                         id: moreActionsVerticalMenu
                         x: parent.width
                         y: 0
-                        
-                        background: Rectangle {
-                            implicitWidth: 100
-                            color: Theme.withAlpha(Theme.surface, Theme.popupTransparency)
-                            border.color: Theme.withAlpha(Theme.outline, 0.2)
-                            radius: Theme.cornerRadiusS
-                        }
-
-                        MenuItem {
-                            text: qsTr("Rotate")
-                            contentItem: StyledText {
-                                text: parent.text
-                                color: parent.hovered ? Theme.primary : Theme.surfaceText
-                                font.pixelSize: Theme.fontSizeSmall
-                            }
-                            background: Rectangle {
-                                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
-                            }
-                            onTriggered: root.rotateRequested()
-                        }
-
-                        MenuItem {
-                            text: qsTr("Mirror")
-                            contentItem: StyledText {
-                                text: parent.text
-                                color: parent.hovered ? Theme.primary : Theme.surfaceText
-                                font.pixelSize: Theme.fontSizeSmall
-                            }
-                            background: Rectangle {
-                                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
-                            }
-                            onTriggered: root.mirrorRequested()
-                        }
                     }
                 }
             }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -33,6 +33,8 @@ Rectangle {
     readonly property var aspectRatioLabels: ["AUTO", "1:1", "16:9", "4:3"]
 
     property string gradientActiveSlot: "start"
+    property bool moreToolsMenuForceClose: false
+    property bool moreToolsMenuOpened: false
 
     signal changeBackdropMode(string mode)
     signal changeBackdropSolidColor(color col)
@@ -45,42 +47,155 @@ Rectangle {
     signal changeBackdropAspectRatio(string ratio)
     signal rotateRequested()
     signal mirrorRequested()
-    signal menuClosed()
 
-    component MoreToolsMenu: Menu {
-        onClosed: root.menuClosed()
+    component MoreToolsMenu: Rectangle {
+        id: menuRoot
+        width: 100
+        height: menuColumn.implicitHeight + Theme.spacingS * 2
+        color: Theme.surfaceContainer
+        border.color: Theme.withAlpha(Theme.outline, 0.15)
+        border.width: 1
+        radius: Theme.cornerRadius
+        z: 1000
 
-        background: Rectangle {
-            implicitWidth: 100
-            color: Theme.withAlpha(Theme.surface, Theme.popupTransparency)
-            border.color: Theme.withAlpha(Theme.outline, 0.2)
-            radius: Theme.cornerRadiusS
+        property bool opened: false
+        onOpenedChanged: {
+            if (opened) {
+                root.moreToolsMenuOpened = true;
+            } else {
+                root.moreToolsMenuOpened = false;
+            }
         }
 
-        MenuItem {
-            text: qsTr("Rotate")
-            contentItem: StyledText {
-                text: parent.text
-                color: parent.hovered ? Theme.primary : Theme.surfaceText
-                font.pixelSize: Theme.fontSizeSmall
+        Component.onDestruction: {
+            if (opened) {
+                root.moreToolsMenuOpened = false;
             }
-            background: Rectangle {
-                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
-            }
-            onTriggered: root.rotateRequested()
         }
 
-        MenuItem {
-            text: qsTr("Mirror")
-            contentItem: StyledText {
-                text: parent.text
-                color: parent.hovered ? Theme.primary : Theme.surfaceText
-                font.pixelSize: Theme.fontSizeSmall
+        visible: opacity > 0
+        opacity: 0
+        scale: 0.9
+
+        states: [
+            State {
+                name: "visible"
+                when: menuRoot.opened
+                PropertyChanges { target: menuRoot; opacity: 1.0; scale: 1.0 }
             }
-            background: Rectangle {
-                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
+        ]
+
+        transitions: [
+            Transition {
+                NumberAnimation { properties: "opacity,scale"; duration: 120; easing.type: Easing.OutQuad }
             }
-            onTriggered: root.mirrorRequested()
+        ]
+
+        function open() {
+            root.moreToolsMenuForceClose = false;
+            menuRoot.opened = true;
+        }
+
+        function close() {
+            menuRoot.opened = false;
+        }
+
+        Connections {
+            target: root
+            function onMoreToolsMenuForceCloseChanged() {
+                if (root.moreToolsMenuForceClose) {
+                    menuRoot.opened = false;
+                }
+            }
+        }
+
+        Column {
+            id: menuColumn
+            anchors.fill: parent
+            anchors.margins: Theme.spacingS
+            spacing: 2
+
+            // Rotate Option
+            Rectangle {
+                width: parent.width
+                height: 28
+                radius: Theme.cornerRadius - 2
+                color: rotateMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+
+                Row {
+                    anchors.fill: parent
+                    anchors.leftMargin: Theme.spacingS
+                    anchors.rightMargin: Theme.spacingS
+                    spacing: Theme.spacingS
+                    anchors.verticalCenter: parent.verticalCenter
+
+                    DankIcon {
+                        name: "rotate_right"
+                        size: 14
+                        color: Theme.surfaceText
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    StyledText {
+                        text: qsTr("Rotate")
+                        font.pixelSize: Theme.fontSizeSmall
+                        color: Theme.surfaceText
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
+
+                MouseArea {
+                    id: rotateMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        menuRoot.close();
+                        root.rotateRequested();
+                    }
+                }
+            }
+
+            // Mirror Option
+            Rectangle {
+                width: parent.width
+                height: 28
+                radius: Theme.cornerRadius - 2
+                color: mirrorMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+
+                Row {
+                    anchors.fill: parent
+                    anchors.leftMargin: Theme.spacingS
+                    anchors.rightMargin: Theme.spacingS
+                    spacing: Theme.spacingS
+                    anchors.verticalCenter: parent.verticalCenter
+
+                    DankIcon {
+                        name: "flip"
+                        size: 14
+                        color: Theme.surfaceText
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    StyledText {
+                        text: qsTr("Mirror")
+                        font.pixelSize: Theme.fontSizeSmall
+                        color: Theme.surfaceText
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
+
+                MouseArea {
+                    id: mirrorMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        menuRoot.close();
+                        root.mirrorRequested();
+                    }
+                }
+            }
         }
     }
 
@@ -200,7 +315,13 @@ Rectangle {
                     buttonSize: 36
                     iconSize: 18
                     tooltipText: qsTr("More Tools")
-                    onClicked: moreActionsMenu.open()
+                    onClicked: {
+                        if (moreActionsMenu.opened) {
+                            moreActionsMenu.close();
+                        } else {
+                            moreActionsMenu.open();
+                        }
+                    }
                     
                     MoreToolsMenu {
                         id: moreActionsMenu
@@ -340,7 +461,13 @@ Rectangle {
                     buttonSize: 36
                     iconSize: 18
                     tooltipText: qsTr("More Tools")
-                    onClicked: moreActionsVerticalMenu.open()
+                    onClicked: {
+                        if (moreActionsVerticalMenu.opened) {
+                            moreActionsVerticalMenu.close();
+                        } else {
+                            moreActionsVerticalMenu.open();
+                        }
+                    }
                     
                     MoreToolsMenu {
                         id: moreActionsVerticalMenu

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -45,8 +45,11 @@ Rectangle {
     signal changeBackdropAspectRatio(string ratio)
     signal rotateRequested()
     signal mirrorRequested()
+    signal menuClosed()
 
     component MoreToolsMenu: Menu {
+        onClosed: root.menuClosed()
+
         background: Rectangle {
             implicitWidth: 100
             color: Theme.withAlpha(Theme.surface, Theme.popupTransparency)

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -43,6 +43,8 @@ Rectangle {
     signal changeBackdropCornerRadius(int radius)
     signal changeBackdropShadowStrength(int strength)
     signal changeBackdropAspectRatio(string ratio)
+    signal rotateRequested()
+    signal mirrorRequested()
 
     readonly property var toolbarPalette: {
         const p1 = root.pluginData["toolbar_color_primary"] || "primary";
@@ -152,6 +154,51 @@ Rectangle {
                                     }
                                 }
                             }
+                        }
+                    }
+                }
+                DankActionButton {
+                    iconName: "more_horiz"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("More Tools")
+                    onClicked: moreActionsMenu.open()
+                    
+                    Menu {
+                        id: moreActionsMenu
+                        y: parent.height
+                        
+                        background: Rectangle {
+                            implicitWidth: 100
+                            color: Theme.withAlpha(Theme.surface, Theme.popupTransparency)
+                            border.color: Theme.withAlpha(Theme.outline, 0.2)
+                            radius: Theme.cornerRadiusS
+                        }
+
+                        MenuItem {
+                            text: qsTr("Rotate")
+                            contentItem: StyledText {
+                                text: parent.text
+                                color: parent.hovered ? Theme.primary : Theme.surfaceText
+                                font.pixelSize: Theme.fontSizeSmall
+                            }
+                            background: Rectangle {
+                                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
+                            }
+                            onTriggered: root.rotateRequested()
+                        }
+
+                        MenuItem {
+                            text: qsTr("Mirror")
+                            contentItem: StyledText {
+                                text: parent.text
+                                color: parent.hovered ? Theme.primary : Theme.surfaceText
+                                font.pixelSize: Theme.fontSizeSmall
+                            }
+                            background: Rectangle {
+                                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
+                            }
+                            onTriggered: root.mirrorRequested()
                         }
                     }
                 }
@@ -280,6 +327,52 @@ Rectangle {
                                     }
                                 }
                             }
+                        }
+                    }
+                }
+                DankActionButton {
+                    iconName: "more_vert"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("More Tools")
+                    onClicked: moreActionsVerticalMenu.open()
+                    
+                    Menu {
+                        id: moreActionsVerticalMenu
+                        x: parent.width
+                        y: 0
+                        
+                        background: Rectangle {
+                            implicitWidth: 100
+                            color: Theme.withAlpha(Theme.surface, Theme.popupTransparency)
+                            border.color: Theme.withAlpha(Theme.outline, 0.2)
+                            radius: Theme.cornerRadiusS
+                        }
+
+                        MenuItem {
+                            text: qsTr("Rotate")
+                            contentItem: StyledText {
+                                text: parent.text
+                                color: parent.hovered ? Theme.primary : Theme.surfaceText
+                                font.pixelSize: Theme.fontSizeSmall
+                            }
+                            background: Rectangle {
+                                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
+                            }
+                            onTriggered: root.rotateRequested()
+                        }
+
+                        MenuItem {
+                            text: qsTr("Mirror")
+                            contentItem: StyledText {
+                                text: parent.text
+                                color: parent.hovered ? Theme.primary : Theme.surfaceText
+                                font.pixelSize: Theme.fontSizeSmall
+                            }
+                            background: Rectangle {
+                                color: parent.hovered ? Theme.withAlpha(Theme.primary, 0.1) : "transparent"
+                            }
+                            onTriggered: root.mirrorRequested()
                         }
                     }
                 }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -484,13 +484,13 @@ Rectangle {
                         width: 24; height: 24; radius: 4; color: root.backdropGradientStart
                         border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
                         border.width: root.gradientActiveSlot === "start" ? 2 : 1
-                        MouseArea { anchors.fill: parent; onClicked: root.gradientActiveSlot = "start" }
+                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "start" }
                     }
                     Rectangle {
                         width: 24; height: 24; radius: 4; color: root.backdropGradientEnd
                         border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
                         border.width: root.gradientActiveSlot === "end" ? 2 : 1
-                        MouseArea { anchors.fill: parent; onClicked: root.gradientActiveSlot = "end" }
+                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
                     }
                 }
                 
@@ -716,13 +716,13 @@ Rectangle {
                         width: 18; height: 18; radius: 3; color: root.backdropGradientStart
                         border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
                         border.width: root.gradientActiveSlot === "start" ? 1.5 : 1
-                        MouseArea { anchors.fill: parent; onClicked: root.gradientActiveSlot = "start" }
+                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "start" }
                     }
                     Rectangle {
                         width: 18; height: 18; radius: 3; color: root.backdropGradientEnd
                         border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
                         border.width: root.gradientActiveSlot === "end" ? 1.5 : 1
-                        MouseArea { anchors.fill: parent; onClicked: root.gradientActiveSlot = "end" }
+                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
                     }
                 }
                 


### PR DESCRIPTION
# What
Adds a "More Tools" (`...` icon) dropdown context menu to both the horizontal and vertical toolbars, populated with "Rotate" (90° clockwise) and "Mirror" (horizontal flip) operations.

# Why
Provides less frequently used canvas operations in a tidy, non-intrusive submenu, keeping the main toolbar clean and focused.

# How
- Uses standard QML `Menu` and `MenuItem` styled to match the dark material theme of DMS.
- Leverages the fast system `mogrify` tool to transform the underlying screenshot file (`/tmp/dms_capture_bg.png`).
- Maps existing annotation coordinates (in `window.strokes`) and crop boundaries (`window.cropRect`) programmatically so that current edits are correctly rotated/mirrored without loss.

## Summary by Sourcery

Add a More Tools dropdown to the capture toolbars that exposes Rotate and Mirror operations for the current screenshot and its annotations.

New Features:
- Introduce a More Tools menu button on both horizontal and vertical quick capture toolbars.
- Add Rotate and Mirror actions that transform the captured screenshot and maintain current selection and annotations.

Enhancements:
- Wire toolbar Rotate and Mirror actions to modal handlers that update the background image, crop rectangle, and stroke positions after transformations.