### PR TITLE
feat(backdrop): refactor sliders to compact hover-expandable controls using HoverSliderPopover

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1284,11 +1284,19 @@ DankModal {
                         
                         if (popover) {
                             if (toolbarCard.isVertical) {
-                                popover.x = pt.x + controlItem.width + Theme.spacingXS;
+                                if (window.toolbarPosition === "right") {
+                                    popover.x = pt.x - popover.width - Theme.spacingXS;
+                                } else {
+                                    popover.x = pt.x + controlItem.width + Theme.spacingXS;
+                                }
                                 popover.y = pt.y + (controlItem.height - popover.height) / 2;
                             } else {
                                 popover.x = pt.x + (controlItem.width - popover.width) / 2;
-                                popover.y = pt.y + controlItem.height + Theme.spacingXS;
+                                if (window.toolbarPosition === "bottom") {
+                                    popover.y = pt.y - popover.height - Theme.spacingXS;
+                                } else {
+                                    popover.y = pt.y + controlItem.height + Theme.spacingXS;
+                                }
                             }
                             popover.open();
                         }
@@ -2654,6 +2662,7 @@ DankModal {
                     id: backdropRadiusPopover
                     minimum: 0
                     maximum: 60
+                    stepSize: 2
                     value: window.backdropCornerRadius
                     onUserValueChanged: (val) => {
                         window.backdropCornerRadius = val;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1275,6 +1275,46 @@ DankModal {
                             moreToolsMenu.open();
                         }
                     }
+                    onBackdropControlHovered: (type, controlItem) => {
+                        var pt = controlItem.mapToItem(contentRoot, 0, 0);
+                        var popover;
+                        if (type === "padding") popover = backdropPaddingPopover;
+                        else if (type === "radius") popover = backdropRadiusPopover;
+                        else if (type === "shadow") popover = backdropShadowPopover;
+                        
+                        if (popover) {
+                            if (toolbarCard.isVertical) {
+                                popover.x = pt.x + controlItem.width + Theme.spacingXS;
+                                popover.y = pt.y + (controlItem.height - popover.height) / 2;
+                            } else {
+                                popover.x = pt.x + (controlItem.width - popover.width) / 2;
+                                popover.y = pt.y + controlItem.height + Theme.spacingXS;
+                            }
+                            popover.open();
+                        }
+                    }
+                    onBackdropControlExited: (type) => {
+                        var popover;
+                        if (type === "padding") popover = backdropPaddingPopover;
+                        else if (type === "radius") popover = backdropRadiusPopover;
+                        else if (type === "shadow") popover = backdropShadowPopover;
+                        
+                        if (popover) {
+                            popover.startCloseTimer();
+                        }
+                    }
+                    onBackdropControlWheel: (type, delta) => {
+                        let step = delta > 0 ? 5 : -5;
+                        if (type === "padding") {
+                            window.backdropPadding = Math.max(10, Math.min(150, window.backdropPadding + step));
+                        } else if (type === "radius") {
+                            let rStep = delta > 0 ? 2 : -2;
+                            window.backdropCornerRadius = Math.max(0, Math.min(60, window.backdropCornerRadius + rStep));
+                        } else if (type === "shadow") {
+                            window.backdropShadowStrength = Math.max(0, Math.min(100, window.backdropShadowStrength + step));
+                        }
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
                 }
 
                 // 2. Centered Canvas Board
@@ -2597,6 +2637,39 @@ DankModal {
                     id: moreToolsMenu
                     onRotateRequested: window.rotateScreenshot()
                     onMirrorRequested: window.mirrorScreenshot()
+                }
+
+                HoverSliderPopover {
+                    id: backdropPaddingPopover
+                    minimum: 10
+                    maximum: 150
+                    value: window.backdropPadding
+                    onUserValueChanged: (val) => {
+                        window.backdropPadding = val;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                }
+
+                HoverSliderPopover {
+                    id: backdropRadiusPopover
+                    minimum: 0
+                    maximum: 60
+                    value: window.backdropCornerRadius
+                    onUserValueChanged: (val) => {
+                        window.backdropCornerRadius = val;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                }
+
+                HoverSliderPopover {
+                    id: backdropShadowPopover
+                    minimum: 0
+                    maximum: 100
+                    value: window.backdropShadowStrength
+                    onUserValueChanged: (val) => {
+                        window.backdropShadowStrength = val;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
                 }
 
                 Canvas {

--- a/components/HoverSliderPopover.qml
+++ b/components/HoverSliderPopover.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+Rectangle {
+    id: popoverRoot
+    width: 120
+    height: 36
+    color: Theme.surfaceContainer
+    border.color: Theme.withAlpha(Theme.outline, 0.15)
+    border.width: 1
+    radius: Theme.cornerRadius
+    z: 10001
+
+    property int minimum: 0
+    property int maximum: 100
+    property int value: 0
+    property bool opened: false
+
+    signal userValueChanged(int val)
+
+    visible: opacity > 0
+    opacity: 0
+    scale: 0.9
+
+    states: [
+        State {
+            name: "visible"
+            when: popoverRoot.opened
+            PropertyChanges { target: popoverRoot; opacity: 1.0; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { properties: "opacity,scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open() {
+        closeTimer.stop();
+        popoverRoot.opened = true;
+    }
+
+    function close() {
+        popoverRoot.opened = false;
+    }
+
+    function startCloseTimer() {
+        closeTimer.start();
+    }
+
+    function stopCloseTimer() {
+        closeTimer.stop();
+    }
+
+    Timer {
+        id: closeTimer
+        interval: 200
+        onTriggered: popoverRoot.close()
+    }
+
+    MouseArea {
+        id: hoverArea
+        anchors.fill: parent
+        hoverEnabled: true
+        onEntered: popoverRoot.open()
+        onExited: popoverRoot.startCloseTimer()
+        
+        onWheel: (wheel) => {
+            let step = wheel.angleDelta.y > 0 ? 5 : -5;
+            let newVal = Math.max(popoverRoot.minimum, Math.min(popoverRoot.maximum, popoverRoot.value + step));
+            popoverRoot.userValueChanged(newVal);
+        }
+
+        DankSlider {
+            id: slider
+            minimum: popoverRoot.minimum
+            maximum: popoverRoot.maximum
+            anchors.fill: parent
+            anchors.margins: Theme.spacingS
+            value: popoverRoot.value
+            showValue: false
+            onSliderValueChanged: val => popoverRoot.userValueChanged(val)
+        }
+    }
+}

--- a/components/HoverSliderPopover.qml
+++ b/components/HoverSliderPopover.qml
@@ -15,6 +15,7 @@ Rectangle {
     property int minimum: 0
     property int maximum: 100
     property int value: 0
+    property int stepSize: 5
     property bool opened: false
 
     signal userValueChanged(int val)
@@ -68,7 +69,7 @@ Rectangle {
         onExited: popoverRoot.startCloseTimer()
         
         onWheel: (wheel) => {
-            let step = wheel.angleDelta.y > 0 ? 5 : -5;
+            let step = wheel.angleDelta.y > 0 ? popoverRoot.stepSize : -popoverRoot.stepSize;
             let newVal = Math.max(popoverRoot.minimum, Math.min(popoverRoot.maximum, popoverRoot.value + step));
             popoverRoot.userValueChanged(newVal);
         }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -46,6 +46,9 @@ Rectangle {
     signal rotateRequested()
     signal mirrorRequested()
     signal moreToolsClicked(var buttonItem)
+    signal backdropControlHovered(string type, var controlItem)
+    signal backdropControlExited(string type)
+    signal backdropControlWheel(string type, int delta)
 
     readonly property var toolbarPalette: {
         const p1 = root.pluginData["toolbar_color_primary"] || "primary";
@@ -414,52 +417,114 @@ Rectangle {
             Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
             
             // Sliders Row
+            // Sliders Row (Hover to reveal slider)
+            // Sliders Row (Hover to reveal popup slider)
             Row {
                 spacing: Theme.spacingM
                 anchors.verticalCenter: parent.verticalCenter
                 
-                Row {
-                    spacing: Theme.spacingXS
-                    Text { text: qsTr("Padding:") + " " + root.backdropPadding + "px"; color: Theme.surfaceText; font.pixelSize: 10; font.bold: true; anchors.verticalCenter: parent.verticalCenter }
-                    DankSlider {
-                        minimum: 10
-                        maximum: 150
-                        width: 80
-                        height: 36
-                        value: root.backdropPadding
-                        showValue: false
-                        onSliderValueChanged: val => root.changeBackdropPadding(val)
+                // Padding Control
+                Item {
+                    id: padControl
+                    width: padRow.implicitWidth
+                    height: 36
+                    anchors.verticalCenter: parent.verticalCenter
+                    
+                    Row {
+                        id: padRow
+                        spacing: Theme.spacingXS
                         anchors.verticalCenter: parent.verticalCenter
+                        DankIcon {
+                            name: "padding"
+                            size: 16
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.backdropPadding + "px"
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: padMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("padding", padControl)
+                        onExited: root.backdropControlExited("padding")
+                        onWheel: (wheel) => root.backdropControlWheel("padding", wheel.angleDelta.y)
                     }
                 }
-                
-                Row {
-                    spacing: Theme.spacingXS
-                    Text { text: qsTr("Radius:") + " " + root.backdropCornerRadius + "px"; color: Theme.surfaceText; font.pixelSize: 10; font.bold: true; anchors.verticalCenter: parent.verticalCenter }
-                    DankSlider {
-                        minimum: 0
-                        maximum: 60
-                        width: 80
-                        height: 36
-                        value: root.backdropCornerRadius
-                        showValue: false
-                        onSliderValueChanged: val => root.changeBackdropCornerRadius(val)
+
+                // Corner Radius Control
+                Item {
+                    id: radControl
+                    width: radRow.implicitWidth
+                    height: 36
+                    anchors.verticalCenter: parent.verticalCenter
+                    
+                    Row {
+                        id: radRow
+                        spacing: Theme.spacingXS
                         anchors.verticalCenter: parent.verticalCenter
+                        DankIcon {
+                            name: "rounded_corner"
+                            size: 16
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.backdropCornerRadius + "px"
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: radMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("radius", radControl)
+                        onExited: root.backdropControlExited("radius")
+                        onWheel: (wheel) => root.backdropControlWheel("radius", wheel.angleDelta.y)
                     }
                 }
-                
-                Row {
-                    spacing: Theme.spacingXS
-                    Text { text: qsTr("Shadow:") + " " + root.backdropShadowStrength + "%"; color: Theme.surfaceText; font.pixelSize: 10; font.bold: true; anchors.verticalCenter: parent.verticalCenter }
-                    DankSlider {
-                        minimum: 0
-                        maximum: 100
-                        width: 80
-                        height: 36
-                        value: root.backdropShadowStrength
-                        showValue: false
-                        onSliderValueChanged: val => root.changeBackdropShadowStrength(val)
+
+                // Shadow Control
+                Item {
+                    id: shadowControl
+                    width: shadowRow.implicitWidth
+                    height: 36
+                    anchors.verticalCenter: parent.verticalCenter
+                    
+                    Row {
+                        id: shadowRow
+                        spacing: Theme.spacingXS
                         anchors.verticalCenter: parent.verticalCenter
+                        DankIcon {
+                            name: "blur_on"
+                            size: 16
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.backdropShadowStrength + "%"
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: shadowMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("shadow", shadowControl)
+                        onExited: root.backdropControlExited("shadow")
+                        onWheel: (wheel) => root.backdropControlWheel("shadow", wheel.angleDelta.y)
                     }
                 }
             }
@@ -645,53 +710,110 @@ Rectangle {
             
             Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
             
-            // Sliders
+            // Sliders (Hover to reveal popover)
             Column {
                 spacing: Theme.spacingS
                 anchors.horizontalCenter: parent.horizontalCenter
                 
-                Column {
-                    spacing: 2
+                // Padding Control
+                Item {
+                    id: padControlVert
+                    width: 36
+                    height: 28
                     anchors.horizontalCenter: parent.horizontalCenter
-                    Text { text: qsTr("Pad:") + " " + root.backdropPadding + "px"; color: Theme.surfaceText; font.pixelSize: 9; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
-                    DankSlider {
-                        minimum: 10
-                        maximum: 150
-                        width: 42
-                        height: 24
-                        value: root.backdropPadding
-                        showValue: false
-                        onSliderValueChanged: val => root.changeBackdropPadding(val)
+                    
+                    Row {
+                        spacing: 2
+                        anchors.centerIn: parent
+                        DankIcon {
+                            name: "padding"
+                            size: 14
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.backdropPadding
+                            font.pixelSize: 9
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: padMouseAreaVert
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("padding", padControlVert)
+                        onExited: root.backdropControlExited("padding")
+                        onWheel: (wheel) => root.backdropControlWheel("padding", wheel.angleDelta.y)
                     }
                 }
-                
-                Column {
-                    spacing: 2
+
+                // Corner Radius Control
+                Item {
+                    id: radControlVert
+                    width: 36
+                    height: 28
                     anchors.horizontalCenter: parent.horizontalCenter
-                    Text { text: qsTr("Rad:") + " " + root.backdropCornerRadius + "px"; color: Theme.surfaceText; font.pixelSize: 9; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
-                    DankSlider {
-                        minimum: 0
-                        maximum: 60
-                        width: 42
-                        height: 24
-                        value: root.backdropCornerRadius
-                        showValue: false
-                        onSliderValueChanged: val => root.changeBackdropCornerRadius(val)
+                    
+                    Row {
+                        spacing: 2
+                        anchors.centerIn: parent
+                        DankIcon {
+                            name: "rounded_corner"
+                            size: 14
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.backdropCornerRadius
+                            font.pixelSize: 9
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: radMouseAreaVert
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("radius", radControlVert)
+                        onExited: root.backdropControlExited("radius")
+                        onWheel: (wheel) => root.backdropControlWheel("radius", wheel.angleDelta.y)
                     }
                 }
-                
-                Column {
-                    spacing: 2
+
+                // Shadow Control
+                Item {
+                    id: shadowControlVert
+                    width: 36
+                    height: 28
                     anchors.horizontalCenter: parent.horizontalCenter
-                    Text { text: qsTr("Shd:") + " " + root.backdropShadowStrength + "%"; color: Theme.surfaceText; font.pixelSize: 9; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter }
-                    DankSlider {
-                        minimum: 0
-                        maximum: 100
-                        width: 42
-                        height: 24
-                        value: root.backdropShadowStrength
-                        showValue: false
-                        onSliderValueChanged: val => root.changeBackdropShadowStrength(val)
+                    
+                    Row {
+                        spacing: 2
+                        anchors.centerIn: parent
+                        DankIcon {
+                            name: "blur_on"
+                            size: 14
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.backdropShadowStrength
+                            font.pixelSize: 9
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: shadowMouseAreaVert
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("shadow", shadowControlVert)
+                        onExited: root.backdropControlExited("shadow")
+                        onWheel: (wheel) => root.backdropControlWheel("shadow", wheel.angleDelta.y)
                     }
                 }
             }


### PR DESCRIPTION
#### What
- Created a new reusable [components/HoverSliderPopover.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/HoverSliderPopover.qml) component containing a hover-sensitive, scale-animated `DankSlider` with wheel scrolling support.
- Refactored the backdrop configuration row/column in [components/QuickCaptureToolbar.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/QuickCaptureToolbar.qml) to replace three bulky sliders (Padding, Radius, Shadow) with compact Icon + Text indicators.
- Hooked up `backdropControlHovered`, `backdropControlExited`, and `backdropControlWheel` signals in the toolbar to coordinate popover instantiation and dynamic positioning at the modal level in [QuickCaptureModal.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/QuickCaptureModal.qml).

#### Why
- Reduces horizontal and vertical space used by backdrop settings inside the toolbar, providing a cleaner, more premium look.
- Resolves Wayland QML click-clipping boundaries by elevating popover sliders to the root modal level (similar to the fix applied for `MoreToolsMenu`).
- Preserves the ability for users to use the mouse scroll wheel over either the icon button or the popup itself to adjust the padding/radius/shadow values directly.

#### How Tested
- Enabled and verified that the quickCapture plugin loads without compile/runtime errors.
- Verified coordinate mapping (`mapToItem`) correctly aligns popovers below/beside controls in both horizontal and vertical toolbar layouts.
- Verified that mouse wheel scrolling and dragging on the slider update the canvas view reactively.

## Summary by Sourcery

Introduce hover-activated popover sliders for backdrop controls and integrate them at the modal level for better layout and interaction behavior.

New Features:
- Add a reusable HoverSliderPopover component providing an animated DankSlider with hover and wheel support.
- Expose backdropControlHovered, backdropControlExited, and backdropControlWheel signals from the toolbar to drive backdrop popover behavior.

Enhancements:
- Refine backdrop padding, radius, and shadow controls in the toolbar into compact icon/text indicators that reveal popover sliders on hover.
- Position backdrop popover sliders relative to toolbar controls for both horizontal and vertical layouts and ensure canvas updates on interaction.