### PR TITLE
feat(backdrop): implement auto color balance from screenshot dominant colors

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -75,6 +75,10 @@ DankModal {
     property int backdropCornerRadius: 12
     property int backdropShadowStrength: 50
     property string backdropAspectRatio: "auto" // auto, 1:1, 16:9, 4:3
+    property bool hasUserCustomizedBackdrop: false
+    property color autoBackdropGradientStart: Theme.primary
+    property color autoBackdropGradientEnd: Theme.secondary
+    property color autoBackdropSolidColor: Theme.primary
 
     // Intensity Management
     property int strokeWidth: 8
@@ -1118,13 +1122,13 @@ DankModal {
 
                 onStatusChanged: {
                     if (status === Image.Ready) {
+                        window.hasUserCustomizedBackdrop = false;
+                        window.hasSampledContrast = false;
                         if (window.activeCanvas) {
                             window.activeCanvas.unloadImage(source);
                             window.activeCanvas.loadImage(source);
                         }
-                        if (!window.hasSampledContrast) {
-                            contrastSampler.requestPaint();
-                        }
+                        contrastSampler.requestPaint();
                     }
                 }
 
@@ -1176,14 +1180,17 @@ DankModal {
                     }
                     onChangeBackdropSolidColor: (col) => {
                         window.backdropSolidColor = col;
+                        window.hasUserCustomizedBackdrop = true;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
                     onChangeBackdropGradientStart: (col) => {
                         window.backdropGradientStart = col;
+                        window.hasUserCustomizedBackdrop = true;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
                     onChangeBackdropGradientEnd: (col) => {
                         window.backdropGradientEnd = col;
+                        window.hasUserCustomizedBackdrop = true;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
                     onChangeBackdropGradientAngle: (angle) => {
@@ -1204,6 +1211,13 @@ DankModal {
                     }
                     onChangeBackdropAspectRatio: (ratio) => {
                         window.backdropAspectRatio = ratio;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onAutoColorBalanceRequested: {
+                        window.backdropGradientStart = window.autoBackdropGradientStart;
+                        window.backdropGradientEnd = window.autoBackdropGradientEnd;
+                        window.backdropSolidColor = window.autoBackdropSolidColor;
+                        window.hasUserCustomizedBackdrop = true;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
 
@@ -2684,19 +2698,32 @@ DankModal {
                 Canvas {
                     id: contrastSampler
                     visible: false
-                    width: 1
-                    height: 1
+                    width: 4
+                    height: 4
                     onPaint: {
                         var ctx = contrastSampler.getContext("2d");
-                        ctx.drawImage(bgImage, 0, 0, 1, 1, 0, 0, 1, 1);
-                        var imgData = ctx.getImageData(0, 0, 1, 1);
+                        ctx.drawImage(bgImage, 0, 0, 4, 4, 0, 0, 4, 4);
+                        var imgData = ctx.getImageData(0, 0, 4, 4);
                         if (imgData && imgData.data) {
-                            var r = imgData.data[0];
-                            var g = imgData.data[1];
-                            var b = imgData.data[2];
+                            // Sample center pixel (index 5) for luminance
+                            var r = imgData.data[5 * 4];
+                            var g = imgData.data[5 * 4 + 1];
+                            var b = imgData.data[5 * 4 + 2];
                             var brightness = Helpers.getLuminance({ r: r/255, g: g/255, b: b/255 });
                             window.isScreenshotDark = (brightness < 0.35);
                             window.hasSampledContrast = true;
+
+                            // Extract auto-balanced colors
+                            var colors = Helpers.extractDominantColors(imgData, Qt);
+                            window.autoBackdropGradientStart = colors.start;
+                            window.autoBackdropGradientEnd = colors.end;
+                            window.autoBackdropSolidColor = colors.start;
+
+                            if (!window.hasUserCustomizedBackdrop) {
+                                window.backdropGradientStart = colors.start;
+                                window.backdropGradientEnd = colors.end;
+                                window.backdropSolidColor = colors.start;
+                            }
                         }
                     }
                 }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1044,6 +1044,7 @@ DankModal {
         window.bgImageSource = "file:///tmp/dms_capture_bg.png";
         window.isScreenshotDark = false;
         window.hasSampledContrast = false;
+        window.hasUserCustomizedBackdrop = false;
         window.cropRect = Qt.rect(0, 0, 0, 0);
         window.hasSelection = false;
         window.activeHandle = "none";
@@ -1122,7 +1123,6 @@ DankModal {
 
                 onStatusChanged: {
                     if (status === Image.Ready) {
-                        window.hasUserCustomizedBackdrop = false;
                         window.hasSampledContrast = false;
                         if (window.activeCanvas) {
                             window.activeCanvas.unloadImage(source);

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -1,0 +1,67 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+Row {
+    id: controlRoot
+
+    property string backdropMode: "none"
+    property color backdropSolidColor: Theme.primary
+    property color backdropGradientStart: Theme.primary
+    property color backdropGradientEnd: Theme.secondary
+    property string gradientActiveSlot: "start"
+    property int itemSize: 24
+    property int iconSize: 14
+
+    signal setGradientActiveSlot(string slot)
+    signal autoColorBalanceRequested()
+
+    spacing: Theme.spacingXS
+    anchors.verticalCenter: parent.verticalCenter
+
+    Rectangle {
+        visible: controlRoot.backdropMode === "solid"
+        width: controlRoot.itemSize; height: controlRoot.itemSize; radius: Math.round(controlRoot.itemSize * 0.16)
+        color: controlRoot.backdropSolidColor
+        border.color: Theme.withAlpha(Theme.outline, 0.3)
+        border.width: 1
+    }
+
+    Row {
+        visible: controlRoot.backdropMode === "gradient"
+        spacing: Theme.spacingXS
+        anchors.verticalCenter: parent.verticalCenter
+
+        Rectangle {
+            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: Math.round(controlRoot.itemSize * 0.16)
+            color: controlRoot.backdropGradientStart
+            border.color: controlRoot.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+            border.width: controlRoot.gradientActiveSlot === "start" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: controlRoot.setGradientActiveSlot("start")
+            }
+        }
+        Rectangle {
+            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: Math.round(controlRoot.itemSize * 0.16)
+            color: controlRoot.backdropGradientEnd
+            border.color: controlRoot.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+            border.width: controlRoot.gradientActiveSlot === "end" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: controlRoot.setGradientActiveSlot("end")
+            }
+        }
+    }
+
+    DankActionButton {
+        buttonSize: controlRoot.itemSize
+        iconName: "auto_awesome"
+        iconSize: controlRoot.iconSize
+        backgroundColor: "transparent"
+        iconColor: Theme.primary
+        onClicked: controlRoot.autoColorBalanceRequested()
+    }
+}

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -217,3 +217,72 @@ function formatWatermarkText(pattern, Quickshell) {
         .replace(/\{mm\}/g, mm)
         .replace(/\{ss\}/gi, ss);
 }
+
+/**
+ * Downsamples screenshot pixels to extract a matching backdrop gradient.
+ * @param {object} imgData - Canvas getImageData object of size 4x4.
+ * @param {object} Qt - The Qt object.
+ * @returns {object} { start, end } QML color values.
+ */
+function extractDominantColors(imgData, Qt) {
+    var pixels = [];
+    for (var i = 0; i < 16; i++) {
+        var r = imgData.data[i * 4];
+        var g = imgData.data[i * 4 + 1];
+        var b = imgData.data[i * 4 + 2];
+        
+        // Calculate saturation: max(r,g,b) - min(r,g,b)
+        var max = Math.max(r, g, b);
+        var min = Math.min(r, g, b);
+        var sat = max - min;
+        
+        pixels.push({ r: r, g: g, b: b, sat: sat, max: max });
+    }
+    
+    // Sort by saturation descending to prefer vibrant colors
+    pixels.sort(function(a, b) { return b.sat - a.sat; });
+    
+    var colorStart, colorEnd;
+    
+    // If the image is extremely grey/monochromatic (saturation < 15)
+    if (pixels[0].sat < 15) {
+        var avg = 0;
+        for (var i = 0; i < 16; i++) {
+            avg += (pixels[i].r + pixels[i].g + pixels[i].b) / 3;
+        }
+        avg = Math.round(avg / 16);
+        // Fallback: use a nice muted grey-blue gradient based on the average brightness
+        colorStart = Qt.rgba(Math.max(0, avg - 20)/255, Math.max(0, avg - 10)/255, Math.min(255, avg + 10)/255, 1);
+        colorEnd = Qt.rgba(Math.min(255, avg + 20)/255, Math.min(255, avg + 10)/255, Math.max(0, avg - 10)/255, 1);
+    } else {
+        // Start color: the most vibrant color
+        var pStart = pixels[0];
+        colorStart = Qt.rgba(pStart.r/255, pStart.g/255, pStart.b/255, 1);
+        
+        // End color: find a pixel that is sufficiently different from start color in RGB space
+        var pEnd = null;
+        var maxDist = -1;
+        for (var j = 1; j < pixels.length; j++) {
+            var pj = pixels[j];
+            var dist = Math.sqrt(Math.pow(pj.r - pStart.r, 2) + Math.pow(pj.g - pStart.g, 2) + Math.pow(pj.b - pStart.b, 2));
+            if (dist > maxDist) {
+                maxDist = dist;
+                pEnd = pj;
+            }
+        }
+        
+        if (pEnd && maxDist > 40) {
+            colorEnd = Qt.rgba(pEnd.r/255, pEnd.g/255, pEnd.b/255, 1);
+        } else {
+            // Generate a complementary/analogous color if no distinct color is found
+            colorEnd = Qt.rgba(
+                Math.min(255, Math.round(pStart.r * 0.7 + 50))/255,
+                Math.min(255, Math.round(pStart.g * 0.7 + 30))/255,
+                Math.min(255, Math.round(pStart.b * 1.2))/255,
+                1
+            );
+        }
+    }
+    
+    return { start: colorStart, end: colorEnd };
+}

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -225,6 +225,14 @@ function formatWatermarkText(pattern, Quickshell) {
  * @returns {object} { start, end } QML color values.
  */
 function extractDominantColors(imgData, Qt) {
+    var fallback = {
+        start: Qt.rgba(0.2, 0.33, 0.47, 1),
+        end: Qt.rgba(0.07, 0.13, 0.2, 1)
+    };
+    if (!imgData || !imgData.data || imgData.data.length < 64) {
+        return fallback;
+    }
+
     var pixels = [];
     for (var i = 0; i < 16; i++) {
         var r = imgData.data[i * 4];

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -49,6 +49,7 @@ Rectangle {
     signal backdropControlHovered(string type, var controlItem)
     signal backdropControlExited(string type)
     signal backdropControlWheel(string type, int delta)
+    signal autoColorBalanceRequested()
 
     readonly property var toolbarPalette: {
         const p1 = root.pluginData["toolbar_color_primary"] || "primary";
@@ -557,6 +558,14 @@ Rectangle {
                         border.width: root.gradientActiveSlot === "end" ? 2 : 1
                         MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
                     }
+                    DankActionButton {
+                        buttonSize: 24
+                        iconName: "auto_awesome"
+                        iconSize: 14
+                        backgroundColor: "transparent"
+                        iconColor: Theme.primary
+                        onClicked: root.autoColorBalanceRequested()
+                    }
                 }
                 
                 Grid {
@@ -845,6 +854,14 @@ Rectangle {
                         border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
                         border.width: root.gradientActiveSlot === "end" ? 1.5 : 1
                         MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
+                    }
+                    DankActionButton {
+                        buttonSize: 18
+                        iconName: "auto_awesome"
+                        iconSize: 10
+                        backgroundColor: "transparent"
+                        iconColor: Theme.primary
+                        onClicked: root.autoColorBalanceRequested()
                     }
                 }
                 

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -542,22 +542,35 @@ Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 
                 Row {
-                    visible: root.backdropMode === "gradient"
                     spacing: Theme.spacingXS
                     anchors.verticalCenter: parent.verticalCenter
-                    
+
                     Rectangle {
-                        width: 24; height: 24; radius: 4; color: root.backdropGradientStart
-                        border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: root.gradientActiveSlot === "start" ? 2 : 1
-                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "start" }
+                        visible: root.backdropMode === "solid"
+                        width: 24; height: 24; radius: 4; color: root.backdropSolidColor
+                        border.color: Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: 1
                     }
-                    Rectangle {
-                        width: 24; height: 24; radius: 4; color: root.backdropGradientEnd
-                        border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: root.gradientActiveSlot === "end" ? 2 : 1
-                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
+
+                    Row {
+                        visible: root.backdropMode === "gradient"
+                        spacing: Theme.spacingXS
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        Rectangle {
+                            width: 24; height: 24; radius: 4; color: root.backdropGradientStart
+                            border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                            border.width: root.gradientActiveSlot === "start" ? 2 : 1
+                            MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "start" }
+                        }
+                        Rectangle {
+                            width: 24; height: 24; radius: 4; color: root.backdropGradientEnd
+                            border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                            border.width: root.gradientActiveSlot === "end" ? 2 : 1
+                            MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
+                        }
                     }
+
                     DankActionButton {
                         buttonSize: 24
                         iconName: "auto_awesome"
@@ -839,22 +852,35 @@ Rectangle {
                 anchors.horizontalCenter: parent.horizontalCenter
                 
                 Row {
-                    visible: root.backdropMode === "gradient"
                     spacing: Theme.spacingXS
                     anchors.horizontalCenter: parent.horizontalCenter
-                    
+
                     Rectangle {
-                        width: 18; height: 18; radius: 3; color: root.backdropGradientStart
-                        border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: root.gradientActiveSlot === "start" ? 1.5 : 1
-                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "start" }
+                        visible: root.backdropMode === "solid"
+                        width: 18; height: 18; radius: 3; color: root.backdropSolidColor
+                        border.color: Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: 1
                     }
-                    Rectangle {
-                        width: 18; height: 18; radius: 3; color: root.backdropGradientEnd
-                        border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: root.gradientActiveSlot === "end" ? 1.5 : 1
-                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
+
+                    Row {
+                        visible: root.backdropMode === "gradient"
+                        spacing: Theme.spacingXS
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        Rectangle {
+                            width: 18; height: 18; radius: 3; color: root.backdropGradientStart
+                            border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                            border.width: root.gradientActiveSlot === "start" ? 1.5 : 1
+                            MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "start" }
+                        }
+                        Rectangle {
+                            width: 18; height: 18; radius: 3; color: root.backdropGradientEnd
+                            border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                            border.width: root.gradientActiveSlot === "end" ? 1.5 : 1
+                            MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
+                        }
                     }
+
                     DankActionButton {
                         buttonSize: 18
                         iconName: "auto_awesome"

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -541,44 +541,16 @@ Rectangle {
                 spacing: Theme.spacingS
                 anchors.verticalCenter: parent.verticalCenter
                 
-                Row {
-                    spacing: Theme.spacingXS
-                    anchors.verticalCenter: parent.verticalCenter
-
-                    Rectangle {
-                        visible: root.backdropMode === "solid"
-                        width: 24; height: 24; radius: 4; color: root.backdropSolidColor
-                        border.color: Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: 1
-                    }
-
-                    Row {
-                        visible: root.backdropMode === "gradient"
-                        spacing: Theme.spacingXS
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        Rectangle {
-                            width: 24; height: 24; radius: 4; color: root.backdropGradientStart
-                            border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                            border.width: root.gradientActiveSlot === "start" ? 2 : 1
-                            MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "start" }
-                        }
-                        Rectangle {
-                            width: 24; height: 24; radius: 4; color: root.backdropGradientEnd
-                            border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                            border.width: root.gradientActiveSlot === "end" ? 2 : 1
-                            MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
-                        }
-                    }
-
-                    DankActionButton {
-                        buttonSize: 24
-                        iconName: "auto_awesome"
-                        iconSize: 14
-                        backgroundColor: "transparent"
-                        iconColor: Theme.primary
-                        onClicked: root.autoColorBalanceRequested()
-                    }
+                BackdropColorSelectors {
+                    backdropMode: root.backdropMode
+                    backdropSolidColor: root.backdropSolidColor
+                    backdropGradientStart: root.backdropGradientStart
+                    backdropGradientEnd: root.backdropGradientEnd
+                    gradientActiveSlot: root.gradientActiveSlot
+                    itemSize: 24
+                    iconSize: 14
+                    onSetGradientActiveSlot: (slot) => root.gradientActiveSlot = slot
+                    onAutoColorBalanceRequested: root.autoColorBalanceRequested()
                 }
                 
                 Grid {
@@ -851,44 +823,16 @@ Rectangle {
                 spacing: Theme.spacingS
                 anchors.horizontalCenter: parent.horizontalCenter
                 
-                Row {
-                    spacing: Theme.spacingXS
-                    anchors.horizontalCenter: parent.horizontalCenter
-
-                    Rectangle {
-                        visible: root.backdropMode === "solid"
-                        width: 18; height: 18; radius: 3; color: root.backdropSolidColor
-                        border.color: Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: 1
-                    }
-
-                    Row {
-                        visible: root.backdropMode === "gradient"
-                        spacing: Theme.spacingXS
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        Rectangle {
-                            width: 18; height: 18; radius: 3; color: root.backdropGradientStart
-                            border.color: root.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                            border.width: root.gradientActiveSlot === "start" ? 1.5 : 1
-                            MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "start" }
-                        }
-                        Rectangle {
-                            width: 18; height: 18; radius: 3; color: root.backdropGradientEnd
-                            border.color: root.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                            border.width: root.gradientActiveSlot === "end" ? 1.5 : 1
-                            MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.gradientActiveSlot = "end" }
-                        }
-                    }
-
-                    DankActionButton {
-                        buttonSize: 18
-                        iconName: "auto_awesome"
-                        iconSize: 10
-                        backgroundColor: "transparent"
-                        iconColor: Theme.primary
-                        onClicked: root.autoColorBalanceRequested()
-                    }
+                BackdropColorSelectors {
+                    backdropMode: root.backdropMode
+                    backdropSolidColor: root.backdropSolidColor
+                    backdropGradientStart: root.backdropGradientStart
+                    backdropGradientEnd: root.backdropGradientEnd
+                    gradientActiveSlot: root.gradientActiveSlot
+                    itemSize: 18
+                    iconSize: 10
+                    onSetGradientActiveSlot: (slot) => root.gradientActiveSlot = slot
+                    onAutoColorBalanceRequested: root.autoColorBalanceRequested()
                 }
                 
                 Grid {


### PR DESCRIPTION
## Description

Implemented dominant color extraction from screenshot pixels to automatically generate backdrop gradients and solid colors.

Changes include:
- Upgraded the 1x1 contrast sampler to a 4x4 sampler `Canvas` in [QuickCaptureModal.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/QuickCaptureModal.qml) to extract dominant colors alongside luminance checks.
- Appended `extractDominantColors` helper function in [Helpers.js](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/Helpers.js) to downsample the screenshot, sort pixels by saturation to pick vibrant colors, and select a complementary pair using Euclidean distance.
- Integrated a color preview square and a magic wand `auto_awesome` action button next to the color preview for both Solid Color and Gradient modes in [QuickCaptureToolbar.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/QuickCaptureToolbar.qml) (horizontal and vertical layouts).
- Wired the `autoColorBalanceRequested` signal to apply the auto-extracted colors and flag the session as user-customized.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

None

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] New user-facing strings are wrapped in `I18n.tr()` with translator context, reusing existing terms where possible
- [x] QML changes: ran `qmllint` with no new warnings

## Summary by Sourcery

Add automatic backdrop color balancing based on dominant screenshot colors and integrate it into the quick capture UI.

New Features:
- Introduce auto-extracted gradient and solid backdrop colors derived from screenshot pixels.
- Expose an auto color balance action in the backdrop toolbar for both solid color and gradient modes.

Enhancements:
- Expand the contrast sampling canvas to downsample multiple pixels and drive both luminance detection and backdrop color selection.
- Track whether the backdrop has been user-customized to avoid overriding manual settings with auto-balanced colors.
- Add a helper to compute dominant and complementary colors from screenshot data for gradient generation.