### PR TITLE
feat(backdrop): implement adjustable linear gradient direction UI

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1295,7 +1295,8 @@ DankModal {
                         if (type === "padding") popover = backdropPaddingPopover;
                         else if (type === "radius") popover = backdropRadiusPopover;
                         else if (type === "shadow") popover = backdropShadowPopover;
-                        
+                        else if (type === "angle") popover = backdropAnglePopover;
+
                         if (popover) {
                             if (toolbarCard.isVertical) {
                                 if (window.toolbarPosition === "right") {
@@ -1320,7 +1321,8 @@ DankModal {
                         if (type === "padding") popover = backdropPaddingPopover;
                         else if (type === "radius") popover = backdropRadiusPopover;
                         else if (type === "shadow") popover = backdropShadowPopover;
-                        
+                        else if (type === "angle") popover = backdropAnglePopover;
+
                         if (popover) {
                             popover.startCloseTimer();
                         }
@@ -1334,6 +1336,9 @@ DankModal {
                             window.backdropCornerRadius = Math.max(0, Math.min(60, window.backdropCornerRadius + rStep));
                         } else if (type === "shadow") {
                             window.backdropShadowStrength = Math.max(0, Math.min(100, window.backdropShadowStrength + step));
+                        } else if (type === "angle") {
+                            let aStep = delta > 0 ? 15 : -15;
+                            window.backdropGradientAngle = (window.backdropGradientAngle + aStep + 360) % 360;
                         }
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
@@ -2691,6 +2696,18 @@ DankModal {
                     value: window.backdropShadowStrength
                     onUserValueChanged: (val) => {
                         window.backdropShadowStrength = val;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                }
+
+                HoverSliderPopover {
+                    id: backdropAnglePopover
+                    minimum: 0
+                    maximum: 360
+                    stepSize: 15
+                    value: window.backdropGradientAngle
+                    onUserValueChanged: (val) => {
+                        window.backdropGradientAngle = val;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
                 }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -528,6 +528,42 @@ Rectangle {
                         onWheel: (wheel) => root.backdropControlWheel("shadow", wheel.angleDelta.y)
                     }
                 }
+
+                // Angle Control (Gradient only)
+                Item {
+                    id: angleControl
+                    visible: root.backdropMode === "gradient"
+                    width: visible ? angleRow.implicitWidth : 0
+                    height: 36
+                    anchors.verticalCenter: parent.verticalCenter
+                    
+                    Row {
+                        id: angleRow
+                        spacing: Theme.spacingXS
+                        anchors.verticalCenter: parent.verticalCenter
+                        DankIcon {
+                            name: "rotate_right"
+                            size: 16
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.backdropGradientAngle + "°"
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: angleMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("angle", angleControl)
+                        onExited: root.backdropControlExited("angle")
+                        onWheel: (wheel) => root.backdropControlWheel("angle", wheel.angleDelta.y)
+                    }
+                }
             }
             
             Rectangle { 
@@ -808,6 +844,41 @@ Rectangle {
                         onEntered: root.backdropControlHovered("shadow", shadowControlVert)
                         onExited: root.backdropControlExited("shadow")
                         onWheel: (wheel) => root.backdropControlWheel("shadow", wheel.angleDelta.y)
+                    }
+                }
+
+                // Angle Control (Gradient only)
+                Item {
+                    id: angleControlVert
+                    visible: root.backdropMode === "gradient"
+                    width: 36
+                    height: visible ? 28 : 0
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    
+                    Row {
+                        spacing: 2
+                        anchors.centerIn: parent
+                        DankIcon {
+                            name: "rotate_right"
+                            size: 14
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.backdropGradientAngle
+                            font.pixelSize: 9
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: angleMouseAreaVert
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("angle", angleControlVert)
+                        onExited: root.backdropControlExited("angle")
+                        onWheel: (wheel) => root.backdropControlWheel("angle", wheel.angleDelta.y)
                     }
                 }
             }


### PR DESCRIPTION
## Description

Implemented an adjustable direction/angle controller for linear gradients to resolve the static 45° angle limitation.

Changes include:
- Integrated a new **Angle Control** item (using icon `rotate_right` and degree indicator) in both horizontal and vertical layout rows within [QuickCaptureToolbar.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/QuickCaptureToolbar.qml). It is only visible when the backdrop mode is `"gradient"`.
- Declared and positioned a new `backdropAnglePopover` (`HoverSliderPopover` mapping values 0–360° with a step-size of 15°) within [QuickCaptureModal.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/QuickCaptureModal.qml).
- Connected mouse wheel events on the toolbar's angle item to increments/decrements of 15° for quick keyboardless adjustments.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

None

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] QML changes: ran `qmllint` with no warnings

## Summary by Sourcery

Add adjustable linear gradient angle controls to the backdrop toolbar and modal.

New Features:
- Introduce an angle control UI for gradient backdrops in both horizontal and vertical quick capture toolbars.
- Add a hover slider popover to set the backdrop gradient angle between 0° and 360° with 15° steps.
- Enable mouse wheel adjustments of the backdrop gradient angle for quick, keyboard-free tuning.