### PR TITLE
feat(backdrop): add radial and conic gradient backdrop modes

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -262,7 +262,7 @@ DankModal {
         } else if (window.backdropMode === "radial") {
             const cx = w / 2;
             const cy = h / 2;
-            const r = Math.sqrt(cx * cx + cy * cy);
+            const r = Math.hypot(cx, cy);
             const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
             grad.addColorStop(0, window.backdropGradientStart.toString());
             grad.addColorStop(1, window.backdropGradientEnd.toString());
@@ -271,22 +271,32 @@ DankModal {
         } else if (window.backdropMode === "conic") {
             const cx = w / 2;
             const cy = h / 2;
-            const r = Math.sqrt(cx * cx + cy * cy);
+            const r = Math.hypot(cx, cy);
             const startAngle = (window.backdropGradientAngle * Math.PI) / 180;
-            const numSlices = 360;
+            const numSlices = 240;
+
+            // Cache color components to avoid JS-to-C++ property boundary crossing cost
             const startCol = window.backdropGradientStart;
             const endCol = window.backdropGradientEnd;
+            const sr = startCol.r * 255;
+            const sg = startCol.g * 255;
+            const sb = startCol.b * 255;
+            const sa = startCol.a;
+            const er = endCol.r * 255;
+            const eg = endCol.g * 255;
+            const eb = endCol.b * 255;
+            const ea = endCol.a;
 
             ctx.save();
             ctx.translate(cx, cy);
             for (let i = 0; i < numSlices; i++) {
                 const angle1 = startAngle + (i / numSlices) * Math.PI * 2;
-                const angle2 = startAngle + ((i + 1.1) / numSlices) * Math.PI * 2;
+                const angle2 = startAngle + ((i + 1.01) / numSlices) * Math.PI * 2;
                 const t = i / numSlices;
-                const rComp = Math.round(startCol.r * 255 * (1 - t) + endCol.r * 255 * t);
-                const gComp = Math.round(startCol.g * 255 * (1 - t) + endCol.g * 255 * t);
-                const bComp = Math.round(startCol.b * 255 * (1 - t) + endCol.b * 255 * t);
-                const aComp = startCol.a * (1 - t) + endCol.a * t;
+                const rComp = Math.round(sr * (1 - t) + er * t);
+                const gComp = Math.round(sg * (1 - t) + eg * t);
+                const bComp = Math.round(sb * (1 - t) + eb * t);
+                const aComp = sa * (1 - t) + ea * t;
                 ctx.fillStyle = "rgba(" + rComp + "," + gComp + "," + bComp + "," + aComp + ")";
                 ctx.beginPath();
                 ctx.moveTo(0, 0);

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -259,6 +259,42 @@ DankModal {
             grad.addColorStop(1, window.backdropGradientEnd.toString());
             ctx.fillStyle = grad;
             ctx.fillRect(0, 0, w, h);
+        } else if (window.backdropMode === "radial") {
+            const cx = w / 2;
+            const cy = h / 2;
+            const r = Math.sqrt(cx * cx + cy * cy);
+            const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+            grad.addColorStop(0, window.backdropGradientStart.toString());
+            grad.addColorStop(1, window.backdropGradientEnd.toString());
+            ctx.fillStyle = grad;
+            ctx.fillRect(0, 0, w, h);
+        } else if (window.backdropMode === "conic") {
+            const cx = w / 2;
+            const cy = h / 2;
+            const r = Math.sqrt(cx * cx + cy * cy);
+            const startAngle = (window.backdropGradientAngle * Math.PI) / 180;
+            const numSlices = 360;
+            const startCol = window.backdropGradientStart;
+            const endCol = window.backdropGradientEnd;
+
+            ctx.save();
+            ctx.translate(cx, cy);
+            for (let i = 0; i < numSlices; i++) {
+                const angle1 = startAngle + (i / numSlices) * Math.PI * 2;
+                const angle2 = startAngle + ((i + 1.1) / numSlices) * Math.PI * 2;
+                const t = i / numSlices;
+                const rComp = Math.round(startCol.r * 255 * (1 - t) + endCol.r * 255 * t);
+                const gComp = Math.round(startCol.g * 255 * (1 - t) + endCol.g * 255 * t);
+                const bComp = Math.round(startCol.b * 255 * (1 - t) + endCol.b * 255 * t);
+                const aComp = startCol.a * (1 - t) + endCol.a * t;
+                ctx.fillStyle = "rgba(" + rComp + "," + gComp + "," + bComp + "," + aComp + ")";
+                ctx.beginPath();
+                ctx.moveTo(0, 0);
+                ctx.arc(0, 0, r, angle1, angle2);
+                ctx.closePath();
+                ctx.fill();
+            }
+            ctx.restore();
         }
     }
 

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -27,8 +27,10 @@ Row {
         border.width: 1
     }
 
+    readonly property bool isGradient: backdropMode === "gradient" || backdropMode === "radial" || backdropMode === "conic"
+
     Row {
-        visible: controlRoot.backdropMode === "gradient"
+        visible: controlRoot.isGradient
         spacing: Theme.spacingXS
         anchors.verticalCenter: parent.verticalCenter
 

--- a/components/BackdropModeSelectors.qml
+++ b/components/BackdropModeSelectors.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+Grid {
+    id: controlRoot
+
+    property string backdropMode: "none"
+    property bool isVertical: false
+
+    signal changeBackdropMode(string mode)
+
+    rows: isVertical ? 5 : 1
+    columns: isVertical ? 1 : 5
+    spacing: Theme.spacingXS
+
+    readonly property var modes: [
+        { mode: "none", icon: "blur_off", tooltip: qsTr("No Backdrop") },
+        { mode: "solid", icon: "format_color_fill", tooltip: qsTr("Solid Color") },
+        { mode: "gradient", icon: "gradient", tooltip: qsTr("Linear Gradient") },
+        { mode: "radial", icon: "filter_tilt_shift", tooltip: qsTr("Radial Gradient") },
+        { mode: "conic", icon: "timelapse", tooltip: qsTr("Conic Gradient") }
+    ]
+
+    Repeater {
+        model: controlRoot.modes
+        delegate: DankActionButton {
+            iconName: modelData.icon
+            buttonSize: 36
+            iconSize: 18
+            tooltipText: modelData.tooltip
+            backgroundColor: controlRoot.backdropMode === modelData.mode ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+            iconColor: controlRoot.backdropMode === modelData.mode ? Theme.primary : Theme.surfaceText
+            onClicked: controlRoot.changeBackdropMode(modelData.mode)
+        }
+    }
+}

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -363,55 +363,11 @@ Rectangle {
             
             Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
             
-            // Mode selection
-            Row {
-                spacing: Theme.spacingXS
+            BackdropModeSelectors {
+                backdropMode: root.backdropMode
+                isVertical: false
+                onChangeBackdropMode: (mode) => root.changeBackdropMode(mode)
                 anchors.verticalCenter: parent.verticalCenter
-                DankActionButton {
-                    iconName: "blur_off"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("No Backdrop")
-                    backgroundColor: root.backdropMode === "none" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "none" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("none")
-                }
-                DankActionButton {
-                    iconName: "format_color_fill"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("Solid Color")
-                    backgroundColor: root.backdropMode === "solid" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "solid" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("solid")
-                }
-                DankActionButton {
-                    iconName: "gradient"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("Linear Gradient")
-                    backgroundColor: root.backdropMode === "gradient" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "gradient" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("gradient")
-                }
-                DankActionButton {
-                    iconName: "filter_tilt_shift"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("Radial Gradient")
-                    backgroundColor: root.backdropMode === "radial" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "radial" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("radial")
-                }
-                DankActionButton {
-                    iconName: "timelapse"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("Conic Gradient")
-                    backgroundColor: root.backdropMode === "conic" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "conic" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("conic")
-                }
             }
             
             Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
@@ -654,55 +610,11 @@ Rectangle {
             
             Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
             
-            // Mode selection
-            Column {
-                spacing: Theme.spacingXS
+            BackdropModeSelectors {
+                backdropMode: root.backdropMode
+                isVertical: true
+                onChangeBackdropMode: (mode) => root.changeBackdropMode(mode)
                 anchors.horizontalCenter: parent.horizontalCenter
-                DankActionButton {
-                    iconName: "blur_off"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("No Backdrop")
-                    backgroundColor: root.backdropMode === "none" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "none" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("none")
-                }
-                DankActionButton {
-                    iconName: "format_color_fill"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("Solid Color")
-                    backgroundColor: root.backdropMode === "solid" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "solid" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("solid")
-                }
-                DankActionButton {
-                    iconName: "gradient"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("Linear Gradient")
-                    backgroundColor: root.backdropMode === "gradient" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "gradient" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("gradient")
-                }
-                DankActionButton {
-                    iconName: "filter_tilt_shift"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("Radial Gradient")
-                    backgroundColor: root.backdropMode === "radial" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "radial" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("radial")
-                }
-                DankActionButton {
-                    iconName: "timelapse"
-                    buttonSize: 36
-                    iconSize: 18
-                    tooltipText: qsTr("Conic Gradient")
-                    backgroundColor: root.backdropMode === "conic" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                    iconColor: root.backdropMode === "conic" ? Theme.primary : Theme.surfaceText
-                    onClicked: root.changeBackdropMode("conic")
-                }
             }
             
             Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -394,6 +394,24 @@ Rectangle {
                     iconColor: root.backdropMode === "gradient" ? Theme.primary : Theme.surfaceText
                     onClicked: root.changeBackdropMode("gradient")
                 }
+                DankActionButton {
+                    iconName: "filter_tilt_shift"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("Radial Gradient")
+                    backgroundColor: root.backdropMode === "radial" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "radial" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("radial")
+                }
+                DankActionButton {
+                    iconName: "timelapse"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("Conic Gradient")
+                    backgroundColor: root.backdropMode === "conic" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "conic" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("conic")
+                }
             }
             
             Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
@@ -529,10 +547,10 @@ Rectangle {
                     }
                 }
 
-                // Angle Control (Gradient only)
+                // Angle Control (Linear and Conic gradients)
                 Item {
                     id: angleControl
-                    visible: root.backdropMode === "gradient"
+                    visible: root.backdropMode === "gradient" || root.backdropMode === "conic"
                     width: visible ? angleRow.implicitWidth : 0
                     height: 36
                     anchors.verticalCenter: parent.verticalCenter
@@ -603,7 +621,7 @@ Rectangle {
                                 onClicked: {
                                     if (root.backdropMode === "solid") {
                                         root.changeBackdropSolidColor(modelData);
-                                    } else if (root.backdropMode === "gradient") {
+                                    } else if (root.backdropMode === "gradient" || root.backdropMode === "radial" || root.backdropMode === "conic") {
                                         if (root.gradientActiveSlot === "start") {
                                             root.changeBackdropGradientStart(modelData);
                                         } else {
@@ -666,6 +684,24 @@ Rectangle {
                     backgroundColor: root.backdropMode === "gradient" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                     iconColor: root.backdropMode === "gradient" ? Theme.primary : Theme.surfaceText
                     onClicked: root.changeBackdropMode("gradient")
+                }
+                DankActionButton {
+                    iconName: "filter_tilt_shift"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("Radial Gradient")
+                    backgroundColor: root.backdropMode === "radial" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "radial" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("radial")
+                }
+                DankActionButton {
+                    iconName: "timelapse"
+                    buttonSize: 36
+                    iconSize: 18
+                    tooltipText: qsTr("Conic Gradient")
+                    backgroundColor: root.backdropMode === "conic" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.backdropMode === "conic" ? Theme.primary : Theme.surfaceText
+                    onClicked: root.changeBackdropMode("conic")
                 }
             }
             
@@ -847,10 +883,10 @@ Rectangle {
                     }
                 }
 
-                // Angle Control (Gradient only)
+                // Angle Control (Linear and Conic gradients)
                 Item {
                     id: angleControlVert
-                    visible: root.backdropMode === "gradient"
+                    visible: root.backdropMode === "gradient" || root.backdropMode === "conic"
                     width: 36
                     height: visible ? 28 : 0
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -920,7 +956,7 @@ Rectangle {
                                 onClicked: {
                                     if (root.backdropMode === "solid") {
                                         root.changeBackdropSolidColor(modelData);
-                                    } else if (root.backdropMode === "gradient") {
+                                    } else if (root.backdropMode === "gradient" || root.backdropMode === "radial" || root.backdropMode === "conic") {
                                         if (root.gradientActiveSlot === "start") {
                                             root.changeBackdropGradientStart(modelData);
                                         } else {


### PR DESCRIPTION
## Description

Adds support for Radial and Conic (sweep) gradient backdrops to the screenshot annotation tool.

Changes include:
- Extended the backdrop drawing logic in [QuickCaptureModal.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/QuickCaptureModal.qml) to render radial gradients using canvas `createRadialGradient` and conic gradients by drawing color-interpolated angular slices.
- Generalised visibility checks in [BackdropColorSelectors.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/BackdropColorSelectors.qml) to show the gradient start/end pickers for all three gradient modes.
- Added two new toggle buttons (**Radial Gradient** and **Conic Gradient**) using icons `filter_tilt_shift` and `timelapse` respectively in both horizontal and vertical toolbar layouts in [QuickCaptureToolbar.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/QuickCaptureToolbar.qml).
- Enabled the linear gradient angle control to also act as the sweep starting angle controller when Conic Gradient mode is active.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

None

## Checklist

- [x] My code follows the conventions in CONTRIBUTING.md
- [x] I have tested my changes locally
- [x] QML changes: ran `qmllint` with no warnings

## Summary by Sourcery

Add support for radial and conic gradient backdrops and integrate their controls into the screenshot annotation UI.

New Features:
- Introduce radial gradient backdrop rendering using canvas radial gradients.
- Introduce conic gradient backdrop rendering with angle-controlled sweep slices.
- Add toolbar buttons to select radial and conic backdrop modes in both horizontal and vertical layouts.
- Allow the existing gradient angle control to be reused for conic gradient starting angle.
- Generalize gradient color selector visibility to work with all gradient backdrop modes.