### PR TITLE
feat: backdrop aspect ratio popover + default solid mode

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -74,7 +74,8 @@ DankModal {
     property int backdropPadding: 40
     property int backdropCornerRadius: 12
     property int backdropShadowStrength: 50
-    property string backdropAspectRatio: "auto" // auto, 1:1, 16:9, 4:3
+    property string backdropAspectRatio: "auto"
+    property real customAspectRatio: 1.50
     property bool hasUserCustomizedBackdrop: false
     property color autoBackdropGradientStart: Theme.primary
     property color autoBackdropGradientEnd: Theme.secondary
@@ -173,6 +174,17 @@ DankModal {
         return window.bgImageItem ? window.bgImageItem.sourceSize.height : 1;
     }
 
+    function getTargetRatio(ratioStr) {
+        if (ratioStr === "1:1") return 1.0;
+        if (ratioStr === "16:9") return 16.0 / 9.0;
+        if (ratioStr === "9:16") return 9.0 / 16.0;
+        if (ratioStr === "4:3") return 4.0 / 3.0;
+        if (ratioStr === "3:2") return 3.0 / 2.0;
+        if (ratioStr === "21:9") return 21.0 / 9.0;
+        if (ratioStr === "custom") return window.customAspectRatio;
+        return 0.0;
+    }
+
     readonly property real canvasWidth: {
         if (window.effectiveBackdropMode === "none") {
             return screenshotWidth;
@@ -182,28 +194,16 @@ DankModal {
         if (window.backdropAspectRatio === "auto") {
             return baseW;
         }
-        if (window.backdropAspectRatio === "1:1") {
-            return Math.max(baseW, baseH);
+        const targetRatio = getTargetRatio(window.backdropAspectRatio);
+        if (targetRatio <= 0.0) {
+            return baseW;
         }
-        if (window.backdropAspectRatio === "16:9") {
-            const targetRatio = 16 / 9;
-            const currentRatio = baseW / baseH;
-            if (currentRatio > targetRatio) {
-                return baseW;
-            } else {
-                return baseH * targetRatio;
-            }
+        const currentRatio = baseW / baseH;
+        if (currentRatio > targetRatio) {
+            return baseW;
+        } else {
+            return baseH * targetRatio;
         }
-        if (window.backdropAspectRatio === "4:3") {
-            const targetRatio = 4 / 3;
-            const currentRatio = baseW / baseH;
-            if (currentRatio > targetRatio) {
-                return baseW;
-            } else {
-                return baseH * targetRatio;
-            }
-        }
-        return baseW;
     }
 
     readonly property real canvasHeight: {
@@ -215,28 +215,16 @@ DankModal {
         if (window.backdropAspectRatio === "auto") {
             return baseH;
         }
-        if (window.backdropAspectRatio === "1:1") {
-            return Math.max(baseW, baseH);
+        const targetRatio = getTargetRatio(window.backdropAspectRatio);
+        if (targetRatio <= 0.0) {
+            return baseH;
         }
-        if (window.backdropAspectRatio === "16:9") {
-            const targetRatio = 16 / 9;
-            const currentRatio = baseW / baseH;
-            if (currentRatio > targetRatio) {
-                return baseW / targetRatio;
-            } else {
-                return baseH;
-            }
+        const currentRatio = baseW / baseH;
+        if (currentRatio > targetRatio) {
+            return baseW / targetRatio;
+        } else {
+            return baseH;
         }
-        if (window.backdropAspectRatio === "4:3") {
-            const targetRatio = 4 / 3;
-            const currentRatio = baseW / baseH;
-            if (currentRatio > targetRatio) {
-                return baseW / targetRatio;
-            } else {
-                return baseH;
-            }
-        }
-        return baseH;
     }
 
     readonly property real backdropScaleFactor: 1.0
@@ -1219,6 +1207,7 @@ DankModal {
                     backdropCornerRadius: window.backdropCornerRadius
                     backdropShadowStrength: window.backdropShadowStrength
                     backdropAspectRatio: window.backdropAspectRatio
+                    customAspectRatio: window.customAspectRatio
 
                     onChangeBackdropMode: (mode) => {
                         window.backdropMode = mode;
@@ -1257,6 +1246,10 @@ DankModal {
                     }
                     onChangeBackdropAspectRatio: (ratio) => {
                         window.backdropAspectRatio = ratio;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeCustomAspectRatio: (ratio) => {
+                        window.customAspectRatio = ratio;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
                     onAutoColorBalanceRequested: {
@@ -1342,6 +1335,7 @@ DankModal {
                         else if (type === "radius") popover = backdropRadiusPopover;
                         else if (type === "shadow") popover = backdropShadowPopover;
                         else if (type === "angle") popover = backdropAnglePopover;
+                        else if (type === "customRatio") popover = backdropCustomRatioPopover;
 
                         if (popover) {
                             if (toolbarCard.isVertical) {
@@ -1368,6 +1362,7 @@ DankModal {
                         else if (type === "radius") popover = backdropRadiusPopover;
                         else if (type === "shadow") popover = backdropShadowPopover;
                         else if (type === "angle") popover = backdropAnglePopover;
+                        else if (type === "customRatio") popover = backdropCustomRatioPopover;
 
                         if (popover) {
                             popover.startCloseTimer();
@@ -1385,6 +1380,9 @@ DankModal {
                         } else if (type === "angle") {
                             let aStep = delta > 0 ? 15 : -15;
                             window.backdropGradientAngle = (window.backdropGradientAngle + aStep + 360) % 360;
+                        } else if (type === "customRatio") {
+                            let ratioStep = delta > 0 ? 0.05 : -0.05;
+                            window.customAspectRatio = Math.max(0.5, Math.min(2.5, window.customAspectRatio + ratioStep));
                         }
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
@@ -2754,6 +2752,17 @@ DankModal {
                     value: window.backdropGradientAngle
                     onUserValueChanged: (val) => {
                         window.backdropGradientAngle = val;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                }
+
+                HoverSliderPopover {
+                    id: backdropCustomRatioPopover
+                    minimum: 50
+                    maximum: 250
+                    value: Math.round(window.customAspectRatio * 100)
+                    onUserValueChanged: (val) => {
+                        window.customAspectRatio = val / 100.0;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
                 }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -958,6 +958,9 @@ DankModal {
                 }
             } else {
                 window.currentTool = toolShortcut.tool;
+                if (toolShortcut.tool === "backdrop" && window.backdropMode === "none") {
+                    window.backdropMode = "solid";
+                }
             }
             event.accepted = true;
         }
@@ -1067,6 +1070,9 @@ DankModal {
         }
 
         window.currentTool = startTool;
+        if (startTool === "backdrop" && window.backdropMode === "none") {
+            window.backdropMode = "solid";
+        }
         window.toolbarVisible = window.configShowToolbar;
         window.strokeWidth = startThickness;
         window.currentColor = startColor;
@@ -1268,6 +1274,9 @@ DankModal {
                             window.currentTool = window.lastActiveTool;
                         } else {
                             window.currentTool = tool;
+                            if (tool === "backdrop" && window.backdropMode === "none") {
+                                window.backdropMode = "solid";
+                            }
                         }
                     }
                     onColorSelected: (color) => {
@@ -1335,7 +1344,7 @@ DankModal {
                         else if (type === "radius") popover = backdropRadiusPopover;
                         else if (type === "shadow") popover = backdropShadowPopover;
                         else if (type === "angle") popover = backdropAnglePopover;
-                        else if (type === "customRatio") popover = backdropCustomRatioPopover;
+                        else if (type === "aspectRatio") popover = backdropAspectRatioPopover;
 
                         if (popover) {
                             if (toolbarCard.isVertical) {
@@ -1362,7 +1371,7 @@ DankModal {
                         else if (type === "radius") popover = backdropRadiusPopover;
                         else if (type === "shadow") popover = backdropShadowPopover;
                         else if (type === "angle") popover = backdropAnglePopover;
-                        else if (type === "customRatio") popover = backdropCustomRatioPopover;
+                        else if (type === "aspectRatio") popover = backdropAspectRatioPopover;
 
                         if (popover) {
                             popover.startCloseTimer();
@@ -1380,9 +1389,11 @@ DankModal {
                         } else if (type === "angle") {
                             let aStep = delta > 0 ? 15 : -15;
                             window.backdropGradientAngle = (window.backdropGradientAngle + aStep + 360) % 360;
-                        } else if (type === "customRatio") {
-                            let ratioStep = delta > 0 ? 0.05 : -0.05;
-                            window.customAspectRatio = Math.max(0.5, Math.min(2.5, window.customAspectRatio + ratioStep));
+                        } else if (type === "aspectRatio") {
+                            if (window.backdropAspectRatio === "custom") {
+                                let ratioStep = delta > 0 ? 0.05 : -0.05;
+                                window.customAspectRatio = Math.max(0.5, Math.min(2.5, window.customAspectRatio + ratioStep));
+                            }
                         }
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
@@ -2756,13 +2767,16 @@ DankModal {
                     }
                 }
 
-                HoverSliderPopover {
-                    id: backdropCustomRatioPopover
-                    minimum: 50
-                    maximum: 250
-                    value: Math.round(window.customAspectRatio * 100)
-                    onUserValueChanged: (val) => {
-                        window.customAspectRatio = val / 100.0;
+                BackdropAspectRatioPopover {
+                    id: backdropAspectRatioPopover
+                    backdropAspectRatio: window.backdropAspectRatio
+                    customAspectRatio: window.customAspectRatio
+                    onChangeBackdropAspectRatio: (ratio) => {
+                        window.backdropAspectRatio = ratio;
+                        if (window.activeCanvas) window.activeCanvas.requestPaint();
+                    }
+                    onChangeCustomAspectRatio: (ratio) => {
+                        window.customAspectRatio = ratio;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ binds {
 - [x] Stamp counter formats (Numeric / Alphabetic / Roman)
 
 ### Planned Backdrop Features (inspired by Gradia)
-- [ ] **Linear Gradient Direction:** Adjustable angle/direction controller in the UI for linear gradients.
-- [ ] **Radial & Conic Gradients:** Support for radial and conic gradient backdrop modes.
-- [ ] **Custom Aspect Ratios:** Define custom canvas aspect ratios alongside standard presets (16:9, 4:3, etc.).
+- [x] **Linear Gradient Direction:** Adjustable angle/direction controller in the UI for linear gradients.
+- [x] **Radial & Conic Gradients:** Support for radial and conic gradient backdrop modes.
+- [x] **Custom Aspect Ratios:** Define custom canvas aspect ratios alongside standard presets (16:9, 4:3, etc.).
 - [ ] **Image Backdrop Mode:** Support setting a custom image file as the screenshot background.
-- [ ] **Customizable Drop Shadows:** Adjust shadow offset, blur radius, and color/opacity.
-- [ ] **Auto Color Balance:** Analyze the screenshot's dominant colors to automatically generate matching backdrop palettes.
-- [ ] **Interactive Padding Resizing:** Visual handles on the backdrop canvas to resize padding dynamically.
+- [x] **Customizable Drop Shadows:** Adjust shadow offset, blur radius, and color/opacity.
+- [x] **Auto Color Balance:** Analyze the screenshot's dominant colors to automatically generate matching backdrop palettes.
+- [x] **Interactive Padding Resizing:** Visual handles on the backdrop canvas to resize padding dynamically.
 
 ## License
 

--- a/components/BackdropAspectRatioPopover.qml
+++ b/components/BackdropAspectRatioPopover.qml
@@ -1,0 +1,178 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+Rectangle {
+    id: popoverRoot
+
+    property string backdropAspectRatio: "auto"
+    property real customAspectRatio: 1.50
+    property bool opened: false
+
+    signal changeBackdropAspectRatio(string ratio)
+    signal changeCustomAspectRatio(real ratio)
+
+    readonly property bool customActive: backdropAspectRatio === "custom"
+
+    width: customActive ? 340 : 220
+    height: 72
+    color: Theme.surfaceContainer
+    border.color: Theme.withAlpha(Theme.outline, 0.15)
+    border.width: 1
+    radius: Theme.cornerRadius
+    z: 10001
+
+    visible: opacity > 0
+    opacity: 0
+    scale: 0.9
+
+    states: [
+        State {
+            name: "visible"
+            when: popoverRoot.opened
+            PropertyChanges { target: popoverRoot; opacity: 1.0; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { properties: "opacity,scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open() {
+        closeTimer.stop();
+        popoverRoot.opened = true;
+    }
+
+    function close() {
+        popoverRoot.opened = false;
+    }
+
+    function startCloseTimer() {
+        closeTimer.start();
+    }
+
+    function stopCloseTimer() {
+        closeTimer.stop();
+    }
+
+    Timer {
+        id: closeTimer
+        interval: 200
+        onTriggered: popoverRoot.close()
+    }
+
+    MouseArea {
+        id: hoverArea
+        anchors.fill: parent
+        hoverEnabled: true
+        onEntered: popoverRoot.open()
+        onExited: popoverRoot.startCloseTimer()
+
+        onWheel: (wheel) => {
+            if (popoverRoot.customActive) {
+                let step = wheel.angleDelta.y > 0 ? 5 : -5;
+                let newVal = Math.max(50, Math.min(250, Math.round(popoverRoot.customAspectRatio * 100) + step));
+                popoverRoot.changeCustomAspectRatio(newVal / 100.0);
+            }
+        }
+
+        Row {
+            anchors.centerIn: parent
+            spacing: Theme.spacingM
+            leftPadding: Theme.spacingS
+            rightPadding: Theme.spacingS
+
+            Grid {
+                columns: 4
+                rows: 2
+                spacing: 4
+                anchors.verticalCenter: parent.verticalCenter
+
+                readonly property var presets: [
+                    { value: "auto", label: "AUTO" },
+                    { value: "1:1", label: "1:1" },
+                    { value: "16:9", label: "16:9" },
+                    { value: "9:16", label: "9:16" },
+                    { value: "4:3", label: "4:3" },
+                    { value: "3:2", label: "3:2" },
+                    { value: "21:9", label: "21:9" },
+                    { value: "custom", label: "CUST" }
+                ]
+
+                Repeater {
+                    model: parent.presets
+                    delegate: Rectangle {
+                        width: 44
+                        height: 24
+                        radius: Theme.cornerRadiusXS
+                        color: popoverRoot.backdropAspectRatio === modelData.value ? Theme.primary : Theme.withAlpha(Theme.surfaceVariant, 0.4)
+                        border.color: popoverRoot.backdropAspectRatio === modelData.value ? "transparent" : Theme.withAlpha(Theme.outline, 0.15)
+                        border.width: 1
+
+                        StyledText {
+                            text: modelData.label
+                            font.pixelSize: 10
+                            font.weight: popoverRoot.backdropAspectRatio === modelData.value ? Font.DemiBold : Font.Normal
+                            color: popoverRoot.backdropAspectRatio === modelData.value ? Theme.onPrimary : Theme.surfaceVariantText
+                            anchors.centerIn: parent
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: popoverRoot.changeBackdropAspectRatio(modelData.value)
+                        }
+                    }
+                }
+            }
+
+            // Separator when custom is active
+            Rectangle {
+                visible: popoverRoot.customActive
+                width: 1
+                height: 36
+                color: Theme.withAlpha(Theme.outline, 0.2)
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            // Slider section (Visible only when custom is active)
+            Row {
+                id: sliderSection
+                visible: popoverRoot.customActive
+                spacing: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+
+                Column {
+                    spacing: 2
+                    anchors.verticalCenter: parent.verticalCenter
+
+                    StyledText {
+                        text: "Ratio"
+                        font.pixelSize: 8
+                        color: Theme.surfaceVariantText
+                    }
+
+                    DankSlider {
+                        id: slider
+                        minimum: 50
+                        maximum: 250
+                        width: 100
+                        value: Math.round(popoverRoot.customAspectRatio * 100)
+                        showValue: false
+                        onSliderValueChanged: val => popoverRoot.changeCustomAspectRatio(val / 100.0)
+                    }
+                }
+
+                StyledText {
+                    text: popoverRoot.customAspectRatio.toFixed(2)
+                    font.pixelSize: 13
+                    font.weight: Font.Medium
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+        }
+    }
+}

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -29,8 +29,10 @@ Rectangle {
     property int backdropShadowStrength: 50
     property string backdropAspectRatio: "auto"
     
-    readonly property var aspectRatios: ["auto", "1:1", "16:9", "4:3"]
-    readonly property var aspectRatioLabels: ["AUTO", "1:1", "16:9", "4:3"]
+    property real customAspectRatio: 1.50
+
+    readonly property var aspectRatios: ["auto", "1:1", "16:9", "9:16", "4:3", "3:2", "21:9", "custom"]
+    readonly property var aspectRatioLabels: ["AUTO", "1:1", "16:9", "9:16", "4:3", "3:2", "21:9", "CUSTOM"]
 
     property string gradientActiveSlot: "start"
 
@@ -43,6 +45,7 @@ Rectangle {
     signal changeBackdropCornerRadius(int radius)
     signal changeBackdropShadowStrength(int strength)
     signal changeBackdropAspectRatio(string ratio)
+    signal changeCustomAspectRatio(real ratio)
     signal rotateRequested()
     signal mirrorRequested()
     signal moreToolsClicked(var buttonItem)
@@ -538,6 +541,42 @@ Rectangle {
                         onWheel: (wheel) => root.backdropControlWheel("angle", wheel.angleDelta.y)
                     }
                 }
+
+                // Custom Aspect Ratio Control
+                Item {
+                    id: customRatioControl
+                    visible: root.backdropAspectRatio === "custom"
+                    width: visible ? customRatioRow.implicitWidth : 0
+                    height: 36
+                    anchors.verticalCenter: parent.verticalCenter
+                    
+                    Row {
+                        id: customRatioRow
+                        spacing: Theme.spacingXS
+                        anchors.verticalCenter: parent.verticalCenter
+                        DankIcon {
+                            name: "aspect_ratio"
+                            size: 16
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.customAspectRatio.toFixed(2)
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: customRatioMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("customRatio", customRatioControl)
+                        onExited: root.backdropControlExited("customRatio")
+                        onWheel: (wheel) => root.backdropControlWheel("customRatio", wheel.angleDelta.y)
+                    }
+                }
             }
             
             Rectangle { 
@@ -827,6 +866,41 @@ Rectangle {
                         onEntered: root.backdropControlHovered("angle", angleControlVert)
                         onExited: root.backdropControlExited("angle")
                         onWheel: (wheel) => root.backdropControlWheel("angle", wheel.angleDelta.y)
+                    }
+                }
+
+                // Custom Aspect Ratio Control
+                Item {
+                    id: customRatioControlVert
+                    visible: root.backdropAspectRatio === "custom"
+                    width: 36
+                    height: visible ? 28 : 0
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    
+                    Row {
+                        spacing: 2
+                        anchors.centerIn: parent
+                        DankIcon {
+                            name: "aspect_ratio"
+                            size: 14
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        StyledText {
+                            text: root.customAspectRatio.toFixed(2)
+                            font.pixelSize: 9
+                            color: Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    MouseArea {
+                        id: customRatioMouseAreaVert
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: root.backdropControlHovered("customRatio", customRatioControlVert)
+                        onExited: root.backdropControlExited("customRatio")
+                        onWheel: (wheel) => root.backdropControlWheel("customRatio", wheel.angleDelta.y)
                     }
                 }
             }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -373,30 +373,7 @@ Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
             }
             
-            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
-            
-            // Aspect Ratio selection (Native DankButtonGroup)
-            DankButtonGroup {
-                anchors.verticalCenter: parent.verticalCenter
-                buttonHeight: 28
-                minButtonWidth: 38
-                buttonPadding: Theme.spacingS
-                checkEnabled: false
-                textSize: 10
-                model: root.aspectRatioLabels
-                currentIndex: root.aspectRatios.indexOf(root.backdropAspectRatio)
-                onSelectionChanged: (index, selected) => {
-                    if (selected) {
-                        root.changeBackdropAspectRatio(root.aspectRatios[index]);
-                    }
-                }
-            }
-            
-            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
-            
-            // Sliders Row
-            // Sliders Row (Hover to reveal slider)
-            // Sliders Row (Hover to reveal popup slider)
+            // Sliders Row (Hover to reveal popup controls)
             Row {
                 spacing: Theme.spacingM
                 anchors.verticalCenter: parent.verticalCenter
@@ -542,16 +519,15 @@ Rectangle {
                     }
                 }
 
-                // Custom Aspect Ratio Control
+                // Aspect Ratio Control (Hover to reveal preset grid + custom slider popover)
                 Item {
-                    id: customRatioControl
-                    visible: root.backdropAspectRatio === "custom"
-                    width: visible ? customRatioRow.implicitWidth : 0
+                    id: aspectControl
+                    width: aspectRow.implicitWidth
                     height: 36
                     anchors.verticalCenter: parent.verticalCenter
                     
                     Row {
-                        id: customRatioRow
+                        id: aspectRow
                         spacing: Theme.spacingXS
                         anchors.verticalCenter: parent.verticalCenter
                         DankIcon {
@@ -561,20 +537,25 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.customAspectRatio.toFixed(2)
+                            text: {
+                                if (root.backdropAspectRatio === "custom") {
+                                    return root.customAspectRatio.toFixed(2);
+                                }
+                                return root.backdropAspectRatio.toUpperCase();
+                            }
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
                     }
                     MouseArea {
-                        id: customRatioMouseArea
+                        id: aspectMouseArea
                         anchors.fill: parent
                         hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
-                        onEntered: root.backdropControlHovered("customRatio", customRatioControl)
-                        onExited: root.backdropControlExited("customRatio")
-                        onWheel: (wheel) => root.backdropControlWheel("customRatio", wheel.angleDelta.y)
+                        onEntered: root.backdropControlHovered("aspectRatio", aspectControl)
+                        onExited: root.backdropControlExited("aspectRatio")
+                        onWheel: (wheel) => root.backdropControlWheel("aspectRatio", wheel.angleDelta.y)
                     }
                 }
             }
@@ -654,75 +635,6 @@ Rectangle {
                 isVertical: true
                 onChangeBackdropMode: (mode) => root.changeBackdropMode(mode)
                 anchors.horizontalCenter: parent.horizontalCenter
-            }
-            
-            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
-            
-            // Aspect Ratio selection (Vertical Segmented Control)
-            Column {
-                spacing: Theme.spacingXS
-                anchors.horizontalCenter: parent.horizontalCenter
-                Repeater {
-                    id: verticalRatioRepeater
-                    model: root.aspectRatios
-                    delegate: Rectangle {
-                        id: verticalSegment
-                        width: 36
-                        height: 28
-                        
-                        property bool selected: root.backdropAspectRatio === modelData
-                        property bool hovered: verticalMouseArea.containsMouse
-                        property bool isFirst: index === 0
-                        property bool isLast: index === (verticalRatioRepeater.count - 1)
-                        
-                        color: {
-                            if (selected) {
-                                if (verticalMouseArea.pressed) return Theme.buttonPressed;
-                                if (verticalSegment.hovered) return Theme.buttonHover;
-                                return Theme.buttonBg;
-                            } else {
-                                if (verticalMouseArea.pressed || verticalSegment.hovered) return Theme.surfaceTextHover;
-                                return Theme.withAlpha(Theme.surfaceVariant, Theme.popupTransparency);
-                            }
-                        }
-                        
-                        radius: (selected || isFirst || isLast) ? Theme.cornerRadius : 0
-
-                        // Mask bottom corners of the first item when not selected
-                        Rectangle {
-                            anchors.bottom: parent.bottom
-                            width: parent.width
-                            height: parent.radius
-                            color: parent.color
-                            visible: !verticalSegment.selected && verticalSegment.isFirst && parent.radius > 0
-                        }
-
-                        // Mask top corners of the last item when not selected
-                        Rectangle {
-                            anchors.top: parent.top
-                            width: parent.width
-                            height: parent.radius
-                            color: parent.color
-                            visible: !verticalSegment.selected && verticalSegment.isLast && parent.radius > 0
-                        }
-
-                        StyledText {
-                            text: modelData.toUpperCase()
-                            font.pixelSize: 9
-                            font.weight: selected ? Font.Medium : Font.Normal
-                            color: selected ? Theme.buttonText : Theme.surfaceVariantText
-                            anchors.centerIn: parent
-                        }
-
-                        MouseArea {
-                            id: verticalMouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root.changeBackdropAspectRatio(modelData)
-                        }
-                    }
-                }
             }
             
             Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
@@ -871,10 +783,9 @@ Rectangle {
 
                 // Custom Aspect Ratio Control
                 Item {
-                    id: customRatioControlVert
-                    visible: root.backdropAspectRatio === "custom"
+                    id: aspectControlVert
                     width: 36
-                    height: visible ? 28 : 0
+                    height: 28
                     anchors.horizontalCenter: parent.horizontalCenter
                     
                     Row {
@@ -887,20 +798,20 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.customAspectRatio.toFixed(2)
+                            text: root.backdropAspectRatio === "custom" ? root.customAspectRatio.toFixed(2) : root.backdropAspectRatio.toUpperCase()
                             font.pixelSize: 9
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
                     }
                     MouseArea {
-                        id: customRatioMouseAreaVert
+                        id: aspectMouseAreaVert
                         anchors.fill: parent
                         hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
-                        onEntered: root.backdropControlHovered("customRatio", customRatioControlVert)
-                        onExited: root.backdropControlExited("customRatio")
-                        onWheel: (wheel) => root.backdropControlWheel("customRatio", wheel.angleDelta.y)
+                        onEntered: root.backdropControlHovered("aspectRatio", aspectControlVert)
+                        onExited: root.backdropControlExited("aspectRatio")
+                        onWheel: (wheel) => root.backdropControlWheel("aspectRatio", wheel.angleDelta.y)
                     }
                 }
             }


### PR DESCRIPTION
### Changes
- **New:** `BackdropAspectRatioPopover` — hover popover with preset grid (AUTO, 1:1, 16:9, 9:16, 4:3, 3:2, 21:9, CUST) + custom ratio slider
- **Toolbar:** replaced inline `DankButtonGroup` (horizontal) and `Column` segments (vertical) with compact icon+text that shows current ratio, hover to reveal popover
- **UX:** backdrop tool now defaults to `solid` mode to prevent toolbar layout shift
- **Roadmap:** marked completed backdrop features

### Backdrop Aspect Ratio Popover
| Presets only | Custom active |
|---|---|
| 8 preset buttons (44x24) | + separator + ratio slider + value display |

### Default to Solid
Switching to backdrop tool (via toolbar button, keyboard shortcut `B`, or startup) now sets `backdropMode = \"solid\"` if it was `\"none\"`, keeping toolbar layout stable.

## Summary by Sourcery

Add a backdrop aspect ratio popover with expanded presets and custom ratio support, and default the backdrop tool to solid mode to stabilize the toolbar layout.

New Features:
- Introduce BackdropAspectRatioPopover with preset aspect ratio grid and custom ratio slider.
- Support a custom backdrop aspect ratio value alongside standard presets in the canvas sizing logic.

Bug Fixes:
- Ensure activating the backdrop tool via shortcuts, toolbar, or startup switches from 'none' to 'solid' mode to avoid layout shifts.

Enhancements:
- Replace inline aspect ratio segmented controls with compact icon+text controls that reveal a hover popover.
- Allow mouse wheel adjustment of custom aspect ratio when using the popover or toolbar controls.
- Refactor backdrop canvas sizing to use a shared target ratio helper supporting all presets and the custom ratio.

Documentation:
- Mark implemented backdrop roadmap items as completed in the README, including gradients, custom ratios, shadows, auto color balance, and interactive padding.