### PR TITLE
refactor(toolbar): centralize spacing and size constants into ToolbarConstants.qml

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -60,6 +60,9 @@ DankModal {
         if (currentTool !== "crop" && currentTool !== "backdrop" && currentTool !== "select") {
             lastActiveTool = currentTool;
         }
+        if (currentTool === "backdrop" && window.backdropMode === "none") {
+            window.backdropMode = "solid";
+        }
         if (window.activeCanvas) {
             window.activeCanvas.requestPaint();
         }
@@ -76,6 +79,19 @@ DankModal {
     property int backdropShadowStrength: 50
     property string backdropAspectRatio: "auto"
     property real customAspectRatio: 1.50
+    readonly property real customRatioMin: 0.50
+    readonly property real customRatioMax: 2.50
+    readonly property real customRatioStep: 0.05
+    readonly property var aspectPresets: [
+        { value: "auto", label: I18n.tr("AUTO") },
+        { value: "1:1", label: "1:1" },
+        { value: "16:9", label: "16:9" },
+        { value: "9:16", label: "9:16" },
+        { value: "4:3", label: "4:3" },
+        { value: "3:2", label: "3:2" },
+        { value: "21:9", label: "21:9" },
+        { value: "custom", label: I18n.tr("CUST") }
+    ]
     property bool hasUserCustomizedBackdrop: false
     property color autoBackdropGradientStart: Theme.primary
     property color autoBackdropGradientEnd: Theme.secondary
@@ -175,13 +191,17 @@ DankModal {
     }
 
     function getTargetRatio(ratioStr) {
+        if (ratioStr === "auto") return 0.0;
         if (ratioStr === "1:1") return 1.0;
         if (ratioStr === "16:9") return 16.0 / 9.0;
         if (ratioStr === "9:16") return 9.0 / 16.0;
         if (ratioStr === "4:3") return 4.0 / 3.0;
         if (ratioStr === "3:2") return 3.0 / 2.0;
         if (ratioStr === "21:9") return 21.0 / 9.0;
-        if (ratioStr === "custom") return window.customAspectRatio;
+        if (ratioStr === "custom") {
+            const val = window.customAspectRatio;
+            return (isFinite(val) && val > 0) ? val : 1.0;
+        }
         return 0.0;
     }
 
@@ -195,7 +215,7 @@ DankModal {
             return baseW;
         }
         const targetRatio = getTargetRatio(window.backdropAspectRatio);
-        if (targetRatio <= 0.0) {
+        if (!(targetRatio > 0.0)) {
             return baseW;
         }
         const currentRatio = baseW / baseH;
@@ -216,7 +236,7 @@ DankModal {
             return baseH;
         }
         const targetRatio = getTargetRatio(window.backdropAspectRatio);
-        if (targetRatio <= 0.0) {
+        if (!(targetRatio > 0.0)) {
             return baseH;
         }
         const currentRatio = baseW / baseH;
@@ -958,9 +978,6 @@ DankModal {
                 }
             } else {
                 window.currentTool = toolShortcut.tool;
-                if (toolShortcut.tool === "backdrop" && window.backdropMode === "none") {
-                    window.backdropMode = "solid";
-                }
             }
             event.accepted = true;
         }
@@ -1070,9 +1087,6 @@ DankModal {
         }
 
         window.currentTool = startTool;
-        if (startTool === "backdrop" && window.backdropMode === "none") {
-            window.backdropMode = "solid";
-        }
         window.toolbarVisible = window.configShowToolbar;
         window.strokeWidth = startThickness;
         window.currentColor = startColor;
@@ -1274,9 +1288,6 @@ DankModal {
                             window.currentTool = window.lastActiveTool;
                         } else {
                             window.currentTool = tool;
-                            if (tool === "backdrop" && window.backdropMode === "none") {
-                                window.backdropMode = "solid";
-                            }
                         }
                     }
                     onColorSelected: (color) => {
@@ -1391,8 +1402,9 @@ DankModal {
                             window.backdropGradientAngle = (window.backdropGradientAngle + aStep + 360) % 360;
                         } else if (type === "aspectRatio") {
                             if (window.backdropAspectRatio === "custom") {
-                                let ratioStep = delta > 0 ? 0.05 : -0.05;
-                                window.customAspectRatio = Math.max(0.5, Math.min(2.5, window.customAspectRatio + ratioStep));
+                                let ratioStep = delta > 0 ? 5 : -5;
+                                let scaled = Math.round(window.customAspectRatio * 100) + ratioStep;
+                                window.customAspectRatio = Math.max(50, Math.min(250, scaled)) / 100.0;
                             }
                         }
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
@@ -2771,6 +2783,7 @@ DankModal {
                     id: backdropAspectRatioPopover
                     backdropAspectRatio: window.backdropAspectRatio
                     customAspectRatio: window.customAspectRatio
+                    presets: window.aspectPresets
                     onChangeBackdropAspectRatio: (ratio) => {
                         window.backdropAspectRatio = ratio;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -1,0 +1,53 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+Item {
+    id: control
+
+    ToolbarConstants { id: tc }
+
+    property string backdropAspectRatio: "auto"
+    property real customAspectRatio: 1.50
+    property bool compact: false
+
+    signal hovered()
+    signal exited()
+    signal wheeled(int delta)
+
+    width: compact ? tc.btnSize : row.implicitWidth
+    height: compact ? tc.btnSizeCompact : tc.btnSize
+
+    Row {
+        id: row
+        spacing: compact ? tc.spacingCompact : Theme.spacingXS
+        anchors.centerIn: compact ? parent : undefined
+        anchors.verticalCenter: compact ? undefined : parent.verticalCenter
+
+        DankIcon {
+            name: "aspect_ratio"
+            size: compact ? tc.iconSizeCompact : tc.backdropIconSize
+            color: Theme.surfaceText
+            anchors.verticalCenter: parent.verticalCenter
+        }
+        StyledText {
+            text: {
+                if (control.backdropAspectRatio === "auto") return I18n.tr("AUTO");
+                if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
+                return control.backdropAspectRatio;
+            }
+            font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
+            color: Theme.surfaceText
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onEntered: control.hovered()
+        onExited: control.exited()
+        onWheel: (wheel) => control.wheeled(wheel.angleDelta.y)
+    }
+}

--- a/components/BackdropAspectRatioPopover.qml
+++ b/components/BackdropAspectRatioPopover.qml
@@ -95,7 +95,7 @@ Rectangle {
             Grid {
                 columns: 4
                 rows: 2
-                spacing: 4
+                spacing: tc.gridSpacing
                 anchors.verticalCenter: parent.verticalCenter
 
                 Repeater {
@@ -143,12 +143,12 @@ Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
 
                 Column {
-                    spacing: 2
+                    spacing: tc.spacingCompact
                     anchors.verticalCenter: parent.verticalCenter
 
                     StyledText {
                         text: I18n.tr("Ratio")
-                        font.pixelSize: 8
+                        font.pixelSize: tc.fontSizeCompact
                         color: Theme.surfaceVariantText
                     }
 
@@ -170,7 +170,7 @@ Rectangle {
 
                 StyledText {
                     text: popoverRoot.customAspectRatio.toFixed(2)
-                    font.pixelSize: 13
+                    font.pixelSize: tc.fontSizeCompact
                     font.weight: Font.Medium
                     color: Theme.surfaceText
                     anchors.verticalCenter: parent.verticalCenter

--- a/components/BackdropAspectRatioPopover.qml
+++ b/components/BackdropAspectRatioPopover.qml
@@ -5,17 +5,24 @@ import qs.Widgets
 Rectangle {
     id: popoverRoot
 
+    ToolbarConstants { id: tc }
+
     property string backdropAspectRatio: "auto"
     property real customAspectRatio: 1.50
+    property real customRatioMin: 0.50
+    property real customRatioMax: 2.50
+    property var presets: []
     property bool opened: false
 
     signal changeBackdropAspectRatio(string ratio)
     signal changeCustomAspectRatio(real ratio)
 
     readonly property bool customActive: backdropAspectRatio === "custom"
+    readonly property int _sliderMin: Math.round(customRatioMin * 100)
+    readonly property int _sliderMax: Math.round(customRatioMax * 100)
 
     width: customActive ? 340 : 220
-    height: 72
+    height: tc.popoverHeight
     color: Theme.surfaceContainer
     border.color: Theme.withAlpha(Theme.outline, 0.15)
     border.width: 1
@@ -73,8 +80,9 @@ Rectangle {
         onWheel: (wheel) => {
             if (popoverRoot.customActive) {
                 let step = wheel.angleDelta.y > 0 ? 5 : -5;
-                let newVal = Math.max(50, Math.min(250, Math.round(popoverRoot.customAspectRatio * 100) + step));
-                popoverRoot.changeCustomAspectRatio(newVal / 100.0);
+                let scaled = Math.round(popoverRoot.customAspectRatio * 100) + step;
+                let newVal = Math.max(popoverRoot._sliderMin, Math.min(popoverRoot._sliderMax, scaled)) / 100.0;
+                popoverRoot.changeCustomAspectRatio(newVal);
             }
         }
 
@@ -90,22 +98,12 @@ Rectangle {
                 spacing: 4
                 anchors.verticalCenter: parent.verticalCenter
 
-                readonly property var presets: [
-                    { value: "auto", label: "AUTO" },
-                    { value: "1:1", label: "1:1" },
-                    { value: "16:9", label: "16:9" },
-                    { value: "9:16", label: "9:16" },
-                    { value: "4:3", label: "4:3" },
-                    { value: "3:2", label: "3:2" },
-                    { value: "21:9", label: "21:9" },
-                    { value: "custom", label: "CUST" }
-                ]
-
                 Repeater {
-                    model: parent.presets
+                    model: popoverRoot.presets
                     delegate: Rectangle {
-                        width: 44
-                        height: 24
+                        required property var modelData
+                        width: tc.presetBtnWidth
+                        height: tc.presetBtnHeight
                         radius: Theme.cornerRadiusXS
                         color: popoverRoot.backdropAspectRatio === modelData.value ? Theme.primary : Theme.withAlpha(Theme.surfaceVariant, 0.4)
                         border.color: popoverRoot.backdropAspectRatio === modelData.value ? "transparent" : Theme.withAlpha(Theme.outline, 0.15)
@@ -113,7 +111,7 @@ Rectangle {
 
                         StyledText {
                             text: modelData.label
-                            font.pixelSize: 10
+                            font.pixelSize: tc.presetFontSize
                             font.weight: popoverRoot.backdropAspectRatio === modelData.value ? Font.DemiBold : Font.Normal
                             color: popoverRoot.backdropAspectRatio === modelData.value ? Theme.onPrimary : Theme.surfaceVariantText
                             anchors.centerIn: parent
@@ -131,8 +129,8 @@ Rectangle {
             // Separator when custom is active
             Rectangle {
                 visible: popoverRoot.customActive
-                width: 1
-                height: 36
+                width: tc.separatorThickness
+                height: tc.btnSize
                 color: Theme.withAlpha(Theme.outline, 0.2)
                 anchors.verticalCenter: parent.verticalCenter
             }
@@ -149,19 +147,24 @@ Rectangle {
                     anchors.verticalCenter: parent.verticalCenter
 
                     StyledText {
-                        text: "Ratio"
+                        text: I18n.tr("Ratio")
                         font.pixelSize: 8
                         color: Theme.surfaceVariantText
                     }
 
                     DankSlider {
                         id: slider
-                        minimum: 50
-                        maximum: 250
-                        width: 100
-                        value: Math.round(popoverRoot.customAspectRatio * 100)
+                        minimum: popoverRoot._sliderMin
+                        maximum: popoverRoot._sliderMax
+                        width: tc.sliderWidth
                         showValue: false
                         onSliderValueChanged: val => popoverRoot.changeCustomAspectRatio(val / 100.0)
+
+                        Binding {
+                            target: slider
+                            property: "value"
+                            value: Math.round(popoverRoot.customAspectRatio * 100)
+                        }
                     }
                 }
 

--- a/components/BackdropModeSelectors.qml
+++ b/components/BackdropModeSelectors.qml
@@ -10,6 +10,8 @@ Grid {
 
     signal changeBackdropMode(string mode)
 
+    ToolbarConstants { id: tc }
+
     rows: isVertical ? 5 : 1
     columns: isVertical ? 1 : 5
     spacing: Theme.spacingXS
@@ -26,8 +28,8 @@ Grid {
         model: controlRoot.modes
         delegate: DankActionButton {
             iconName: modelData.icon
-            buttonSize: 36
-            iconSize: 18
+            buttonSize: tc.btnSize
+            iconSize: tc.iconSize
             tooltipText: modelData.tooltip
             backgroundColor: controlRoot.backdropMode === modelData.mode ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
             iconColor: controlRoot.backdropMode === modelData.mode ? Theme.primary : Theme.surfaceText

--- a/components/HoverSliderPopover.qml
+++ b/components/HoverSliderPopover.qml
@@ -4,8 +4,11 @@ import qs.Widgets
 
 Rectangle {
     id: popoverRoot
+
+    ToolbarConstants { id: tc }
+
     width: 120
-    height: 36
+    height: tc.btnSize
     color: Theme.surfaceContainer
     border.color: Theme.withAlpha(Theme.outline, 0.15)
     border.width: 1

--- a/components/MoreToolsMenu.qml
+++ b/components/MoreToolsMenu.qml
@@ -4,6 +4,9 @@ import qs.Widgets
 
 Rectangle {
     id: menuRoot
+
+    ToolbarConstants { id: tc }
+
     width: 120
     height: menuColumn.implicitHeight + Theme.spacingS * 2
     color: Theme.surfaceContainer
@@ -46,7 +49,7 @@ Rectangle {
         id: menuColumn
         anchors.fill: parent
         anchors.margins: Theme.spacingS
-        spacing: 2
+        spacing: tc.spacingCompact
 
         // Rotate Option
         Rectangle {

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -201,7 +201,7 @@ Rectangle {
                         }
                         return root.strokeWidth + "px";
                     }
-                    width: 32; horizontalAlignment: Text.AlignRight
+                    width: tc.btnSize; horizontalAlignment: Text.AlignRight
                     color: Theme.surfaceText; font.pixelSize: 11; font.bold: true; anchors.verticalCenter: parent.verticalCenter
                 }
                 DankSlider {
@@ -721,7 +721,7 @@ Rectangle {
                     id: angleControlVert
                     visible: root.backdropMode === "gradient" || root.backdropMode === "conic"
                     width: tc.btnSize
-                    height: visible ? 28 : 0
+                    height: visible ? tc.btnSizeCompact : 0
                     anchors.horizontalCenter: parent.horizontalCenter
                     
                     Row {

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -8,6 +8,7 @@ Rectangle {
     id: root
 
     property var pluginData: ({})
+    ToolbarConstants { id: tc }
     CaptureConfig { id: config; pluginData: root.pluginData }
 
     property string currentTool: "crop"
@@ -30,9 +31,6 @@ Rectangle {
     property string backdropAspectRatio: "auto"
     
     property real customAspectRatio: 1.50
-
-    readonly property var aspectRatios: ["auto", "1:1", "16:9", "9:16", "4:3", "3:2", "21:9", "custom"]
-    readonly property var aspectRatioLabels: ["AUTO", "1:1", "16:9", "9:16", "4:3", "3:2", "21:9", "CUSTOM"]
 
     property string gradientActiveSlot: "start"
 
@@ -111,28 +109,28 @@ Rectangle {
             Row {
                 spacing: Theme.spacingXS; anchors.verticalCenter: parent.verticalCenter
                 DankActionButton {
-                    iconName: "near_me"; buttonSize: 36; iconSize: 18; tooltipText: "Select (Tab)"
+                    iconName: "near_me"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Select (Tab)"
                     backgroundColor: root.currentTool === "select" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                     iconColor: root.currentTool === "select" ? Theme.primary : Theme.surfaceText
                     onClicked: root.toolSelected("select")
                 }
                 DankActionButton {
                     iconName: root.showAnnotations ? "visibility" : "visibility_off"
-                    buttonSize: 36; iconSize: 18
+                    buttonSize: tc.btnSize; iconSize: tc.iconSize
                     tooltipText: root.showAnnotations ? "Hide Annotations (X)" : "Show Annotations (X)"
                     iconColor: root.showAnnotations ? Theme.primary : Theme.surfaceText
                     backgroundColor: "transparent"
                     onClicked: root.annotationsToggled()
                 }
                 DankActionButton {
-                    iconName: "crop"; buttonSize: 36; iconSize: 18; tooltipText: "Crop (Ctrl+X)"
+                    iconName: "crop"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Crop (Ctrl+X)"
                     backgroundColor: root.currentTool === "crop" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                     iconColor: root.currentTool === "crop" ? Theme.primary : Theme.surfaceText
                     onClicked: root.toolSelected("crop")
                 }
             }
 
-            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+            Rectangle { width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
             // Tools
             Row {
@@ -140,11 +138,11 @@ Rectangle {
                 Repeater {
                     model: config.toolButtons
                     delegate: Item {
-                        width: 36
-                        height: 36
+                        width: tc.btnSize
+                        height: tc.btnSize
                         DankActionButton {
                             anchors.fill: parent
-                            iconName: modelData.icon; buttonSize: 36; iconSize: 18; tooltipText: modelData.tooltip
+                            iconName: modelData.icon; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: modelData.tooltip
                             backgroundColor: root.currentTool === modelData.id ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                             iconColor: root.currentTool === modelData.id ? Theme.primary : Theme.surfaceText
                             onClicked: root.toolSelected(modelData.id)
@@ -168,22 +166,22 @@ Rectangle {
                 DankActionButton {
                     id: moreActionsBtn
                     iconName: "more_horiz"
-                    buttonSize: 36
-                    iconSize: 18
+                    buttonSize: tc.btnSize
+                    iconSize: tc.iconSize
                     tooltipText: qsTr("More Tools")
                     onClicked: root.moreToolsClicked(moreActionsBtn)
                 }
             }
 
-            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+            Rectangle { width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
             // Colors
             Grid {
-                rows: 2; columns: 4; spacing: 4; anchors.verticalCenter: parent.verticalCenter
+                rows: 2; columns: 4; spacing: tc.gridSpacing; anchors.verticalCenter: parent.verticalCenter
                 Repeater {
                     model: root.toolbarPalette
                     delegate: Rectangle {
-                        width: 20; height: 20; radius: 10; color: modelData
+                        width: tc.swatchSize; height: tc.swatchSize; radius: tc.swatchRadius; color: modelData
                         border.color: Qt.colorEqual(root.currentColor, modelData) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
                         border.width: Qt.colorEqual(root.currentColor, modelData) ? 2 : 1
                         MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.colorSelected(modelData) }
@@ -191,7 +189,7 @@ Rectangle {
                 }
             }
 
-            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+            Rectangle { width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
             // Thickness Section
             Row {
@@ -210,8 +208,8 @@ Rectangle {
                     id: hSlider
                     minimum: root.activeToolType === "pixelate" ? 2 : (root.activeToolType === "spotlight" ? 10 : (root.activeToolType === "callout" ? 100 : 1))
                     maximum: root.activeToolType === "pixelate" ? 12 : (root.activeToolType === "text" ? 120 : (root.activeToolType === "spotlight" ? 95 : (root.activeToolType === "callout" ? 500 : 50)))
-                    width: 100
-                    height: 36
+                    width: tc.sliderWidth
+                    height: tc.btnSize
                     showValue: false
                     onSliderValueChanged: newValue => root.strokeWidthSelected(newValue)
                     anchors.verticalCenter: parent.verticalCenter
@@ -224,17 +222,17 @@ Rectangle {
                 }
             }
 
-            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+            Rectangle { width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
             // Actions
             Row {
                 spacing: Theme.spacingXS; anchors.verticalCenter: parent.verticalCenter
-                DankActionButton { iconName: "undo"; buttonSize: 36; iconSize: 18; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; onClicked: root.undoRequested() }
-                DankActionButton { iconName: "picture_in_picture"; buttonSize: 36; iconSize: 18; tooltipText: "Float Window (Ctrl+F)"; onClicked: root.floatRequested() }
-                DankActionButton { iconName: "save"; buttonSize: 36; iconSize: 18; tooltipText: "Save to File (Ctrl+S)"; onClicked: root.saveRequested() }
-                DankActionButton { iconName: "content_copy"; buttonSize: 36; iconSize: 18; tooltipText: "Copy to Clipboard (Ctrl+C)"; onClicked: root.copyRequested() }
-                DankActionButton { iconName: "done_all"; buttonSize: 36; iconSize: 18; tooltipText: "Copy & Save (Enter)"; backgroundColor: Theme.withAlpha(Theme.primary, 0.1); iconColor: Theme.primary; onClicked: root.copyAndSaveRequested() }
-                DankActionButton { iconName: "close"; buttonSize: 36; iconSize: 18; iconColor: Theme.error; onClicked: root.closeRequested() }
+                DankActionButton { iconName: "undo"; buttonSize: tc.btnSize; iconSize: tc.iconSize; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; onClicked: root.undoRequested() }
+                DankActionButton { iconName: "picture_in_picture"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Float Window (Ctrl+F)"; onClicked: root.floatRequested() }
+                DankActionButton { iconName: "save"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Save to File (Ctrl+S)"; onClicked: root.saveRequested() }
+                DankActionButton { iconName: "content_copy"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Copy to Clipboard (Ctrl+C)"; onClicked: root.copyRequested() }
+                DankActionButton { iconName: "done_all"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Copy & Save (Enter)"; backgroundColor: Theme.withAlpha(Theme.primary, 0.1); iconColor: Theme.primary; onClicked: root.copyAndSaveRequested() }
+                DankActionButton { iconName: "close"; buttonSize: tc.btnSize; iconSize: tc.iconSize; iconColor: Theme.error; onClicked: root.closeRequested() }
             }
         }
     }
@@ -248,39 +246,39 @@ Rectangle {
             Column {
                 spacing: Theme.spacingXS; anchors.horizontalCenter: parent.horizontalCenter
                 DankActionButton {
-                    iconName: "near_me"; buttonSize: 36; iconSize: 18; tooltipText: "Select (Tab)"
+                    iconName: "near_me"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Select (Tab)"
                     backgroundColor: root.currentTool === "select" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                     iconColor: root.currentTool === "select" ? Theme.primary : Theme.surfaceText
                     onClicked: root.toolSelected("select")
                 }
                 DankActionButton {
                     iconName: root.showAnnotations ? "visibility" : "visibility_off"
-                    buttonSize: 36; iconSize: 18
+                    buttonSize: tc.btnSize; iconSize: tc.iconSize
                     tooltipText: root.showAnnotations ? "Hide Annotations (X)" : "Show Annotations (X)"
                     iconColor: root.showAnnotations ? Theme.primary : Theme.surfaceText
                     backgroundColor: "transparent"
                     onClicked: root.annotationsToggled()
                 }
                 DankActionButton {
-                    iconName: "crop"; buttonSize: 36; iconSize: 18; tooltipText: "Crop (Ctrl+X)"
+                    iconName: "crop"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Crop (Ctrl+X)"
                     backgroundColor: root.currentTool === "crop" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                     iconColor: root.currentTool === "crop" ? Theme.primary : Theme.surfaceText
                     onClicked: root.toolSelected("crop")
                 }
             }
 
-            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
 
             Grid {
                 columns: 1; spacing: Theme.spacingXS; anchors.horizontalCenter: parent.horizontalCenter
                 Repeater {
                     model: config.toolButtons
                     delegate: Item {
-                        width: 36
-                        height: 36
+                        width: tc.btnSize
+                        height: tc.btnSize
                         DankActionButton {
                             anchors.fill: parent
-                            iconName: modelData.icon; buttonSize: 36; iconSize: 18
+                            iconName: modelData.icon; buttonSize: tc.btnSize; iconSize: tc.iconSize
                             backgroundColor: root.currentTool === modelData.id ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                             iconColor: root.currentTool === modelData.id ? Theme.primary : Theme.surfaceText
                             onClicked: root.toolSelected(modelData.id)
@@ -304,21 +302,21 @@ Rectangle {
                 DankActionButton {
                     id: moreActionsVerticalBtn
                     iconName: "more_vert"
-                    buttonSize: 36
-                    iconSize: 18
+                    buttonSize: tc.btnSize
+                    iconSize: tc.iconSize
                     tooltipText: qsTr("More Tools")
                     onClicked: root.moreToolsClicked(moreActionsVerticalBtn)
                 }
             }
 
-            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
 
             Grid {
-                columns: 2; spacing: 6; anchors.horizontalCenter: parent.horizontalCenter
+                columns: 2; spacing: tc.gridSpacing + 2; anchors.horizontalCenter: parent.horizontalCenter
                 Repeater {
                     model: root.toolbarPalette
                     delegate: Rectangle {
-                        width: 18; height: 18; radius: 9; color: modelData
+                        width: tc.swatchSizeVert; height: tc.swatchSizeVert; radius: tc.swatchRadiusVert; color: modelData
                         border.color: Qt.colorEqual(root.currentColor, modelData) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
                         border.width: 1
                         MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.colorSelected(modelData) }
@@ -326,7 +324,7 @@ Rectangle {
                 }
             }
 
-            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
 
             // Thickness Text Only
             Text {
@@ -339,12 +337,12 @@ Rectangle {
                 color: Theme.surfaceText; font.pixelSize: 10; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter
             }
 
-            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
 
             Column {
                 spacing: Theme.spacingXS; anchors.horizontalCenter: parent.horizontalCenter
-                DankActionButton { iconName: "undo"; buttonSize: 36; iconSize: 18; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; onClicked: root.undoRequested() }
-                DankActionButton { iconName: "done_all"; buttonSize: 36; iconSize: 18; tooltipText: "Copy & Save (Enter)"; backgroundColor: Theme.withAlpha(Theme.primary, 0.1); iconColor: Theme.primary; onClicked: root.copyAndSaveRequested() }
+                DankActionButton { iconName: "undo"; buttonSize: tc.btnSize; iconSize: tc.iconSize; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; onClicked: root.undoRequested() }
+                DankActionButton { iconName: "done_all"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Copy & Save (Enter)"; backgroundColor: Theme.withAlpha(Theme.primary, 0.1); iconColor: Theme.primary; onClicked: root.copyAndSaveRequested() }
             }
         }
     }
@@ -358,13 +356,13 @@ Rectangle {
             // Back button
             DankActionButton {
                 iconName: "arrow_back"
-                buttonSize: 36
-                iconSize: 18
+                buttonSize: tc.btnSize
+                iconSize: tc.iconSize
                 tooltipText: qsTr("Back to Annotation (B)")
                 onClicked: root.toolSelected("back")
             }
             
-            Rectangle { width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+            Rectangle { width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
             
             BackdropModeSelectors {
                 backdropMode: root.backdropMode
@@ -382,7 +380,7 @@ Rectangle {
                 Item {
                     id: padControl
                     width: padRow.implicitWidth
-                    height: 36
+                    height: tc.btnSize
                     anchors.verticalCenter: parent.verticalCenter
                     
                     Row {
@@ -391,7 +389,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         DankIcon {
                             name: "padding"
-                            size: 16
+                            size: tc.backdropIconSize
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -417,7 +415,7 @@ Rectangle {
                 Item {
                     id: radControl
                     width: radRow.implicitWidth
-                    height: 36
+                    height: tc.btnSize
                     anchors.verticalCenter: parent.verticalCenter
                     
                     Row {
@@ -426,7 +424,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         DankIcon {
                             name: "rounded_corner"
-                            size: 16
+                            size: tc.backdropIconSize
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -452,7 +450,7 @@ Rectangle {
                 Item {
                     id: shadowControl
                     width: shadowRow.implicitWidth
-                    height: 36
+                    height: tc.btnSize
                     anchors.verticalCenter: parent.verticalCenter
                     
                     Row {
@@ -461,7 +459,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         DankIcon {
                             name: "blur_on"
-                            size: 16
+                            size: tc.backdropIconSize
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -488,7 +486,7 @@ Rectangle {
                     id: angleControl
                     visible: root.backdropMode === "gradient" || root.backdropMode === "conic"
                     width: visible ? angleRow.implicitWidth : 0
-                    height: 36
+                    height: tc.btnSize
                     anchors.verticalCenter: parent.verticalCenter
                     
                     Row {
@@ -497,7 +495,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         DankIcon {
                             name: "rotate_right"
-                            size: 16
+                            size: tc.backdropIconSize
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -520,49 +518,21 @@ Rectangle {
                 }
 
                 // Aspect Ratio Control (Hover to reveal preset grid + custom slider popover)
-                Item {
+                AspectRatioControl {
                     id: aspectControl
-                    width: aspectRow.implicitWidth
-                    height: 36
+                    backdropAspectRatio: root.backdropAspectRatio
+                    customAspectRatio: root.customAspectRatio
+                    compact: false
                     anchors.verticalCenter: parent.verticalCenter
-                    
-                    Row {
-                        id: aspectRow
-                        spacing: Theme.spacingXS
-                        anchors.verticalCenter: parent.verticalCenter
-                        DankIcon {
-                            name: "aspect_ratio"
-                            size: 16
-                            color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                        StyledText {
-                            text: {
-                                if (root.backdropAspectRatio === "custom") {
-                                    return root.customAspectRatio.toFixed(2);
-                                }
-                                return root.backdropAspectRatio.toUpperCase();
-                            }
-                            font.pixelSize: Theme.fontSizeSmall
-                            color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                    }
-                    MouseArea {
-                        id: aspectMouseArea
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onEntered: root.backdropControlHovered("aspectRatio", aspectControl)
-                        onExited: root.backdropControlExited("aspectRatio")
-                        onWheel: (wheel) => root.backdropControlWheel("aspectRatio", wheel.angleDelta.y)
-                    }
+                    onHovered: root.backdropControlHovered("aspectRatio", aspectControl)
+                    onExited: root.backdropControlExited("aspectRatio")
+                    onWheeled: (delta) => root.backdropControlWheel("aspectRatio", delta)
                 }
             }
             
             Rectangle { 
                 visible: root.backdropMode !== "none"
-                width: 1; height: 24; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter 
+                width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter 
             }
             
             // Colors (Solid or Gradient)
@@ -584,11 +554,11 @@ Rectangle {
                 }
                 
                 Grid {
-                    rows: 2; columns: 4; spacing: 4; anchors.verticalCenter: parent.verticalCenter
+                    rows: 2; columns: 4; spacing: tc.gridSpacing; anchors.verticalCenter: parent.verticalCenter
                     Repeater {
                         model: root.toolbarPalette
                         delegate: Rectangle {
-                            width: 16; height: 16; radius: 8; color: modelData
+                            width: tc.swatchSizeSmall; height: tc.swatchSizeSmall; radius: tc.swatchRadiusSmall; color: modelData
                             border.color: Theme.withAlpha(Theme.outline, 0.3)
                             border.width: 1
                             MouseArea {
@@ -622,13 +592,13 @@ Rectangle {
             // Back button
             DankActionButton {
                 iconName: "arrow_back"
-                buttonSize: 36
-                iconSize: 18
+                buttonSize: tc.btnSize
+                iconSize: tc.iconSize
                 tooltipText: qsTr("Back to Annotation (B)")
                 onClicked: root.toolSelected("back")
             }
             
-            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
             
             BackdropModeSelectors {
                 backdropMode: root.backdropMode
@@ -637,7 +607,7 @@ Rectangle {
                 anchors.horizontalCenter: parent.horizontalCenter
             }
             
-            Rectangle { width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+            Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
             
             // Sliders (Hover to reveal popover)
             Column {
@@ -647,22 +617,22 @@ Rectangle {
                 // Padding Control
                 Item {
                     id: padControlVert
-                    width: 36
-                    height: 28
+                    width: tc.btnSize
+                    height: tc.btnSizeCompact
                     anchors.horizontalCenter: parent.horizontalCenter
                     
                     Row {
-                        spacing: 2
+                        spacing: tc.spacingCompact
                         anchors.centerIn: parent
                         DankIcon {
                             name: "padding"
-                            size: 14
+                            size: tc.iconSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
                             text: root.backdropPadding
-                            font.pixelSize: 9
+                            font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -681,22 +651,22 @@ Rectangle {
                 // Corner Radius Control
                 Item {
                     id: radControlVert
-                    width: 36
-                    height: 28
+                    width: tc.btnSize
+                    height: tc.btnSizeCompact
                     anchors.horizontalCenter: parent.horizontalCenter
                     
                     Row {
-                        spacing: 2
+                        spacing: tc.spacingCompact
                         anchors.centerIn: parent
                         DankIcon {
                             name: "rounded_corner"
-                            size: 14
+                            size: tc.iconSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
                             text: root.backdropCornerRadius
-                            font.pixelSize: 9
+                            font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -715,22 +685,22 @@ Rectangle {
                 // Shadow Control
                 Item {
                     id: shadowControlVert
-                    width: 36
-                    height: 28
+                    width: tc.btnSize
+                    height: tc.btnSizeCompact
                     anchors.horizontalCenter: parent.horizontalCenter
                     
                     Row {
-                        spacing: 2
+                        spacing: tc.spacingCompact
                         anchors.centerIn: parent
                         DankIcon {
                             name: "blur_on"
-                            size: 14
+                            size: tc.iconSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
                             text: root.backdropShadowStrength
-                            font.pixelSize: 9
+                            font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -750,22 +720,22 @@ Rectangle {
                 Item {
                     id: angleControlVert
                     visible: root.backdropMode === "gradient" || root.backdropMode === "conic"
-                    width: 36
+                    width: tc.btnSize
                     height: visible ? 28 : 0
                     anchors.horizontalCenter: parent.horizontalCenter
                     
                     Row {
-                        spacing: 2
+                        spacing: tc.spacingCompact
                         anchors.centerIn: parent
                         DankIcon {
                             name: "rotate_right"
-                            size: 14
+                            size: tc.iconSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
                             text: root.backdropGradientAngle
-                            font.pixelSize: 9
+                            font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -782,43 +752,21 @@ Rectangle {
                 }
 
                 // Custom Aspect Ratio Control
-                Item {
+                AspectRatioControl {
                     id: aspectControlVert
-                    width: 36
-                    height: 28
+                    backdropAspectRatio: root.backdropAspectRatio
+                    customAspectRatio: root.customAspectRatio
+                    compact: true
                     anchors.horizontalCenter: parent.horizontalCenter
-                    
-                    Row {
-                        spacing: 2
-                        anchors.centerIn: parent
-                        DankIcon {
-                            name: "aspect_ratio"
-                            size: 14
-                            color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                        StyledText {
-                            text: root.backdropAspectRatio === "custom" ? root.customAspectRatio.toFixed(2) : root.backdropAspectRatio.toUpperCase()
-                            font.pixelSize: 9
-                            color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                    }
-                    MouseArea {
-                        id: aspectMouseAreaVert
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onEntered: root.backdropControlHovered("aspectRatio", aspectControlVert)
-                        onExited: root.backdropControlExited("aspectRatio")
-                        onWheel: (wheel) => root.backdropControlWheel("aspectRatio", wheel.angleDelta.y)
-                    }
+                    onHovered: root.backdropControlHovered("aspectRatio", aspectControlVert)
+                    onExited: root.backdropControlExited("aspectRatio")
+                    onWheeled: (delta) => root.backdropControlWheel("aspectRatio", delta)
                 }
             }
             
             Rectangle { 
                 visible: root.backdropMode !== "none"
-                width: 24; height: 1; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter 
+                width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter 
             }
             
             // Colors (Solid or Gradient)
@@ -840,11 +788,11 @@ Rectangle {
                 }
                 
                 Grid {
-                    columns: 2; spacing: 4; anchors.horizontalCenter: parent.horizontalCenter
+                    columns: 2; spacing: tc.gridSpacing; anchors.horizontalCenter: parent.horizontalCenter
                     Repeater {
                         model: root.toolbarPalette
                         delegate: Rectangle {
-                            width: 14; height: 14; radius: 7; color: modelData
+                            width: tc.swatchSizeVertSmall; height: tc.swatchSizeVertSmall; radius: tc.swatchRadiusVertSmall; color: modelData
                             border.color: Theme.withAlpha(Theme.outline, 0.3)
                             border.width: 1
                             MouseArea {

--- a/components/ToolbarConstants.qml
+++ b/components/ToolbarConstants.qml
@@ -1,0 +1,32 @@
+import QtQuick
+
+QtObject {
+    readonly property int btnSize: 36
+    readonly property int iconSize: 18
+
+    readonly property int btnSizeCompact: 28
+    readonly property int iconSizeCompact: 14
+    readonly property int spacingCompact: 2
+    readonly property int fontSizeCompact: 9
+
+    readonly property int separatorThickness: 1
+    readonly property int separatorLength: 24
+
+    readonly property int backdropIconSize: 16
+
+    readonly property int sliderWidth: 100
+
+    readonly property int swatchSize: 20
+    readonly property int swatchRadius: 10
+    readonly property int swatchSizeSmall: 16
+    readonly property int swatchRadiusSmall: 8
+    readonly property int swatchSizeVert: 18
+    readonly property int swatchRadiusVert: 9
+    readonly property int swatchSizeVertSmall: 14
+    readonly property int swatchRadiusVertSmall: 7
+
+    readonly property int presetBtnWidth: 44
+    readonly property int presetBtnHeight: 24
+    readonly property int presetFontSize: 10
+    readonly property int popoverHeight: 72
+}

--- a/components/ToolbarConstants.qml
+++ b/components/ToolbarConstants.qml
@@ -12,6 +12,8 @@ QtObject {
     readonly property int separatorThickness: 1
     readonly property int separatorLength: 24
 
+    readonly property int gridSpacing: 4
+
     readonly property int backdropIconSize: 16
 
     readonly property int sliderWidth: 100


### PR DESCRIPTION
## Summary

Create `ToolbarConstants.qml` as a single source of truth for all layout constants (button sizes, separator dimensions, icon sizes, spacing, swatch sizes, etc.) used across the toolbar and backdrop controls.

### Changes
- **New:** `components/ToolbarConstants.qml` — 20 centralized constants for toolbar layout
- **New:** `components/AspectRatioControl.qml` — reusable component replacing duplicated horizontal/vertical aspect ratio controls
- **Migrated:** `QuickCaptureToolbar.qml` — 78 references updated to use `tc.*` constants
- **Migrated:** `BackdropAspectRatioPopover.qml`, `BackdropModeSelectors.qml`, `AspectRatioControl.qml` — hardcoded values replaced
- **Migrated:** `HoverSliderPopover.qml`, `MoreToolsMenu.qml` — updated to use shared constants
- **QuickCaptureModal.qml:** removed 3 duplicates of `backdropMode = \"solid\"` transition (already centralized in `onCurrentToolChanged`)