### PR TITLE
feat(pen): smooth pen rendering and snap shift to 15 degrees

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1911,7 +1911,7 @@ DankModal {
                                          
                                          let finalPt = absPt;
                                          if ((mouse.modifiers & Qt.ShiftModifier) && (window.currentTool === "line" || window.currentTool === "arrow" || window.currentTool === "highlighter")) {
-                                             // Snapping angle calculation (8 directions / 45 degrees)
+                                             // Snapping angle calculation (24 directions / 15 degrees)
                                              const p0 = window.currentStroke.points[0];
                                              if (p0) {
                                                  const dx = absPt.x - p0.x;
@@ -1919,7 +1919,7 @@ DankModal {
                                                  const L = Math.sqrt(dx * dx + dy * dy);
                                                  if (L > 0) {
                                                      const angle = Math.atan2(dy, dx);
-                                                     const snappedAngle = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+                                                     const snappedAngle = Math.round(angle / (Math.PI / 12)) * (Math.PI / 12);
                                                      finalPt = Qt.point(p0.x + L * Math.cos(snappedAngle), p0.y + L * Math.sin(snappedAngle));
                                                  }
                                              }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1919,7 +1919,8 @@ DankModal {
                                                  const L = Math.sqrt(dx * dx + dy * dy);
                                                  if (L > 0) {
                                                      const angle = Math.atan2(dy, dx);
-                                                     const snappedAngle = Math.round(angle / (Math.PI / 12)) * (Math.PI / 12);
+                                                     const SNAP_STEP = Math.PI / 12; // 15 degrees
+                                                     const snappedAngle = Math.round(angle / SNAP_STEP) * SNAP_STEP;
                                                      finalPt = Qt.point(p0.x + L * Math.cos(snappedAngle), p0.y + L * Math.sin(snappedAngle));
                                                  }
                                              }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ git clone https://github.com/hthienloc/dms-quick-capture ~/.config/DankMaterialS
   | Tool | Shift Behavior |
   |------|----------------|
   | Pen | Draws straight lines |
-  | Line, Arrow, Highlighter | Snaps angle to 45° increments |
+  | Line, Arrow, Highlighter | Snaps angle to 15° increments |
   | Ellipse | Perfect circle |
   | Rectangle, Redact, Pixelate | Perfect square |
 

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -28,8 +28,17 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         ctx.lineJoin = "round";
         ctx.beginPath();
         ctx.moveTo(stroke.points[0].x, stroke.points[0].y);
-        for (var i = 1; i < stroke.points.length; i++) {
-            ctx.lineTo(stroke.points[i].x, stroke.points[i].y);
+        if (stroke.points.length === 1) {
+            ctx.lineTo(stroke.points[0].x, stroke.points[0].y);
+        } else if (stroke.points.length === 2) {
+            ctx.lineTo(stroke.points[1].x, stroke.points[1].y);
+        } else {
+            for (var i = 1; i < stroke.points.length - 1; i++) {
+                const xc = (stroke.points[i].x + stroke.points[i + 1].x) / 2;
+                const yc = (stroke.points[i].y + stroke.points[i + 1].y) / 2;
+                ctx.quadraticCurveTo(stroke.points[i].x, stroke.points[i].y, xc, yc);
+            }
+            ctx.lineTo(stroke.points[stroke.points.length - 1].x, stroke.points[stroke.points.length - 1].y);
         }
         ctx.stroke();
 

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -27,19 +27,28 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         ctx.lineCap = "round";
         ctx.lineJoin = "round";
         ctx.beginPath();
-        ctx.moveTo(stroke.points[0].x, stroke.points[0].y);
-        if (stroke.points.length === 1) {
-            ctx.lineTo(stroke.points[0].x, stroke.points[0].y);
-        } else if (stroke.points.length === 2) {
-            ctx.lineTo(stroke.points[1].x, stroke.points[1].y);
-        } else {
-            for (var i = 1; i < stroke.points.length - 1; i++) {
-                const xc = (stroke.points[i].x + stroke.points[i + 1].x) / 2;
-                const yc = (stroke.points[i].y + stroke.points[i + 1].y) / 2;
-                ctx.quadraticCurveTo(stroke.points[i].x, stroke.points[i].y, xc, yc);
-            }
-            ctx.lineTo(stroke.points[stroke.points.length - 1].x, stroke.points[stroke.points.length - 1].y);
+        
+        const pts = stroke.points;
+        const len = pts.length;
+        ctx.moveTo(pts[0].x, pts[0].y);
+
+        if (len === 1) {
+            ctx.lineTo(pts[0].x, pts[0].y);
+            ctx.stroke();
+            return;
         }
+        if (len === 2) {
+            ctx.lineTo(pts[1].x, pts[1].y);
+            ctx.stroke();
+            return;
+        }
+
+        for (let i = 1; i < len - 2; i++) {
+            const xc = (pts[i].x + pts[i + 1].x) / 2;
+            const yc = (pts[i].y + pts[i + 1].y) / 2;
+            ctx.quadraticCurveTo(pts[i].x, pts[i].y, xc, yc);
+        }
+        ctx.quadraticCurveTo(pts[len - 2].x, pts[len - 2].y, pts[len - 1].x, pts[len - 1].y);
         ctx.stroke();
 
     } else if (stroke.tool === "line") {

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -10,7 +10,7 @@ DMS Quick Capture is an interactive vector annotation and screenshot utility for
 
 - **Plugin ID:** `quickCapture`
 - **Plugin Type:** `composite` (bundles background daemon, bar widget, settings UI)
-- **Current Version:** `2.7.2` (see [plugin.json](file:///home/loccun/Documents/GitHub/dms-quick-capture/plugin.json))
+- **Current Version:** `2.7.3` (see [plugin.json](file:///home/loccun/Documents/GitHub/dms-quick-capture/plugin.json))
 
 ### Core Components Map
 

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "id": "quickCapture",
     "name": "Quick Capture",
     "description": "Instant screenshot and overlay annotation utility for Wayland",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "author": "Loc Huynh",
     "icon": "screenshot_region",
     "type": "composite",


### PR DESCRIPTION
### What
- Apply midpoint quadratic Bezier curve interpolation to the pen tool for smoother rendering.
- Change Shift angle snapping from 45 degrees to 15 degrees increments.
- Update the Shift key snapping documentation in README.md.
- Bump version to 2.7.3.

### Why
- Fixes rough/jagged segments during pen drawing.
- Provides finer control (15-degree snaps) when drawing lines, arrows, and highlighters.

### How tested
- Tested pen drawing visually inside the Quick Capture annotator.
- Verified Shift key snaps line angles correctly at 15-degree increments.

## Summary by Sourcery

Improve pen stroke rendering smoothness and refine angle snapping behavior while updating related documentation and versioning.

New Features:
- Smooth pen stroke rendering using interpolated curves instead of straight point-to-point segments.

Enhancements:
- Refine Shift-modified angle snapping for line, arrow, and highlighter tools from 45° to 15° increments.
- Update plugin version metadata to 2.7.3.

Documentation:
- Document the 15° Shift angle snapping behavior and update the referenced plugin version in the AI guide.