### PR TITLE
feat(github): skip auto-assignment if the creator is hthienloc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,7 +2,6 @@ name: 🐛 Bug Report
 description: Report a bug or unexpected behavior in DMS Quick Capture
 title: "[Bug]: "
 labels: ["bug"]
-assignees: ["hthienloc"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,7 +2,6 @@ name: 💡 Feature Request
 description: Suggest an idea or enhancement for DMS Quick Capture
 title: "[Feature]: "
 labels: ["enhancement"]
-assignees: ["hthienloc"]
 body:
   - type: textarea
     id: problem

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,10 +11,11 @@ env:
 jobs:
   assign:
     # Fork PR runs get a read-only GITHUB_TOKEN; skip external forks cleanly.
-    # Gate the pull_request check to prevent evaluation errors on issue events.
+    # Gate the pull_request check and prevent triggering if the actor is hthienloc.
     if: >-
-      github.event_name == 'issues' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'issues' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) &&
+      github.actor != 'hthienloc'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### What
- Remove the native `assignees` key from bug report and feature request templates.
- Add a check `github.actor != 'hthienloc'` to the auto-assign workflow to avoid running on issues/PRs created by the maintainer.

### Why
- Prevents the workflow from triggering and automatically assigning `hthienloc` when the creator is `hthienloc` themselves.

### How tested
- Tested workflow conditional syntax locally and verified YAML template changes.

## Summary by Sourcery

Update GitHub automation to avoid auto-assigning issues and PRs created by the maintainer.

Enhancements:
- Tighten the auto-assign workflow condition to skip runs when the actor is the maintainer while still handling issues and same-repo pull requests.

CI:
- Adjust the auto-assign GitHub Actions workflow condition to exclude events triggered by the maintainer account.