### PR TITLE
feat(qr): add QR Code Scanner tool and update roadmap

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -641,6 +641,75 @@ DankModal {
         });
     }
 
+    function runQrScan() {
+        window.ocrRect = Qt.rect(0, 0, 0, 0);
+        window.currentTool = "qr";
+        if (window.activeCanvas) window.activeCanvas.requestPaint();
+        if (typeof ToastService !== "undefined" && ToastService) {
+            ToastService.showInfo(I18n.tr("QR Scan: Draw a rectangle on the image to scan"));
+        }
+    }
+
+    function executeQrScan() {
+        const r = window.ocrRect;
+        if (r.width < 10 || r.height < 10) {
+            window.ocrRect = Qt.rect(0, 0, 0, 0);
+            if (window.activeCanvas) window.activeCanvas.requestPaint();
+            return;
+        }
+
+        // Account for crop offset when mapping to source image coordinates
+        const cropOffsetX = window.hasSelection ? window.cropRect.x : 0;
+        const cropOffsetY = window.hasSelection ? window.cropRect.y : 0;
+        const ix = Math.round(r.x + cropOffsetX);
+        const iy = Math.round(r.y + cropOffsetY);
+        const iw = Math.round(r.width);
+        const ih = Math.round(r.height);
+
+        let bgPath = decodeURIComponent(window.bgImageSource.toString());
+        if (bgPath.startsWith("file://")) bgPath = bgPath.substring(7);
+        const qIdx = bgPath.indexOf("?");
+        if (qIdx !== -1) bgPath = bgPath.substring(0, qIdx);
+
+        const tempCropPath = "/tmp/dms_qr_crop.png";
+        Proc.runCommand("crop-qr-temp", ["magick", bgPath, "-crop", iw + "x" + ih + "+" + ix + "+" + iy, tempCropPath], (stdout1, exitCode1) => {
+            if (exitCode1 === 0) {
+                Proc.runCommand("run-qr-scan", ["zbarimg", "--raw", "-q", tempCropPath], (stdout2, exitCode2) => {
+                    Proc.runCommand("cleanup-qr-temp", ["rm", "-f", tempCropPath]);
+
+                    if (exitCode2 === 0) {
+                        const result = stdout2.trim();
+                        if (result) {
+                            DMSService.sendRequest("clipboard.copy", { "text": result }, function(response) {
+                                if (typeof ToastService !== "undefined" && ToastService) {
+                                    ToastService.showInfo(I18n.tr("QR Decoded: Copied to clipboard"));
+                                }
+                            });
+                        } else {
+                            if (typeof ToastService !== "undefined" && ToastService) {
+                                ToastService.showInfo(I18n.tr("QR Scan: No QR code detected"));
+                            }
+                        }
+                    } else {
+                        if (typeof ToastService !== "undefined" && ToastService) {
+                            ToastService.showError(I18n.tr("QR Scan failed or no QR code found"));
+                        }
+                    }
+                    window.currentTool = window.lastActiveTool;
+                    window.ocrRect = Qt.rect(0, 0, 0, 0);
+                    if (window.activeCanvas) window.activeCanvas.requestPaint();
+                });
+            } else {
+                if (typeof ToastService !== "undefined" && ToastService) {
+                    ToastService.showError(I18n.tr("QR Scan failed: Could not crop image"));
+                }
+                window.currentTool = window.lastActiveTool;
+                window.ocrRect = Qt.rect(0, 0, 0, 0);
+                if (window.activeCanvas) window.activeCanvas.requestPaint();
+            }
+        });
+    }
+
     shouldBeVisible: false
     
     // Spacious modal dimensions occupying 90% width and 90% height of the screen
@@ -958,7 +1027,7 @@ DankModal {
         const hasCtrl = event.modifiers & Qt.ControlModifier;
 
         if (event.key === Qt.Key_Escape) {
-            if (window.currentTool === "ocr") {
+            if (window.currentTool === "ocr" || window.currentTool === "qr") {
                 window.currentTool = window.lastActiveTool;
                 window.ocrRect = Qt.rect(0, 0, 0, 0);
                 if (window.activeCanvas) window.activeCanvas.requestPaint();
@@ -1573,7 +1642,7 @@ DankModal {
                             // 1. Draw Dimming Selection Overlay (only if in crop mode)
                             DrawingRenderer.drawSelectionOverlay(ctx, {
                                 isCropMode: window.currentTool === "crop",
-                                isOcrMode: window.currentTool === "ocr",
+                                isOcrMode: window.currentTool === "ocr" || window.currentTool === "qr",
                                 cropRect: window.cropRect,
                                 ocrRect: window.ocrRect,
                                 canvasWidth: window.canvasWidth,
@@ -1879,8 +1948,8 @@ DankModal {
                                         drawingCanvas.requestPaint();
                                         return;
                                     }
-                                } else if (window.currentTool === "ocr") {
-                                    if (window.activeHandle === "ocr") {
+                                } else if (window.currentTool === "ocr" || window.currentTool === "qr") {
+                                    if (window.activeHandle === "ocr" || window.activeHandle === "qr") {
                                         const ox = mouse.x / window.editScale;
                                         const oy = mouse.y / window.editScale;
                                         const x1 = Math.min(window.selectStart.x, ox);
@@ -2066,12 +2135,12 @@ DankModal {
                                     return;
                                 }
 
-                                if (window.currentTool === "ocr") {
+                                if (window.currentTool === "ocr" || window.currentTool === "qr") {
                                     const ox = mouse.x / window.editScale;
                                     const oy = mouse.y / window.editScale;
                                     window.selectStart = Qt.point(ox, oy);
                                     window.ocrRect = Qt.rect(ox, oy, 0, 0);
-                                    window.activeHandle = "ocr";
+                                    window.activeHandle = window.currentTool;
                                     drawingCanvas.requestPaint();
                                     return;
                                 }
@@ -2177,6 +2246,12 @@ DankModal {
                                 if (window.currentTool === "ocr") {
                                     window.activeHandle = "none";
                                     window.executeOcr();
+                                    return;
+                                }
+
+                                if (window.currentTool === "qr") {
+                                    window.activeHandle = "none";
+                                    window.executeQrScan();
                                     return;
                                 }
 
@@ -2847,6 +2922,7 @@ DankModal {
                     onRotateRequested: window.rotateScreenshot()
                     onMirrorRequested: window.mirrorScreenshot()
                     onOcrRequested: window.runOcr()
+                    onQrScanRequested: window.runQrScan()
                 }
 
                 HoverSliderPopover {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -602,7 +602,8 @@ DankModal {
         if (qIdx !== -1) bgPath = bgPath.substring(0, qIdx);
         let ocrLang = "eng";
 
-        const tempCropPath = "/tmp/dms_ocr_crop.png";
+        const uniqueId = Date.now() + "_" + Math.floor(Math.random() * 1000000);
+        const tempCropPath = "/tmp/dms_ocr_crop_" + uniqueId + ".png";
         Proc.runCommand("crop-ocr-temp", ["magick", bgPath, "-crop", iw + "x" + ih + "+" + ix + "+" + iy, tempCropPath], (stdout1, exitCode1) => {
             if (exitCode1 === 0) {
                 Proc.runCommand("run-ocr", ["tesseract", tempCropPath, "-", "-l", ocrLang], (stdout2, exitCode2) => {
@@ -671,7 +672,8 @@ DankModal {
         const qIdx = bgPath.indexOf("?");
         if (qIdx !== -1) bgPath = bgPath.substring(0, qIdx);
 
-        const tempCropPath = "/tmp/dms_qr_crop.png";
+        const uniqueId = Date.now() + "_" + Math.floor(Math.random() * 1000000);
+        const tempCropPath = "/tmp/dms_qr_crop_" + uniqueId + ".png";
         Proc.runCommand("crop-qr-temp", ["magick", bgPath, "-crop", iw + "x" + ih + "+" + ix + "+" + iy, tempCropPath], (stdout1, exitCode1) => {
             if (exitCode1 === 0) {
                 Proc.runCommand("run-qr-scan", ["zbarimg", "--raw", "-q", tempCropPath], (stdout2, exitCode2) => {
@@ -690,9 +692,13 @@ DankModal {
                                 ToastService.showInfo(I18n.tr("QR Scan: No QR code detected"));
                             }
                         }
+                    } else if (exitCode2 === 4) {
+                        if (typeof ToastService !== "undefined" && ToastService) {
+                            ToastService.showInfo(I18n.tr("QR Scan: No QR code detected"));
+                        }
                     } else {
                         if (typeof ToastService !== "undefined" && ToastService) {
-                            ToastService.showError(I18n.tr("QR Scan failed or no QR code found"));
+                            ToastService.showError(I18n.tr("QR Scan failed or command execution error"));
                         }
                     }
                     window.currentTool = window.lastActiveTool;

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ binds {
 ## Roadmap
 
 - [x] OCR (Optical Character Recognition) text scanner
-- [ ] QR Code Scanner
+- [x] QR Code Scanner
 - [ ] Canvas Color Picker
 - [ ] Image Filters (Grayscale, negative, brightness/contrast)
 - [ ] Image Backdrop Mode: Support setting a custom image file as the screenshot background

--- a/components/MoreToolsMenu.qml
+++ b/components/MoreToolsMenu.qml
@@ -23,6 +23,7 @@ Rectangle {
     signal rotateRequested()
     signal mirrorRequested()
     signal ocrRequested()
+    signal qrScanRequested()
 
     states: [
         State {
@@ -178,6 +179,47 @@ Rectangle {
                 onClicked: {
                     menuRoot.close();
                     menuRoot.ocrRequested();
+                }
+            }
+        }
+
+        // QR Scanner Option
+        Rectangle {
+            width: parent.width
+            height: 32
+            radius: Theme.cornerRadius - 2
+            color: qrMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+
+            Row {
+                anchors.fill: parent
+                anchors.leftMargin: Theme.spacingS
+                anchors.rightMargin: Theme.spacingS
+                spacing: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+
+                DankIcon {
+                    name: "qr_code"
+                    size: 16
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                StyledText {
+                    text: qsTr("Scan QR")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            MouseArea {
+                id: qrMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    menuRoot.close();
+                    menuRoot.qrScanRequested();
                 }
             }
         }


### PR DESCRIPTION
### What
- Integrate a QR Code Scanner tool into the screenshot annotation modal using the `zbarimg` binary to decode QR codes in a drag-selected region.
- Add a new "Scan QR" option with a `qr_code` icon inside `MoreToolsMenu.qml`.
- Implement `runQrScan()` and `executeQrScan()` in `QuickCaptureModal.qml`, reusing the selection overlay rendering of the OCR tool.
- Copy decoded text directly to the clipboard natively using `DMSService.sendRequest` and show a toast notification.
- Update `README.md` to check off the QR Code Scanner item under the roadmap.

### Why
- Provides native, local QR code scanning capability on screenshots without requiring external dependencies (other than `zbar`).
- Parallels the OCR tool structure, keeping the implementation lightweight and secure.

### How tested
- Verified QML linting has no syntax errors.
- Triggered plugin reloading in DMS and manually verified the region drag-selection rendering and scanning functionality.

## Summary by Sourcery

Add a QR code scanning tool to the quick capture modal and expose it via the More Tools menu, enabling region-based QR decoding on screenshots with clipboard integration and user feedback.

New Features:
- Introduce a QR scan tool that lets users drag-select a region of the screenshot to decode QR codes locally.
- Expose a "Scan QR" option with a QR icon in the More Tools menu wired into the quick capture modal workflow.

Enhancements:
- Integrate QR scan mode into existing selection overlay, input handling, and escape-to-cancel flows alongside the OCR tool.
- Automatically copy decoded QR content to the clipboard and show success or error toasts based on scan results.

Documentation:
- Update the README roadmap to mark the QR Code Scanner feature as completed.