### PR TITLE
Add support for replacing with last two digits of the year

### DIFF
--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -395,7 +395,7 @@ PluginSettings {
         }
 
         InfoText {
-            text: I18n.tr("Supports formatting: %Y (Year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)")
+            text: I18n.tr("Supports formatting: %Y (Year), %y (Last 2 digits of the year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)")
             opacity: 0.85
         }
 
@@ -1797,7 +1797,7 @@ PluginSettings {
         }
 
         InfoText {
-            text: I18n.tr("Supports formatting: {user} (Username), \\n (New Line), %Y (Year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)")
+            text: I18n.tr("Supports formatting: {user} (Username), \\n (New Line), %Y (Year), %y (Last 2 digits of the year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)")
             opacity: 0.85
             visible: enableWatermark.value && (watermarkType.value === "text" || watermarkType.value === "hybrid")
             height: visible ? implicitHeight : 0

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -1730,7 +1730,7 @@ PluginSettings {
             options: [
                 { label: I18n.tr("Text"), value: "text" },
                 { label: I18n.tr("Image"), value: "image" },
-                { label: I18n.tr("Hybrid"), value: "hybrid" }
+                { label: I18n.tr("Image + Text"), value: "hybrid" }
             ]
             defaultValue: "text"
             visible: enableWatermark.value

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -192,7 +192,7 @@ function formatWatermarkText(pattern, Quickshell) {
     };
 
     const yyyy = now.getFullYear();
-    const yy = yyyy % 100;
+    const yy = pad(yyyy % 100);
     const MM = pad(now.getMonth() + 1);
     const dd = pad(now.getDate());
     const HH = pad(now.getHours());

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -192,6 +192,7 @@ function formatWatermarkText(pattern, Quickshell) {
     };
 
     const yyyy = now.getFullYear();
+    const yy = yyyy % 100;
     const MM = pad(now.getMonth() + 1);
     const dd = pad(now.getDate());
     const HH = pad(now.getHours());
@@ -205,6 +206,7 @@ function formatWatermarkText(pattern, Quickshell) {
         .replace(/\{user\}/gi, username)
         .replace(/\{username\}/gi, username)
         .replace(/%Y/g, yyyy)
+        .replace(/%y/g, yy)
         .replace(/%m/g, MM)
         .replace(/%d/g, dd)
         .replace(/%H/g, HH)

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -31,6 +31,7 @@ QtObject {
         };
 
         const yyyy = now.getFullYear();
+        const yy = yyyy % 1000
         const MM = pad(now.getMonth() + 1);
         const dd = pad(now.getDate());
         const HH = pad(now.getHours());
@@ -40,6 +41,7 @@ QtObject {
 
         let filename = pattern
             .replace(/%Y/g, yyyy)
+            .replace(/%y/g, yy)
             .replace(/%m/g, MM)
             .replace(/%d/g, dd)
             .replace(/%H/g, HH)

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -31,7 +31,7 @@ QtObject {
         };
 
         const yyyy = now.getFullYear();
-        const yy = yyyy % 1000
+        const yy = pad(yyyy % 100);
         const MM = pad(now.getMonth() + 1);
         const dd = pad(now.getDate());
         const HH = pad(now.getHours());


### PR DESCRIPTION
Very simple addition that adds support for replacing %y with the last 2 digits of the year
example: %y becomes 26
I chose %y as its the same as the date command and i think that format is mostly followed by the filename pattern replacements?

## Summary by Sourcery

Add support for using %y as a two-digit year placeholder in filename and watermark formatting patterns.

New Features:
- Allow filename patterns to use %y to insert the last two digits of the current year.
- Allow watermark text patterns to use %y to insert the last two digits of the current year.

Documentation:
- Document the new %y (last two digits of the year) placeholder in the quick capture and watermark formatting help text.