### PR TITLE
feat(settings): add option to select monitor for displaying annotation modal

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,7 +18,7 @@ body:
     id: plugin_version
     attributes:
       label: Quick Capture Plugin Version
-      placeholder: e.g. 2.7.4
+      placeholder: e.g. 2.7.5
     validations:
       required: true
   - type: input

--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -205,4 +205,5 @@ QtObject {
     }
 
     function formatWatermarkText(pattern) { return Helpers.formatWatermarkText(pattern, Quickshell); }
+    readonly property string modalDisplayTarget: pluginData["modalDisplayTarget"] || "focused"
 }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -719,22 +719,30 @@ DankModal {
     shouldBeVisible: false
     
     // Spacious modal dimensions occupying 90% width and 90% height of the screen
-    modalWidth: Math.round(window.screenWidth * 0.9)
-    modalHeight: Math.round(window.screenHeight * 0.9)
+    modalWidth: Math.round((window.targetScreen ? window.targetScreen.width : (Quickshell.screens[0] ? Quickshell.screens[0].width : 1920)) * 0.9)
+    modalHeight: Math.round((window.targetScreen ? window.targetScreen.height : (Quickshell.screens[0] ? Quickshell.screens[0].height : 1080)) * 0.9)
     enableShadow: true
     positioning: "center"
 
     targetScreen: {
         const mode = config.modalDisplayTarget;
+        const fallback = (Quickshell.screens && Quickshell.screens.length > 0) ? Quickshell.screens[0] : null;
         if (mode === "focused") {
-            return CompositorService.getFocusedScreen() ?? Quickshell.screens[0];
+            return CompositorService.getFocusedScreen() ?? fallback;
         }
         if (mode === "primary") {
-            return Quickshell.screens[0];
+            return fallback;
         }
-        // Specific screen name matching
-        const found = Array.from(Quickshell.screens.values()).find(s => s.name === mode);
-        return found ?? (CompositorService.getFocusedScreen() ?? Quickshell.screens[0]);
+        // Specific screen name matching with defensive check
+        if (Quickshell.screens) {
+            for (let i = 0; i < Quickshell.screens.length; i++) {
+                const s = Quickshell.screens[i];
+                if (s && s.name === mode) {
+                    return s;
+                }
+            }
+        }
+        return (CompositorService.getFocusedScreen() ?? fallback);
     }
 
     // Component scope bridging properties

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -719,10 +719,23 @@ DankModal {
     shouldBeVisible: false
     
     // Spacious modal dimensions occupying 90% width and 90% height of the screen
-    modalWidth: Math.round(Quickshell.screens[0].width * 0.9)
-    modalHeight: Math.round(Quickshell.screens[0].height * 0.9)
+    modalWidth: Math.round(window.screenWidth * 0.9)
+    modalHeight: Math.round(window.screenHeight * 0.9)
     enableShadow: true
     positioning: "center"
+
+    targetScreen: {
+        const mode = config.modalDisplayTarget;
+        if (mode === "focused") {
+            return CompositorService.getFocusedScreen() ?? Quickshell.screens[0];
+        }
+        if (mode === "primary") {
+            return Quickshell.screens[0];
+        }
+        // Specific screen name matching
+        const found = Array.from(Quickshell.screens.values()).find(s => s.name === mode);
+        return found ?? (CompositorService.getFocusedScreen() ?? Quickshell.screens[0]);
+    }
 
     // Component scope bridging properties
     property string bgImageSource: ""

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -728,8 +728,7 @@ PluginSettings {
             label: I18n.tr("Modal Display Screen")
             options: {
                 const list = [
-                    { label: I18n.tr("Focused Screen"), value: "focused" },
-                    { label: I18n.tr("Primary Screen (Index 0)"), value: "primary" }
+                    { label: I18n.tr("Focused Screen"), value: "focused" }
                 ];
                 if (Quickshell.screens) {
                     for (let i = 0; i < Quickshell.screens.length; i++) {

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -713,13 +713,37 @@ PluginSettings {
         SectionTitle {
             text: I18n.tr("Styles")
             icon: "aspect_ratio"
-            showReset: modalOpacity.isDirty || showCanvasBorder.isDirty || editQuality.isDirty
+            showReset: modalOpacity.isDirty || showCanvasBorder.isDirty || editQuality.isDirty || modalDisplayTarget.isDirty
             onResetClicked: {
                 modalOpacity.resetToDefault();
                 showCanvasBorder.resetToDefault();
                 editQuality.resetToDefault();
+                modalDisplayTarget.resetToDefault();
             }
         }
+
+        SelectionSettingPlus {
+            id: modalDisplayTarget
+            settingKey: "modalDisplayTarget"
+            label: I18n.tr("Modal Display Screen")
+            options: {
+                const list = [
+                    { label: I18n.tr("Focused Screen"), value: "focused" },
+                    { label: I18n.tr("Primary Screen (Index 0)"), value: "primary" }
+                ];
+                for (let i = 0; i < Quickshell.screens.length; i++) {
+                    const scr = Quickshell.screens[i];
+                    list.push({
+                        label: I18n.tr("Screen: %1 (%2x%3)").arg(scr.name).arg(scr.width).arg(scr.height),
+                        value: scr.name
+                    });
+                }
+                return list;
+            }
+            defaultValue: "focused"
+        }
+
+        Separator {}
 
         SliderSettingPlus {
             id: modalOpacity

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -731,12 +731,16 @@ PluginSettings {
                     { label: I18n.tr("Focused Screen"), value: "focused" },
                     { label: I18n.tr("Primary Screen (Index 0)"), value: "primary" }
                 ];
-                for (let i = 0; i < Quickshell.screens.length; i++) {
-                    const scr = Quickshell.screens[i];
-                    list.push({
-                        label: I18n.tr("Screen: %1 (%2x%3)").arg(scr.name).arg(scr.width).arg(scr.height),
-                        value: scr.name
-                    });
+                if (Quickshell.screens) {
+                    for (let i = 0; i < Quickshell.screens.length; i++) {
+                        const scr = Quickshell.screens[i];
+                        if (scr) {
+                            list.push({
+                                label: I18n.tr("Screen: %1 (%2x%3)").arg(scr.name).arg(scr.width).arg(scr.height),
+                                value: scr.name
+                            });
+                        }
+                    }
                 }
                 return list;
             }

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -10,7 +10,7 @@ DMS Quick Capture is an interactive vector annotation and screenshot utility for
 
 - **Plugin ID:** `quickCapture`
 - **Plugin Type:** `composite` (bundles background daemon, bar widget, settings UI)
-- **Current Version:** `2.7.4` (see [plugin.json](file:///home/loccun/Documents/GitHub/dms-quick-capture/plugin.json))
+- **Current Version:** `2.7.5` (see [plugin.json](file:///home/loccun/Documents/GitHub/dms-quick-capture/plugin.json))
 
 ### Core Components Map
 

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "id": "quickCapture",
     "name": "Quick Capture",
     "description": "Instant screenshot and overlay annotation utility for Wayland",
-    "version": "2.7.4",
+    "version": "2.7.5",
     "author": "Loc Huynh",
     "icon": "screenshot_region",
     "type": "composite",


### PR DESCRIPTION
Closes #55 

### What
- Add `modalDisplayTarget` setting property in `CaptureConfig.qml`.
- Update `QuickCaptureModal.qml` to calculate modal size based on `window.screenWidth` / `window.screenHeight` (resolving dynamic display scale).
- Configure the `targetScreen` property in `QuickCaptureModal.qml` to evaluate and return the desired Quickshell screen target based on the selected setting (either Focused screen, Primary screen index 0, or a specific screen name matching).
- Add a new dynamic monitor selection dropdown setting `Modal Display Screen` (`modalDisplayTarget` key) inside the interface styles section of `QuickCaptureSettings.qml`, populated on-the-fly with the names and resolutions of all connected screens via `Quickshell.screens`.

### Why
- Fixes layout issues on multi-monitor setups where modal sizing was previously locked to `screens[0]` dimensions.
- Gives power-users explicit control to choose where they want the annotation interface to display.

### How tested
- Verified QML files compile cleanly.
- Manually verified UI rendering of the new setting dropdown in the settings card.

## Summary by Sourcery

Add configurable monitor targeting for the quick capture annotation modal and update its sizing to respect the active screen’s dimensions.

New Features:
- Introduce a Modal Display Screen setting that lets users choose which monitor displays the annotation modal, including focused, primary, or a specific screen by name.

Enhancements:
- Derive quick capture modal dimensions from the active window’s screen size instead of always using the primary screen, improving behavior on multi-monitor setups.
- Expose modalDisplayTarget in capture configuration so modal screen selection is driven by plugin settings.