### PR TITLE
fix(text): optimize text hitbox using character proportional width estimation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,7 +18,7 @@ body:
     id: plugin_version
     attributes:
       label: Quick Capture Plugin Version
-      placeholder: e.g. 2.7.5
+      placeholder: e.g. 2.7.6
     validations:
       required: true
   - type: input

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -979,9 +979,51 @@ DankModal {
                 if (dist <= radius) return i;
             } else if (stroke.tool === "text") {
                 const p0 = stroke.points[0];
-                const h = stroke.width * 4 + 10;
-                const w = Math.max(40, stroke.text.length * stroke.width * 2 + 10);
-                if (mx >= p0.x - 5 && mx <= p0.x + w && my >= p0.y - 5 && my <= p0.y + h) {
+                const isMonospace = stroke.isMonospace === true;
+                const isBold = stroke.isBold === true;
+                const fontSize = stroke.width;
+
+                // Character-by-character proportional font width estimation
+                let estWidth = 0;
+                const txt = stroke.text || "";
+                let charWidthRatio = isMonospace ? 0.6 : 0.52;
+                if (isBold) charWidthRatio += 0.05;
+
+                for (let c = 0; c < txt.length; c++) {
+                    const charCode = txt.charCodeAt(c);
+                    if (charCode > 255) {
+                        estWidth += fontSize * 0.85;
+                    } else if (isMonospace) {
+                        estWidth += fontSize * charWidthRatio;
+                    } else {
+                        const char = txt.charAt(c);
+                        if (/[iIlldt1|()\[\]{}]/.test(char)) {
+                            estWidth += fontSize * 0.28;
+                        } else if (/[mwMW]/.test(char)) {
+                            estWidth += fontSize * 0.8;
+                        } else if (/[A-Z]/.test(char)) {
+                            estWidth += fontSize * 0.65;
+                        } else {
+                            estWidth += fontSize * charWidthRatio;
+                        }
+                    }
+                }
+
+                let textW = Math.max(40, estWidth);
+                let textH = fontSize;
+                let textY = p0.y;
+                let textX = p0.x;
+
+                if (stroke.hasBackground) {
+                    const padX = fontSize * 0.3;
+                    const padY = fontSize * 0.15;
+                    textX -= padX;
+                    textY -= padY;
+                    textW += padX * 2;
+                    textH += padY * 2;
+                }
+
+                if (mx >= textX - 8 && mx <= textX + textW + 8 && my >= textY - 8 && my <= textY + textH + 8) {
                     return i;
                 }
             } else if (stroke.tool === "callout" && stroke.points.length === 4) {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -905,6 +905,54 @@ DankModal {
         return Helpers.constrainSquarePoint(start, point, Qt);
     }
 
+    function estimateTextWidth(text, fontSize, isBold, isMonospace) {
+        if (!text) return 0;
+        let charWidthRatio = isMonospace ? 0.6 : 0.52;
+        if (isBold) charWidthRatio += 0.05;
+
+        let estWidth = 0;
+        for (let c = 0; c < text.length; c++) {
+            const charCode = text.charCodeAt(c);
+            if (charCode > 255) {
+                // Treat known CJK and related ranges as wide; fall back to proportional width
+                const isCJKOrWideScript =
+                        // CJK Unified Ideographs
+                        (charCode >= 0x3400 && charCode <= 0x4DBF) ||
+                        (charCode >= 0x4E00 && charCode <= 0x9FFF) ||
+                        (charCode >= 0xF900 && charCode <= 0xFAFF) ||
+                        // Hiragana
+                        (charCode >= 0x3040 && charCode <= 0x309F) ||
+                        // Katakana
+                        (charCode >= 0x30A0 && charCode <= 0x30FF) ||
+                        // Hangul syllables
+                        (charCode >= 0xAC00 && charCode <= 0xD7AF);
+
+                if (isCJKOrWideScript) {
+                    estWidth += fontSize * 0.9;
+                } else {
+                    // Non-ASCII but not CJK (e.g. accented Latin/Vietnamese diacritics): proportional width
+                    estWidth += fontSize * charWidthRatio;
+                }
+            } else if (isMonospace) {
+                estWidth += fontSize * charWidthRatio;
+            } else {
+                const char = text.charAt(c);
+                if ("iIlldt1|()[]{}".indexOf(char) !== -1) {
+                    estWidth += fontSize * 0.28;
+                } else if ("mwMW".indexOf(char) !== -1) {
+                    estWidth += fontSize * 0.8;
+                } else if (char >= "A" && char <= "Z") {
+                    estWidth += fontSize * 0.65;
+                } else {
+                    estWidth += fontSize * charWidthRatio;
+                }
+            }
+        }
+
+        const maxW = fontSize * text.length * (isMonospace ? 1.2 : 1.6);
+        return Math.min(estWidth, maxW);
+    }
+
     function findStrokeAt(mx, my) {
         for (let i = window.strokes.length - 1; i >= 0; i--) {
             const stroke = window.strokes[i];
@@ -979,37 +1027,10 @@ DankModal {
                 if (dist <= radius) return i;
             } else if (stroke.tool === "text") {
                 const p0 = stroke.points[0];
-                const isMonospace = stroke.isMonospace === true;
-                const isBold = stroke.isBold === true;
                 const fontSize = stroke.width;
-
-                // Character-by-character proportional font width estimation
-                let estWidth = 0;
                 const txt = stroke.text || "";
-                let charWidthRatio = isMonospace ? 0.6 : 0.52;
-                if (isBold) charWidthRatio += 0.05;
 
-                for (let c = 0; c < txt.length; c++) {
-                    const charCode = txt.charCodeAt(c);
-                    if (charCode > 255) {
-                        estWidth += fontSize * 0.85;
-                    } else if (isMonospace) {
-                        estWidth += fontSize * charWidthRatio;
-                    } else {
-                        const char = txt.charAt(c);
-                        if (/[iIlldt1|()\[\]{}]/.test(char)) {
-                            estWidth += fontSize * 0.28;
-                        } else if (/[mwMW]/.test(char)) {
-                            estWidth += fontSize * 0.8;
-                        } else if (/[A-Z]/.test(char)) {
-                            estWidth += fontSize * 0.65;
-                        } else {
-                            estWidth += fontSize * charWidthRatio;
-                        }
-                    }
-                }
-
-                let textW = Math.max(40, estWidth);
+                let textW = Math.max(40, window.estimateTextWidth(txt, fontSize, stroke.isBold === true, stroke.isMonospace === true));
                 let textH = fontSize;
                 let textY = p0.y;
                 let textX = p0.x;

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -10,7 +10,7 @@ DMS Quick Capture is an interactive vector annotation and screenshot utility for
 
 - **Plugin ID:** `quickCapture`
 - **Plugin Type:** `composite` (bundles background daemon, bar widget, settings UI)
-- **Current Version:** `2.7.5` (see [plugin.json](file:///home/loccun/Documents/GitHub/dms-quick-capture/plugin.json))
+- **Current Version:** `2.7.6` (see [plugin.json](file:///home/loccun/Documents/GitHub/dms-quick-capture/plugin.json))
 
 ### Core Components Map
 

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "id": "quickCapture",
     "name": "Quick Capture",
     "description": "Instant screenshot and overlay annotation utility for Wayland",
-    "version": "2.7.5",
+    "version": "2.7.6",
     "author": "Loc Huynh",
     "icon": "screenshot_region",
     "type": "composite",


### PR DESCRIPTION
### What
- Optimize the text annotation hit-box logic inside `findStrokeAt` in `QuickCaptureModal.qml`.
- Implement a character-by-character proportional font width estimation method that evaluates styles (monospace, bold, and thin/wide characters) dynamically.
- Limit the grab height to exactly the font size and add background padding dynamically if `stroke.hasBackground` is active.
- Bind the click grab area to a comfortable offset of 8 pixels around the exact text boundaries.

### Why
- Fixes the bug where text selection hit-boxes were over-expanded (hardcoded to `stroke.width * 4 + 10` height and double font size width), making empty spaces behind the text interactively grab-able.

### How tested
- Verified QML compiles cleanly.
- Manually tested that text selection matches the exact visual boundaries of the text notes.

## Summary by Sourcery

Tighten text annotation hit-box detection in QuickCaptureModal to better match rendered text.

Bug Fixes:
- Resolve overly large text selection hit-boxes that allowed empty surrounding areas to be interactively grabbed.

Enhancements:
- Estimate text width using character-by-character proportional metrics that account for monospace, bold, and varying character widths, and align hit-box height with font size and optional background padding.