### PR TITLE
feat: implement canvas color picker (eyedropper) tool

### DIFF
--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -18,7 +18,6 @@ QtObject {
         { id: "stamp", icon: "looks_one", tooltip: qsTr("Number Stamp (A)") },
         { id: "highlighter", icon: "border_color", tooltip: qsTr("Highlighter (S)") },
         { id: "eraser", icon: "auto_fix_normal", tooltip: qsTr("Eraser (D)") },
-        { id: "colorpicker", icon: "colorize", tooltip: qsTr("Color Picker (I)") },
         { id: "spotlight", icon: "highlight", tooltip: qsTr("Focus Spotlight (F)") },
         { id: "callout", icon: "zoom_in", tooltip: qsTr("Area Zoom (Z) | Hold G for Loupe") },
         { id: "backdrop", icon: "wallpaper", tooltip: qsTr("Image Backdrop (B)") }

--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -18,6 +18,7 @@ QtObject {
         { id: "stamp", icon: "looks_one", tooltip: qsTr("Number Stamp (A)") },
         { id: "highlighter", icon: "border_color", tooltip: qsTr("Highlighter (S)") },
         { id: "eraser", icon: "auto_fix_normal", tooltip: qsTr("Eraser (D)") },
+        { id: "colorpicker", icon: "colorize", tooltip: qsTr("Color Picker (I)") },
         { id: "spotlight", icon: "highlight", tooltip: qsTr("Focus Spotlight (F)") },
         { id: "callout", icon: "zoom_in", tooltip: qsTr("Area Zoom (Z) | Hold G for Loupe") },
         { id: "backdrop", icon: "wallpaper", tooltip: qsTr("Image Backdrop (B)") }
@@ -165,6 +166,7 @@ QtObject {
         { key: "A", tool: "stamp" },
         { key: "S", tool: "highlighter" },
         { key: "D", tool: "eraser" },
+        { key: "I", tool: "colorpicker" },
         { key: "F", tool: "spotlight" },
         { key: "Z", tool: "callout" },
         { key: "B", tool: "backdrop" }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1106,9 +1106,9 @@ DankModal {
     function sampleCanvasColor(mouseX, mouseY) {
         if (!window.activeCanvas) return window.currentColor;
         
-        // Clamp and round coordinates to prevent out-of-bounds errors and ensure integer coordinates
-        var x = Math.max(0, Math.min(Math.floor(mouseX), window.activeCanvas.width - 1));
-        var y = Math.max(0, Math.min(Math.floor(mouseY), window.activeCanvas.height - 1));
+        // Clamp and round coordinates to prevent out-of-bounds errors and ensure integer coordinates in device pixels
+        var x = Math.max(0, Math.min(Math.floor(mouseX * window.dpr), Math.floor(window.activeCanvas.width * window.dpr) - 1));
+        var y = Math.max(0, Math.min(Math.floor(mouseY * window.dpr), Math.floor(window.activeCanvas.height * window.dpr) - 1));
         
         // Performance optimization: skip sampling if the pixel coordinates haven't changed
         if (window._lastSampledX === x && window._lastSampledY === y) {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2778,9 +2778,9 @@ DankModal {
 
                     Rectangle {
                         id: magnifier
-                        width: 140
-                        height: 140
-                        radius: 70
+                        width: 160
+                        height: 160
+                        radius: 80
                         border.color: Theme.primary
                         border.width: 2
                         color: "black"
@@ -2893,7 +2893,7 @@ DankModal {
                             anchors.bottom: parent.bottom
                             anchors.left: parent.left
                             anchors.right: parent.right
-                            height: 48
+                            height: 56
                             color: Theme.withAlpha(Theme.surfaceContainer, 0.9)
                             border.color: Theme.withAlpha(Theme.outline, 0.15)
                             border.width: 1
@@ -2904,9 +2904,9 @@ DankModal {
 
                                 // Color preview swatch
                                 Rectangle {
-                                    width: 16
-                                    height: 16
-                                    radius: 4
+                                    width: 20
+                                    height: 20
+                                    radius: 5
                                     color: window.hoveredColor
                                     border.color: Theme.withAlpha(Theme.outline, 0.3)
                                     border.width: 1
@@ -2919,7 +2919,7 @@ DankModal {
 
                                     StyledText {
                                         text: window.formatHexColor(window.hoveredColor).toUpperCase()
-                                        font.pixelSize: 10
+                                        font.pixelSize: 12
                                         font.bold: true
                                         color: Theme.surfaceText
                                     }
@@ -2931,7 +2931,7 @@ DankModal {
                                             var b = Math.round((window.hoveredColor.b || 0) * 255);
                                             return "RGB: " + r + "," + g + "," + b;
                                         }
-                                        font.pixelSize: 8
+                                        font.pixelSize: 9
                                         color: Theme.surfaceVariantText
                                     }
                                 }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -55,6 +55,9 @@ DankModal {
     property string lastActiveTool: "pen"
     property string colorPickerMode: "draw" // draw, copy
     property color hoveredColor: "transparent"
+    property int _lastSampledX: -1
+    property int _lastSampledY: -1
+    property color _lastSampledColor: "transparent"
     readonly property real dpr: Screen.devicePixelRatio || 1.0
     onCurrentToolChanged: {
         if (currentTool !== "text" && window.isTyping) {
@@ -62,6 +65,12 @@ DankModal {
         }
         if (currentTool !== "crop" && currentTool !== "backdrop" && currentTool !== "select" && currentTool !== "colorpicker") {
             lastActiveTool = currentTool;
+        }
+        if (currentTool === "colorpicker") {
+            window._lastSampledX = -1;
+            window._lastSampledY = -1;
+            window._lastSampledColor = "transparent";
+            window.hoveredColor = window.sampleCanvasColor(window.cursorX * window.editScale, window.cursorY * window.editScale);
         }
         if (currentTool === "backdrop" && window.backdropMode === "none") {
             window.backdropMode = "solid";
@@ -1084,17 +1093,52 @@ DankModal {
 
     function shortcutToken(key) { return Helpers.shortcutToken(key, Qt); }
 
+    function formatHexColor(color) {
+        var r = Math.round(color.r * 255).toString(16);
+        if (r.length < 2) r = "0" + r;
+        var g = Math.round(color.g * 255).toString(16);
+        if (g.length < 2) g = "0" + g;
+        var b = Math.round(color.b * 255).toString(16);
+        if (b.length < 2) b = "0" + b;
+        return "#" + r + g + b;
+    }
+
     function sampleCanvasColor(mouseX, mouseY) {
         if (!window.activeCanvas) return window.currentColor;
+        
+        // Clamp and round coordinates to prevent out-of-bounds errors and ensure integer coordinates
+        var x = Math.max(0, Math.min(Math.floor(mouseX), window.activeCanvas.width - 1));
+        var y = Math.max(0, Math.min(Math.floor(mouseY), window.activeCanvas.height - 1));
+        
+        // Performance optimization: skip sampling if the pixel coordinates haven't changed
+        if (window._lastSampledX === x && window._lastSampledY === y) {
+            return window._lastSampledColor || window.currentColor;
+        }
+        
         try {
             var ctx = window.activeCanvas.getContext("2d");
-            var imgData = ctx.getImageData(mouseX, mouseY, 1, 1);
+            if (!ctx) return window.currentColor;
+            
+            var imgData = ctx.getImageData(x, y, 1, 1);
             if (imgData && imgData.data && imgData.data.length >= 4) {
                 var r = imgData.data[0];
                 var g = imgData.data[1];
                 var b = imgData.data[2];
                 var a = imgData.data[3];
-                return Qt.rgba(r / 255, g / 255, b / 255, a / 255);
+                
+                var pickedColor;
+                if (a === 0) {
+                    pickedColor = window.currentColor;
+                } else {
+                    // Force alpha to 1.0 to ensure we always sample an opaque color.
+                    pickedColor = Qt.rgba(r / 255, g / 255, b / 255, 1.0);
+                }
+                
+                window._lastSampledX = x;
+                window._lastSampledY = y;
+                window._lastSampledColor = pickedColor;
+                
+                return pickedColor;
             }
         } catch (e) {
             console.warn("Color picker failed to sample pixel color:", e);
@@ -2237,7 +2281,7 @@ DankModal {
                                  if (window.currentTool === "colorpicker") {
                                      if (mouse.button === Qt.LeftButton) {
                                          const pickedColor = window.sampleCanvasColor(mouse.x, mouse.y);
-                                         const hexStr = pickedColor.toString().toUpperCase();
+                                         const hexStr = window.formatHexColor(pickedColor).toUpperCase();
                                          if (window.colorPickerMode === "copy") {
                                              Quickshell.execDetached(["dms", "cl", "copy", hexStr]);
                                              if (typeof ToastService !== "undefined" && ToastService) {
@@ -2837,7 +2881,7 @@ DankModal {
                         // Color details banner at the bottom of the magnifier
                         Rectangle {
                             id: colorInfoBanner
-                            visible: window.currentTool === "colorpicker"
+                            visible: window.currentTool === "colorpicker" && window.hoveredColor !== Qt.color("transparent")
                             anchors.bottom: parent.bottom
                             anchors.left: parent.left
                             anchors.right: parent.right
@@ -2866,7 +2910,7 @@ DankModal {
                                     spacing: 0
 
                                     StyledText {
-                                        text: window.hoveredColor.toString().toUpperCase()
+                                        text: window.formatHexColor(window.hoveredColor).toUpperCase()
                                         font.pixelSize: 8
                                         font.bold: true
                                         color: Theme.surfaceText
@@ -2874,9 +2918,9 @@ DankModal {
 
                                     StyledText {
                                         text: {
-                                            var r = Math.round(window.hoveredColor.r * 255);
-                                            var g = Math.round(window.hoveredColor.g * 255);
-                                            var b = Math.round(window.hoveredColor.b * 255);
+                                            var r = Math.round((window.hoveredColor.r || 0) * 255);
+                                            var g = Math.round((window.hoveredColor.g || 0) * 255);
+                                            var b = Math.round((window.hoveredColor.b || 0) * 255);
                                             return "RGB: " + r + "," + g + "," + b;
                                         }
                                         font.pixelSize: 7

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -53,12 +53,14 @@ DankModal {
     // State Variables
     property string currentTool: "crop" // crop, select, pen, line, arrow, rect, ellipse, text, pixelate, redact, stamp, highlighter, eraser, spotlight, backdrop
     property string lastActiveTool: "pen"
+    property string colorPickerMode: "draw" // draw, copy
+    property color hoveredColor: "transparent"
     readonly property real dpr: Screen.devicePixelRatio || 1.0
     onCurrentToolChanged: {
         if (currentTool !== "text" && window.isTyping) {
             window.commitTypingText();
         }
-        if (currentTool !== "crop" && currentTool !== "backdrop" && currentTool !== "select") {
+        if (currentTool !== "crop" && currentTool !== "backdrop" && currentTool !== "select" && currentTool !== "colorpicker") {
             lastActiveTool = currentTool;
         }
         if (currentTool === "backdrop" && window.backdropMode === "none") {
@@ -1082,6 +1084,24 @@ DankModal {
 
     function shortcutToken(key) { return Helpers.shortcutToken(key, Qt); }
 
+    function sampleCanvasColor(mouseX, mouseY) {
+        if (!window.activeCanvas) return window.currentColor;
+        try {
+            var ctx = window.activeCanvas.getContext("2d");
+            var imgData = ctx.getImageData(mouseX, mouseY, 1, 1);
+            if (imgData && imgData.data && imgData.data.length >= 4) {
+                var r = imgData.data[0];
+                var g = imgData.data[1];
+                var b = imgData.data[2];
+                var a = imgData.data[3];
+                return Qt.rgba(r / 255, g / 255, b / 255, a / 255);
+            }
+        } catch (e) {
+            console.warn("Color picker failed to sample pixel color:", e);
+        }
+        return window.currentColor;
+    }
+
     function shortcutColor(color) {
         return color === "primary" ? Theme.primary : color;
     }
@@ -1210,10 +1230,13 @@ DankModal {
         const toolShortcut = config.findByKey(config.toolShortcuts, token);
         if (toolShortcut) {
             if (window.currentTool === toolShortcut.tool) {
-                if (toolShortcut.tool === "backdrop" || toolShortcut.tool === "crop") {
+                if (toolShortcut.tool === "backdrop" || toolShortcut.tool === "crop" || toolShortcut.tool === "colorpicker") {
                     window.currentTool = window.lastActiveTool;
                 }
             } else {
+                if (toolShortcut.tool === "colorpicker") {
+                    window.colorPickerMode = "draw";
+                }
                 window.currentTool = toolShortcut.tool;
             }
             event.accepted = true;
@@ -1523,6 +1546,12 @@ DankModal {
                             window.currentTool = window.lastActiveTool;
                         } else if (tool === "crop" && window.currentTool === "crop") {
                             window.currentTool = window.lastActiveTool;
+                        } else if (tool === "colorpicker-draw") {
+                            window.colorPickerMode = "draw";
+                            window.currentTool = "colorpicker";
+                        } else if (tool === "colorpicker-copy") {
+                            window.colorPickerMode = "copy";
+                            window.currentTool = "colorpicker";
                         } else {
                             window.currentTool = tool;
                         }
@@ -1959,10 +1988,13 @@ DankModal {
                             property string hoveredHandle: "none"
                             property int hoveredStrokeIdx: -1
                             onPositionChanged: (mouse) => {
-                                const origX = mouse.x / window.editScale;
-                                const origY = mouse.y / window.editScale;
-                                window.cursorX = origX;
-                                window.cursorY = origY;
+                                 const origX = mouse.x / window.editScale;
+                                 const origY = mouse.y / window.editScale;
+                                 window.cursorX = origX;
+                                 window.cursorY = origY;
+                                 if (window.currentTool === "colorpicker") {
+                                     window.hoveredColor = window.sampleCanvasColor(mouse.x, mouse.y);
+                                 };
                                 hoveredHandle = window.getHoveredHandle(origX, origY);
 
                                 const absPt = getAbsolutePoint(mouse.x, mouse.y);
@@ -2094,6 +2126,9 @@ DankModal {
                             cursorShape: {
                                 if (hoveredHandle === "tl" || hoveredHandle === "br") return Qt.SizeFDiagCursor;
                                 if (hoveredHandle === "tr" || hoveredHandle === "bl") return Qt.SizeBDiagCursor;
+                                if (window.currentTool === "colorpicker") {
+                                    return Qt.CrossCursor;
+                                }
                                 if (window.currentTool === "select") {
                                     return window.selectedStroke ? Qt.ClosedHandCursor : (drawMouseArea.hoveredStrokeIdx !== -1 ? Qt.OpenHandCursor : Qt.ArrowCursor);
                                 }
@@ -2198,6 +2233,23 @@ DankModal {
                                     }
                                     return;
                                 }
+
+                                 if (window.currentTool === "colorpicker") {
+                                     if (mouse.button === Qt.LeftButton) {
+                                         const pickedColor = window.sampleCanvasColor(mouse.x, mouse.y);
+                                         const hexStr = pickedColor.toString().toUpperCase();
+                                         if (window.colorPickerMode === "copy") {
+                                             Quickshell.execDetached(["dms", "cl", "copy", hexStr]);
+                                             if (typeof ToastService !== "undefined" && ToastService) {
+                                                 ToastService.showInfo(I18n.tr("Color copied to clipboard: %1").arg(hexStr));
+                                             }
+                                         } else {
+                                             window.currentColor = pickedColor;
+                                         }
+                                         window.currentTool = window.lastActiveTool;
+                                     }
+                                     return;
+                                 }
 
                                 if (window.currentTool === "crop") {
                                     const ox = mouse.x / window.editScale;
@@ -2680,7 +2732,7 @@ DankModal {
                         border.color: Theme.primary
                         border.width: 2
                         color: "black"
-                        visible: window.enableMagnifier && window.isZoomPressed && drawMouseArea.containsMouse
+                        visible: (window.enableMagnifier && window.isZoomPressed && drawMouseArea.containsMouse) || (window.currentTool === "colorpicker" && drawMouseArea.containsMouse)
                         z: 200
                         enabled: false
 
@@ -2780,6 +2832,58 @@ DankModal {
                             width: 1.5
                             height: 16
                             color: Theme.primary
+                        }
+
+                        // Color details banner at the bottom of the magnifier
+                        Rectangle {
+                            id: colorInfoBanner
+                            visible: window.currentTool === "colorpicker"
+                            anchors.bottom: parent.bottom
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            height: 38
+                            color: Theme.withAlpha(Theme.surfaceContainer, 0.9)
+                            border.color: Theme.withAlpha(Theme.outline, 0.15)
+                            border.width: 1
+
+                            Row {
+                                anchors.centerIn: parent
+                                spacing: Theme.spacingS
+
+                                // Color preview swatch
+                                Rectangle {
+                                    width: 12
+                                    height: 12
+                                    radius: 3
+                                    color: window.hoveredColor
+                                    border.color: Theme.withAlpha(Theme.outline, 0.3)
+                                    border.width: 1
+                                    anchors.verticalCenter: parent.verticalCenter
+                                }
+
+                                Column {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    spacing: 0
+
+                                    StyledText {
+                                        text: window.hoveredColor.toString().toUpperCase()
+                                        font.pixelSize: 8
+                                        font.bold: true
+                                        color: Theme.surfaceText
+                                    }
+
+                                    StyledText {
+                                        text: {
+                                            var r = Math.round(window.hoveredColor.r * 255);
+                                            var g = Math.round(window.hoveredColor.g * 255);
+                                            var b = Math.round(window.hoveredColor.b * 255);
+                                            return "RGB: " + r + "," + g + "," + b;
+                                        }
+                                        font.pixelSize: 7
+                                        color: Theme.surfaceVariantText
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -2999,6 +3103,10 @@ DankModal {
                     onMirrorRequested: window.mirrorScreenshot()
                     onOcrRequested: window.runOcr()
                     onQrScanRequested: window.runQrScan()
+                    onCopyColorRequested: {
+                        window.colorPickerMode = "copy";
+                        window.currentTool = "colorpicker";
+                    }
                 }
 
                 HoverSliderPopover {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2893,7 +2893,7 @@ DankModal {
                             anchors.bottom: parent.bottom
                             anchors.left: parent.left
                             anchors.right: parent.right
-                            height: 38
+                            height: 48
                             color: Theme.withAlpha(Theme.surfaceContainer, 0.9)
                             border.color: Theme.withAlpha(Theme.outline, 0.15)
                             border.width: 1
@@ -2904,9 +2904,9 @@ DankModal {
 
                                 // Color preview swatch
                                 Rectangle {
-                                    width: 12
-                                    height: 12
-                                    radius: 3
+                                    width: 16
+                                    height: 16
+                                    radius: 4
                                     color: window.hoveredColor
                                     border.color: Theme.withAlpha(Theme.outline, 0.3)
                                     border.width: 1
@@ -2919,7 +2919,7 @@ DankModal {
 
                                     StyledText {
                                         text: window.formatHexColor(window.hoveredColor).toUpperCase()
-                                        font.pixelSize: 8
+                                        font.pixelSize: 10
                                         font.bold: true
                                         color: Theme.surfaceText
                                     }
@@ -2931,7 +2931,7 @@ DankModal {
                                             var b = Math.round((window.hoveredColor.b || 0) * 255);
                                             return "RGB: " + r + "," + g + "," + b;
                                         }
-                                        font.pixelSize: 7
+                                        font.pixelSize: 8
                                         color: Theme.surfaceVariantText
                                     }
                                 }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1792,6 +1792,14 @@ DankModal {
                                 window.drawBackdropBackground(ctx, window.canvasWidth, window.canvasHeight);
                                 window.drawScreenshotShadow(ctx);
                                 window.drawScreenshotImage(ctx, bgImage);
+                            } else if (window.currentTool === "colorpicker") {
+                                if (bgImage.status === Image.Ready) {
+                                    if (window.hasSelection) {
+                                        ctx.drawImage(bgImage, window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height, 0, 0, window.canvasWidth, window.canvasHeight);
+                                    } else {
+                                        ctx.drawImage(bgImage, 0, 0, window.canvasWidth, window.canvasHeight);
+                                    }
+                                }
                             }
 
                             // 1. Draw Dimming Selection Overlay (only if in crop mode)

--- a/components/MoreToolsMenu.qml
+++ b/components/MoreToolsMenu.qml
@@ -24,6 +24,7 @@ Rectangle {
     signal mirrorRequested()
     signal ocrRequested()
     signal qrScanRequested()
+    signal copyColorRequested()
 
     states: [
         State {
@@ -220,6 +221,47 @@ Rectangle {
                 onClicked: {
                     menuRoot.close();
                     menuRoot.qrScanRequested();
+                }
+            }
+        }
+
+        // Copy Color Option
+        Rectangle {
+            width: parent.width
+            height: 32
+            radius: Theme.cornerRadius - 2
+            color: copyColorMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+
+            Row {
+                anchors.fill: parent
+                anchors.leftMargin: Theme.spacingS
+                anchors.rightMargin: Theme.spacingS
+                spacing: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+
+                DankIcon {
+                    name: "colorize"
+                    size: 16
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                StyledText {
+                    text: qsTr("Copy Color")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            MouseArea {
+                id: copyColorMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    menuRoot.close();
+                    menuRoot.copyColorRequested();
                 }
             }
         }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -174,6 +174,16 @@ Rectangle {
                 }
             }
 
+            DankActionButton {
+                iconName: "colorize"
+                buttonSize: tc.btnSize
+                iconSize: tc.iconSize
+                tooltipText: qsTr("Color Picker (I)")
+                backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
+                onClicked: root.toolSelected("colorpicker-draw")
+            }
+
             Rectangle { width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
             // Thickness Section
@@ -294,6 +304,17 @@ Rectangle {
                         MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.colorSelected(modelData) }
                     }
                 }
+            }
+
+            DankActionButton {
+                iconName: "colorize"
+                buttonSize: tc.btnSize
+                iconSize: tc.iconSize
+                tooltipText: qsTr("Color Picker (I)")
+                backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
+                anchors.horizontalCenter: parent.horizontalCenter
+                onClicked: root.toolSelected("colorpicker-draw")
             }
 
             Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "id": "quickCapture",
     "name": "Quick Capture",
     "description": "Instant screenshot and overlay annotation utility for Wayland",
-    "version": "2.7.6",
+    "version": "2.7.7",
     "author": "Loc Huynh",
     "icon": "screenshot_region",
     "type": "composite",


### PR DESCRIPTION
### What
- Implemented Canvas Color Picker (Eyedropper) tool in `dms-quick-capture`.
- Added color selection button to the toolbar for picking the drawing color, and a "Copy Color" option to the "More Tools" menu for copying the color code.
- Integrated a real-time magnifying loupe (magnifier) showing a color preview swatch, Hex code, and RGB values.
- Intercepted the shortcut key `I` to toggle the color picker in drawing mode.

### Why
- Resolves the "Canvas Color Picker" item on the roadmap.

### How tested
- Checked QML layout, event interception, canvas rendering, and `getImageData` pixel extraction logic in the shell environment.

## Summary by Sourcery

Add a canvas color picker tool with draw and copy modes, integrated into the quick capture workflow and magnifier overlay.

New Features:
- Introduce a color picker tool that can sample colors from the canvas and either set the current drawing color or copy the color code.
- Add toolbar and More Tools menu entries for activating the color picker in draw or copy mode, including shortcut key I.
- Extend the magnifier overlay to show a live color swatch with Hex and RGB details while using the color picker.

Enhancements:
- Update cursor and hover behavior in drawing mode to support color sampling interaction.