### PR TITLE
feat: add line styles (dashed, dotted) and line options toolbar

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -55,6 +55,7 @@ DankModal {
     property string lastActiveTool: "pen"
     property string colorPickerMode: "draw" // draw, copy
     property color hoveredColor: "transparent"
+    property string activeLineStyle: "solid"
     property int _lastSampledX: -1
     property int _lastSampledY: -1
     property color _lastSampledColor: "transparent"
@@ -2211,6 +2212,9 @@ DankModal {
                                         } else if (window.currentTool === "text") {
                                             textOptionsToolbar.open(mapped.x, mapped.y);
                                             return;
+                                        } else if (window.currentTool === "line") {
+                                            lineOptionsToolbar.open(mapped.x, mapped.y);
+                                            return;
                                         }
                                     }
                                     radialMenu.open(mapped.x, mapped.y);
@@ -2393,7 +2397,8 @@ DankModal {
                                     tool: window.currentTool,
                                     color: window.currentColor.toString(),
                                     width: window.activeIntensity,
-                                    points: [getAbsolutePoint(mouse.x, mouse.y)]
+                                    points: [getAbsolutePoint(mouse.x, mouse.y)],
+                                    lineStyle: window.currentTool === "line" ? window.activeLineStyle : "solid"
                                 };
                                 drawingCanvas.requestPaint();
                             }
@@ -3147,6 +3152,13 @@ DankModal {
                     toolbarPosition: window.toolbarPosition
                     currentFormat: window.stampCounterFormat
                     onFormatSelected: (format) => window.stampCounterFormat = format
+                }
+
+                LineOptionsToolbar {
+                    id: lineOptionsToolbar
+                    toolbarPosition: window.toolbarPosition
+                    currentStyle: window.activeLineStyle
+                    onStyleSelected: (style) => window.activeLineStyle = style
                 }
 
                 MoreToolsMenu {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -56,6 +56,20 @@ DankModal {
     property string colorPickerMode: "draw" // draw, copy
     property color hoveredColor: "transparent"
     property string activeLineStyle: "solid"
+    onActiveLineStyleChanged: {
+        if (window.selectedStroke && window.selectedStroke.tool === "line") {
+            window.selectedStroke.lineStyle = window.activeLineStyle;
+            const idx = window.strokes.indexOf(window.selectedStroke);
+            if (idx !== -1) {
+                window.strokes[idx] = window.selectedStroke;
+                window.strokes = [...window.strokes];
+            }
+        }
+        if (window.currentStroke && window.currentStroke.tool === "line") {
+            window.currentStroke.lineStyle = window.activeLineStyle;
+        }
+        if (window.activeCanvas) window.activeCanvas.requestPaint();
+    }
     property int _lastSampledX: -1
     property int _lastSampledY: -1
     property color _lastSampledColor: "transparent"
@@ -2254,6 +2268,9 @@ DankModal {
                                         
                                         window.selectedStroke = stroke;
                                         window.currentColor = stroke.color;
+                                        if (stroke.tool === "line" && stroke.lineStyle) {
+                                            window.activeLineStyle = stroke.lineStyle;
+                                        };
 
                                         // Detection for callout destination dragging
                                         if (stroke.tool === "callout" && stroke.points.length === 4) {

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -63,7 +63,7 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         if (stroke.lineStyle === "dashed") {
             ctx.setLineDash([stroke.width * 2.5, stroke.width * 1.5]);
         } else if (stroke.lineStyle === "dotted") {
-            ctx.setLineDash([0, stroke.width * 2]);
+            ctx.setLineDash([0.01, stroke.width * 2]);
         } else {
             ctx.setLineDash([]);
         }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -63,7 +63,7 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         if (stroke.lineStyle === "dashed") {
             ctx.setLineDash([stroke.width * 2.5, stroke.width * 1.5]);
         } else if (stroke.lineStyle === "dotted") {
-            ctx.setLineDash([stroke.width, stroke.width]);
+            ctx.setLineDash([0, stroke.width * 2]);
         } else {
             ctx.setLineDash([]);
         }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -58,10 +58,21 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         ctx.lineJoin = "round";
         const p0 = stroke.points[0];
         const p1 = stroke.points[stroke.points.length - 1];
+
+        ctx.save();
+        if (stroke.lineStyle === "dashed") {
+            ctx.setLineDash([stroke.width * 3, stroke.width * 3]);
+        } else if (stroke.lineStyle === "dotted") {
+            ctx.setLineDash([stroke.width, stroke.width * 2]);
+        } else {
+            ctx.setLineDash([]);
+        }
+
         ctx.beginPath();
         ctx.moveTo(p0.x, p0.y);
         ctx.lineTo(p1.x, p1.y);
         ctx.stroke();
+        ctx.restore();
 
     } else if (stroke.tool === "highlighter") {
         ctx.strokeStyle = Qt.rgba(rgb.r, rgb.g, rgb.b, 0.4);

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -61,9 +61,9 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
 
         ctx.save();
         if (stroke.lineStyle === "dashed") {
-            ctx.setLineDash([stroke.width * 3, stroke.width * 3]);
+            ctx.setLineDash([stroke.width * 2.5, stroke.width * 1.5]);
         } else if (stroke.lineStyle === "dotted") {
-            ctx.setLineDash([stroke.width, stroke.width * 2]);
+            ctx.setLineDash([stroke.width, stroke.width]);
         } else {
             ctx.setLineDash([]);
         }

--- a/components/LineOptionsToolbar.qml
+++ b/components/LineOptionsToolbar.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import qs.Common
 import qs.Widgets
 import ".."
@@ -110,9 +109,6 @@ Item {
                             root.styleSelected(modelData.style);
                             root.close();
                         }
-                        ToolTip.visible: containsMouse
-                        ToolTip.delay: 500
-                        ToolTip.text: modelData.tooltip
                     }
                 }
             }

--- a/components/LineOptionsToolbar.qml
+++ b/components/LineOptionsToolbar.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls
 import qs.Common
 import qs.Widgets
 import ".."
@@ -109,6 +110,9 @@ Item {
                             root.styleSelected(modelData.style);
                             root.close();
                         }
+                        ToolTip.visible: containsMouse
+                        ToolTip.delay: 500
+                        ToolTip.text: modelData.tooltip
                     }
                 }
             }

--- a/components/LineOptionsToolbar.qml
+++ b/components/LineOptionsToolbar.qml
@@ -1,0 +1,117 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+import ".."
+
+Item {
+    id: root
+    z: 2000
+    anchors.fill: parent
+
+    ToolbarConstants { id: tc }
+
+    property bool visibleState: false
+    visible: opacity > 0
+    opacity: 0
+
+    property real menuX: 0
+    property real menuY: 0
+
+    property string currentStyle: "solid"
+    property string toolbarPosition: "top"
+
+    signal styleSelected(string style)
+
+    states: [
+        State {
+            name: "visible"
+            when: root.visibleState
+            PropertyChanges { target: root; opacity: 1.0 }
+            PropertyChanges { target: menuContent; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { target: root; property: "opacity"; duration: 120; easing.type: Easing.OutQuad }
+            NumberAnimation { target: menuContent; property: "scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open(x, y) {
+        root.menuX = x;
+        root.menuY = y;
+        root.visibleState = true;
+    }
+
+    function close() {
+        root.visibleState = false;
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: (mouse) => {
+            root.close();
+            mouse.accepted = false;
+        }
+    }
+
+    Rectangle {
+        id: menuContent
+        width: contentRow.implicitWidth + Theme.spacingM * 2
+        height: tc.subToolbarHeight
+        x: Math.max(10, Math.min(root.width - width - 10, root.menuX - width / 2))
+        y: root.toolbarPosition === "bottom"
+            ? Math.max(10, Math.min(root.height - height - 10, root.menuY - height - 20))
+            : Math.max(10, Math.min(root.height - height - 10, root.menuY + 20))
+        scale: 0.95
+
+        color: Theme.surfaceContainer
+        border.color: Theme.withAlpha(Theme.outline, 0.15)
+        border.width: 1
+        radius: Theme.cornerRadius
+        
+        Row {
+            id: contentRow
+            anchors.centerIn: parent
+            spacing: Theme.spacingS
+
+            // Group: Line Styles (Solid, Dashed, Dotted)
+            Repeater {
+                model: [
+                    { icon: "line_weight", style: "solid", tooltip: qsTr("Solid Line") },
+                    { icon: "border_style", style: "dashed", tooltip: qsTr("Dashed Line") },
+                    { icon: "more_horiz", style: "dotted", tooltip: qsTr("Dotted Line") }
+                ]
+
+                delegate: Rectangle {
+                    width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
+                    radius: Theme.cornerRadius - 2
+                    color: root.currentStyle === modelData.style 
+                        ? Theme.withAlpha(Theme.primary, 0.15) 
+                        : (styleMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                    border.color: root.currentStyle === modelData.style ? Theme.primary : "transparent"
+                    border.width: 1
+
+                    DankIcon {
+                        anchors.centerIn: parent
+                        name: modelData.icon
+                        size: tc.subToolbarIconSize
+                        color: root.currentStyle === modelData.style ? Theme.primary : Theme.surfaceText
+                    }
+
+                    MouseArea {
+                        id: styleMouse
+                        anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            root.styleSelected(modelData.style);
+                            root.close();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "id": "quickCapture",
     "name": "Quick Capture",
     "description": "Instant screenshot and overlay annotation utility for Wayland",
-    "version": "2.7.7",
+    "version": "2.7.8",
     "author": "Loc Huynh",
     "icon": "screenshot_region",
     "type": "composite",


### PR DESCRIPTION
### Description
This Pull Request adds customizable line styles (`dashed` and `dotted`) to the Line tool, along with a mini option toolbar activated via `Shift + Right Click`.

### Key Changes
- Created `LineOptionsToolbar.qml` as a context-aware mini toolbar for selecting the active line style.
- Linked `Shift + Right Click` to display `LineOptionsToolbar` when the line tool is active.
- Updated standard stroke logic in `QuickCaptureModal.qml` to cache and store `lineStyle` properties.
- Upgraded line drawing rendering in `DrawingRenderer.js` using `ctx.setLineDash` to cleanly draw solid, dashed, and dotted lines (rendering dotted style as perfect circular dots by leveraging sub-pixel segments and round line caps).
- Bumped version to `2.7.8` in `plugin.json`.

### How Tested
- Verified drawing with Solid, Dashed, and Dotted lines.
- Verified `Shift + Right Click` triggers the Line options toolbar correctly.
- Checked that Canvas state is correctly preserved and doesn't bleed into other drawing tools.

## Summary by Sourcery

Add configurable line styles to the line drawing tool and expose them via a contextual options toolbar.

New Features:
- Introduce solid, dashed, and dotted styles for line strokes, stored as part of the canvas state.
- Add a Line options mini toolbar that appears near the cursor when the line tool is active and the shortcut is used.

Enhancements:
- Update line rendering to respect the selected line style using canvas dash patterns for cleaner visual output.

Build:
- Bump plugin version to 2.7.8 in plugin.json.