### PR TITLE
refactor: relocate eraser to More Tools and optimize keyboard shortcuts

### DIFF
--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -17,7 +17,6 @@ QtObject {
         { id: "redact", icon: "ad_off", tooltip: qsTr("Redact (R)") },
         { id: "stamp", icon: "looks_one", tooltip: qsTr("Number Stamp (A)") },
         { id: "highlighter", icon: "border_color", tooltip: qsTr("Highlighter (S)") },
-        { id: "eraser", icon: "auto_fix_normal", tooltip: qsTr("Eraser (D)") },
         { id: "spotlight", icon: "highlight", tooltip: qsTr("Focus Spotlight (F)") },
         { id: "callout", icon: "zoom_in", tooltip: qsTr("Area Zoom (Z) | Hold G for Loupe") },
         { id: "backdrop", icon: "wallpaper", tooltip: qsTr("Image Backdrop (B)") }

--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -17,7 +17,7 @@ QtObject {
         { id: "redact", icon: "ad_off", tooltip: qsTr("Redact (R)") },
         { id: "stamp", icon: "looks_one", tooltip: qsTr("Number Stamp (A)") },
         { id: "highlighter", icon: "border_color", tooltip: qsTr("Highlighter (S)") },
-        { id: "spotlight", icon: "highlight", tooltip: qsTr("Focus Spotlight (F)") },
+        { id: "spotlight", icon: "highlight", tooltip: qsTr("Focus Spotlight (D)") },
         { id: "callout", icon: "zoom_in", tooltip: qsTr("Area Zoom (Z) | Hold G for Loupe") },
         { id: "backdrop", icon: "wallpaper", tooltip: qsTr("Image Backdrop (B)") }
     ]
@@ -163,9 +163,9 @@ QtObject {
         { key: "R", tool: "redact" },
         { key: "A", tool: "stamp" },
         { key: "S", tool: "highlighter" },
-        { key: "D", tool: "eraser" },
-        { key: "I", tool: "colorpicker" },
-        { key: "F", tool: "spotlight" },
+        { key: "D", tool: "spotlight" },
+        { key: "F", tool: "colorpicker" },
+        { key: "T", tool: "eraser" },
         { key: "Z", tool: "callout" },
         { key: "B", tool: "backdrop" }
     ]

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -3184,6 +3184,7 @@ DankModal {
                     onMirrorRequested: window.mirrorScreenshot()
                     onOcrRequested: window.runOcr()
                     onQrScanRequested: window.runQrScan()
+                    onEraserRequested: window.currentTool = "eraser"
                     onCopyColorRequested: {
                         window.colorPickerMode = "copy";
                         window.currentTool = "colorpicker";

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -2229,7 +2229,8 @@ PluginSettings {
                 ShortcutRow { keyText: "V"; actionText: I18n.tr("Select / Move stroke") }
                 ShortcutRow { keyText: "1 - 4"; actionText: I18n.tr("Pen, Line, Arrow, Rect") }
                 ShortcutRow { keyText: "Q - R"; actionText: I18n.tr("Ellipse, Text, Pixelate, Redact (Q, W, E, R)") }
-                ShortcutRow { keyText: "A - D"; actionText: I18n.tr("Stamp, Highlighter, Eraser (A, S, D)") }
+                ShortcutRow { keyText: "A - D"; actionText: I18n.tr("Stamp, Highlighter, Spotlight (A, S, D)") }
+                ShortcutRow { keyText: "F / T"; actionText: I18n.tr("Color Picker, Eraser (F, T)") }
             }
 
             Separator { opacity: 0.1 }

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ git clone https://github.com/hthienloc/dms-quick-capture ~/.config/DankMaterialS
 | `R` | Redact |
 | `A` | Stamp |
 | `S` | Highlighter |
-| `D` | Eraser |
-| `F` | Spotlight |
+| `D` | Focus Spotlight |
+| `F` | Color Picker (Ink/Eyedropper) |
+| `T` | Eraser |
 | `Z` | Area Zoom (Callout) |
 | `B` | Backdrop Options |
 | `V` | Select |
@@ -81,6 +82,7 @@ git clone https://github.com/hthienloc/dms-quick-capture ~/.config/DankMaterialS
 | **Right-click** on canvas | 8 customizable tool presets |
 | **Shift+Right-click** (Stamp active) | Open Stamp Options mini-toolbar (Numeric, Alphabetic, Roman) |
 | **Shift+Right-click** (Text active) | Open Text Options mini-toolbar (Bold, Italic, Underline, Background) |
+| **Shift+Right-click** (Line active) | Open Line Options mini-toolbar (Solid, Dashed, Dotted) |
 
 ### Special Tools
 

--- a/components/MoreToolsMenu.qml
+++ b/components/MoreToolsMenu.qml
@@ -25,6 +25,7 @@ Rectangle {
     signal ocrRequested()
     signal qrScanRequested()
     signal copyColorRequested()
+    signal eraserRequested()
 
     states: [
         State {
@@ -221,6 +222,47 @@ Rectangle {
                 onClicked: {
                     menuRoot.close();
                     menuRoot.qrScanRequested();
+                }
+            }
+        }
+
+        // Eraser Option
+        Rectangle {
+            width: parent.width
+            height: 32
+            radius: Theme.cornerRadius - 2
+            color: eraserMouseArea.containsMouse ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+
+            Row {
+                anchors.fill: parent
+                anchors.leftMargin: Theme.spacingS
+                anchors.rightMargin: Theme.spacingS
+                spacing: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+
+                DankIcon {
+                    name: "auto_fix_normal"
+                    size: 16
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                StyledText {
+                    text: qsTr("Eraser (D)")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            MouseArea {
+                id: eraserMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    menuRoot.close();
+                    menuRoot.eraserRequested();
                 }
             }
         }

--- a/components/MoreToolsMenu.qml
+++ b/components/MoreToolsMenu.qml
@@ -248,7 +248,7 @@ Rectangle {
                 }
 
                 StyledText {
-                    text: qsTr("Eraser (D)")
+                    text: qsTr("Eraser (T)")
                     font.pixelSize: Theme.fontSizeSmall
                     color: Theme.surfaceText
                     anchors.verticalCenter: parent.verticalCenter

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -178,7 +178,7 @@ Rectangle {
                 iconName: "colorize"
                 buttonSize: tc.btnSize
                 iconSize: tc.iconSize
-                tooltipText: qsTr("Color Picker (I)")
+                tooltipText: qsTr("Color Picker (F)")
                 backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                 iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
                 onClicked: root.toolSelected("colorpicker-draw")
@@ -310,7 +310,7 @@ Rectangle {
                 iconName: "colorize"
                 buttonSize: tc.btnSize
                 iconSize: tc.iconSize
-                tooltipText: qsTr("Color Picker (I)")
+                tooltipText: qsTr("Color Picker (F)")
                 backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                 iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
                 anchors.horizontalCenter: parent.horizontalCenter

--- a/docs/ipc-and-settings.md
+++ b/docs/ipc-and-settings.md
@@ -51,14 +51,15 @@ Pressing these keys changes the active tool:
 - `2`: Line
 - `3`: Arrow
 - `4`: Rectangle
-- `5` / `S`: Highlighter (Alpha brush)
+- `S`: Highlighter (Alpha brush)
 - `Q`: Ellipse
 - `W`: Text Box
 - `E`: Pixelate (Redaction blur)
 - `R`: Redact (Solid block covering)
 - `A`: Stamp (Incremental counters)
-- `D`: Eraser (Individual vector click eraser)
-- `F`: Spotlight (Darken background outside selection)
+- `D`: Spotlight (Darken background outside selection)
+- `F`: Color Picker (Ink/Eyedropper)
+- `T`: Eraser (Individual vector click eraser)
 - `Z`: Area Zoom / Callout box
 - `V`: Select / Move tool
 - `B`: Backdrop options
@@ -81,6 +82,7 @@ Pressing these keys changes the active tool:
 - **Right-Click on Canvas:** Displays the 8-preset Radial Menu for swift tool/color selection.
 - **Shift + Right-Click (Stamp active):** Changes counter format (Numbers, Alphabetical, Roman numerals).
 - **Shift + Right-Click (Text active):** Standard text decoration toggle (Bold, Italic, Underline, Background).
+- **Shift + Right-Click (Line active):** Changes line style (Solid, Dashed, Dotted).
 
 ---
 

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "id": "quickCapture",
     "name": "Quick Capture",
     "description": "Instant screenshot and overlay annotation utility for Wayland",
-    "version": "2.7.9",
+    "version": "2.8.0",
     "author": "Loc Huynh",
     "icon": "screenshot_region",
     "type": "composite",

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "id": "quickCapture",
     "name": "Quick Capture",
     "description": "Instant screenshot and overlay annotation utility for Wayland",
-    "version": "2.7.8",
+    "version": "2.7.9",
     "author": "Loc Huynh",
     "icon": "screenshot_region",
     "type": "composite",


### PR DESCRIPTION
### Description
This Pull Request refactors the toolbar by moving the less-used Eraser tool to the "More Tools" menu and optimizes the keyboard shortcuts for better accessibility on the left-hand home rows.

### Key Changes
- Removed `eraser` from `toolButtons` in `CaptureConfig.qml` to keep the main toolbar drawing tools clean.
- Added an `eraserRequested` signal and the "Eraser (T)" option inside `MoreToolsMenu.qml`.
- Re-mapped hotkeys in `CaptureConfig.qml` to focus on left-hand rows by importance:
  - **`D`**: Focus Spotlight (moved from `F` to `D` for home-row access).
  - **`F`**: Color Picker (moved from `I` to `F` for immediate access next to drawing tools).
  - **`T`**: Eraser (moved from `D` to `T` as it is now in the More Tools menu).
- Updated tooltips in `QuickCaptureToolbar.qml` to reflect the new `F` shortcut for Color Picker.
- Bumped version to `2.7.9` in `plugin.json`.
- Documented the updated hotkeys in `README.md`, `docs/ipc-and-settings.md`, and the Settings UI in `QuickCaptureSettings.qml`.

### How Tested
- Verified shortcuts `D`, `F`, and `T` map correctly to their respective tools.
- Verified selecting "Eraser" from the More Tools menu triggers the eraser tool.
- Confirmed the settings panel correctly lists the updated keybindings.

## Summary by Sourcery

Relocate the Eraser tool from the main toolbar into the More Tools menu and update keyboard shortcuts and UI text to reflect the new tool layout.

New Features:
- Add an Eraser option to the More Tools menu that activates the eraser tool when selected.

Enhancements:
- Remap keyboard shortcuts so Spotlight uses D, Color Picker uses F, and Eraser uses T for improved ergonomics.
- Update tooltips, settings UI, and user-facing documentation to match the new keybindings and interactions, including line style options via Shift+Right-click.
- Wire the new Eraser menu signal into the capture modal so selecting Eraser from More Tools switches the active tool.