### PR TITLE
feat: add ArrowOptionsToolbar and support custom line/head styles for arrows

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -70,6 +70,36 @@ DankModal {
         }
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
+    property string activeArrowLineStyle: "solid"
+    property string activeArrowHeadStyle: "single-filled"
+    onActiveArrowLineStyleChanged: {
+        if (window.selectedStroke && window.selectedStroke.tool === "arrow") {
+            window.selectedStroke.arrowLineStyle = window.activeArrowLineStyle;
+            const idx = window.strokes.indexOf(window.selectedStroke);
+            if (idx !== -1) {
+                window.strokes[idx] = window.selectedStroke;
+                window.strokes = [...window.strokes];
+            }
+        }
+        if (window.currentStroke && window.currentStroke.tool === "arrow") {
+            window.currentStroke.arrowLineStyle = window.activeArrowLineStyle;
+        }
+        if (window.activeCanvas) window.activeCanvas.requestPaint();
+    }
+    onActiveArrowHeadStyleChanged: {
+        if (window.selectedStroke && window.selectedStroke.tool === "arrow") {
+            window.selectedStroke.arrowHeadStyle = window.activeArrowHeadStyle;
+            const idx = window.strokes.indexOf(window.selectedStroke);
+            if (idx !== -1) {
+                window.strokes[idx] = window.selectedStroke;
+                window.strokes = [...window.strokes];
+            }
+        }
+        if (window.currentStroke && window.currentStroke.tool === "arrow") {
+            window.currentStroke.arrowHeadStyle = window.activeArrowHeadStyle;
+        }
+        if (window.activeCanvas) window.activeCanvas.requestPaint();
+    }
     property int _lastSampledX: -1
     property int _lastSampledY: -1
     property color _lastSampledColor: "transparent"
@@ -2229,6 +2259,9 @@ DankModal {
                                         } else if (window.currentTool === "line") {
                                             lineOptionsToolbar.open(mapped.x, mapped.y);
                                             return;
+                                        } else if (window.currentTool === "arrow") {
+                                            arrowOptionsToolbar.open(mapped.x, mapped.y);
+                                            return;
                                         }
                                     }
                                     radialMenu.open(mapped.x, mapped.y);
@@ -2270,7 +2303,11 @@ DankModal {
                                         window.currentColor = stroke.color;
                                         if (stroke.tool === "line" && stroke.lineStyle) {
                                             window.activeLineStyle = stroke.lineStyle;
-                                        };
+                                        }
+                                        if (stroke.tool === "arrow") {
+                                            if (stroke.arrowLineStyle) window.activeArrowLineStyle = stroke.arrowLineStyle;
+                                            if (stroke.arrowHeadStyle) window.activeArrowHeadStyle = stroke.arrowHeadStyle;
+                                        }
 
                                         // Detection for callout destination dragging
                                         if (stroke.tool === "callout" && stroke.points.length === 4) {
@@ -2415,7 +2452,9 @@ DankModal {
                                     color: window.currentColor.toString(),
                                     width: window.activeIntensity,
                                     points: [getAbsolutePoint(mouse.x, mouse.y)],
-                                    lineStyle: window.currentTool === "line" ? window.activeLineStyle : "solid"
+                                    lineStyle: window.currentTool === "line" ? window.activeLineStyle : "solid",
+                                    arrowLineStyle: window.currentTool === "arrow" ? window.activeArrowLineStyle : "solid",
+                                    arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled"
                                 };
                                 drawingCanvas.requestPaint();
                             }
@@ -3176,6 +3215,15 @@ DankModal {
                     toolbarPosition: window.toolbarPosition
                     currentStyle: window.activeLineStyle
                     onStyleSelected: (style) => window.activeLineStyle = style
+                }
+
+                ArrowOptionsToolbar {
+                    id: arrowOptionsToolbar
+                    toolbarPosition: window.toolbarPosition
+                    currentLineStyle: window.activeArrowLineStyle
+                    currentHeadStyle: window.activeArrowHeadStyle
+                    onLineStyleSelected: (style) => window.activeArrowLineStyle = style
+                    onHeadStyleSelected: (style) => window.activeArrowHeadStyle = style
                 }
 
                 MoreToolsMenu {

--- a/components/ArrowOptionsToolbar.qml
+++ b/components/ArrowOptionsToolbar.qml
@@ -1,0 +1,168 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+import ".."
+
+Item {
+    id: root
+    z: 2000
+    anchors.fill: parent
+
+    ToolbarConstants { id: tc }
+
+    property bool visibleState: false
+    visible: opacity > 0
+    opacity: 0
+
+    property real menuX: 0
+    property real menuY: 0
+
+    property string currentLineStyle: "solid"
+    property string currentHeadStyle: "single-filled"
+    property string toolbarPosition: "top"
+
+    signal lineStyleSelected(string style)
+    signal headStyleSelected(string style)
+
+    states: [
+        State {
+            name: "visible"
+            when: root.visibleState
+            PropertyChanges { target: root; opacity: 1.0 }
+            PropertyChanges { target: menuContent; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { target: root; property: "opacity"; duration: 120; easing.type: Easing.OutQuad }
+            NumberAnimation { target: menuContent; property: "scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open(x, y) {
+        root.menuX = x;
+        root.menuY = y;
+        root.visibleState = true;
+    }
+
+    function close() {
+        root.visibleState = false;
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: (mouse) => {
+            root.close();
+            mouse.accepted = false;
+        }
+    }
+
+    Rectangle {
+        id: menuContent
+        width: contentColumn.implicitWidth + Theme.spacingM * 2
+        height: contentColumn.implicitHeight + Theme.spacingM * 2
+        x: Math.max(10, Math.min(root.width - width - 10, root.menuX - width / 2))
+        y: root.toolbarPosition === "bottom"
+            ? Math.max(10, Math.min(root.height - height - 10, root.menuY - height - 20))
+            : Math.max(10, Math.min(root.height - height - 10, root.menuY + 20))
+        scale: 0.95
+
+        color: Theme.surfaceContainer
+        border.color: Theme.withAlpha(Theme.outline, 0.15)
+        border.width: 1
+        radius: Theme.cornerRadius
+        
+        Column {
+            id: contentColumn
+            anchors.centerIn: parent
+            spacing: Theme.spacingS
+
+            // Top Row: Arrow Head Styles (Filled, Open, Double)
+            Row {
+                id: headRow
+                spacing: Theme.spacingS
+                Repeater {
+                    model: [
+                        { icon: "trending_flat", style: "single-filled" },
+                        { icon: "chevron_right", style: "single-open" },
+                        { icon: "swap_horiz", style: "double-filled" }
+                    ]
+
+                    delegate: Rectangle {
+                        width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
+                        radius: Theme.cornerRadius - 2
+                        color: root.currentHeadStyle === modelData.style 
+                            ? Theme.withAlpha(Theme.primary, 0.15) 
+                            : (headMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                        border.color: root.currentHeadStyle === modelData.style ? Theme.primary : "transparent"
+                        border.width: 1
+
+                        DankIcon {
+                            anchors.centerIn: parent
+                            name: modelData.icon
+                            size: tc.subToolbarIconSize
+                            color: root.currentHeadStyle === modelData.style ? Theme.primary : Theme.surfaceText
+                        }
+
+                        MouseArea {
+                            id: headMouse
+                            anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.headStyleSelected(modelData.style);
+                                root.close();
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Horizontal Separator
+            Rectangle {
+                width: headRow.implicitWidth; height: 1
+                color: Theme.withAlpha(Theme.outline, 0.15)
+            }
+
+            // Bottom Row: Line Styles (Solid, Dashed, Dotted)
+            Row {
+                id: lineRow
+                spacing: Theme.spacingS
+                Repeater {
+                    model: [
+                        { icon: "line_weight", style: "solid" },
+                        { icon: "border_style", style: "dashed" },
+                        { icon: "more_horiz", style: "dotted" }
+                    ]
+
+                    delegate: Rectangle {
+                        width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
+                        radius: Theme.cornerRadius - 2
+                        color: root.currentLineStyle === modelData.style 
+                            ? Theme.withAlpha(Theme.primary, 0.15) 
+                            : (lineMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                        border.color: root.currentLineStyle === modelData.style ? Theme.primary : "transparent"
+                        border.width: 1
+
+                        DankIcon {
+                            anchors.centerIn: parent
+                            name: modelData.icon
+                            size: tc.subToolbarIconSize
+                            color: root.currentLineStyle === modelData.style ? Theme.primary : Theme.surfaceText
+                        }
+
+                        MouseArea {
+                            id: lineMouse
+                            anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.lineStyleSelected(modelData.style);
+                                root.close();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -148,24 +148,73 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         const len = Math.sqrt(dx * dx + dy * dy);
 
         if (len > 0) {
+            const SPREAD_ANGLE = Math.PI / 7;
+            const MIN_HEAD_LENGTH = 15;
+            const HEAD_LENGTH_MULTIPLIER = 4;
+            const BASE_FACTOR = Math.cos(SPREAD_ANGLE); // ~0.9009, matching base of the arrowhead triangle
+
+            const DASH_LENGTH_RATIO = 2.5;
+            const DASH_GAP_RATIO = 1.5;
+            const DOTTED_SEGMENT_LENGTH = 0.01;
+            const DOTTED_GAP_RATIO = 2;
+
             const angle = Math.atan2(dy, dx);
-            const spread = Math.PI / 7;
-            const headLength = Math.max(15, stroke.width * 4);
-            const shaftLength = Math.max(0, len - headLength * 0.8);
-            const shaftEndX = p0.x + shaftLength * Math.cos(angle);
-            const shaftEndY = p0.y + shaftLength * Math.sin(angle);
+            const headLength = Math.max(MIN_HEAD_LENGTH, stroke.width * HEAD_LENGTH_MULTIPLIER);
+            
+            const isDoubleHead = stroke.arrowHeadStyle === "double-filled";
+            const isOpenHead = stroke.arrowHeadStyle === "single-open";
+
+            const startOffset = isDoubleHead ? headLength * BASE_FACTOR : 0;
+            const endOffset = isOpenHead ? 0 : headLength * BASE_FACTOR;
+            const shaftLength = Math.max(0, len - startOffset - endOffset);
+
+            const shaftStartX = p0.x + startOffset * Math.cos(angle);
+            const shaftStartY = p0.y + startOffset * Math.sin(angle);
+            const shaftEndX = shaftStartX + shaftLength * Math.cos(angle);
+            const shaftEndY = shaftStartY + shaftLength * Math.sin(angle);
+
+            // Draw arrow shaft
+            ctx.save();
+            if (stroke.arrowLineStyle === "dashed") {
+                ctx.setLineDash([stroke.width * DASH_LENGTH_RATIO, stroke.width * DASH_GAP_RATIO]);
+            } else if (stroke.arrowLineStyle === "dotted") {
+                ctx.setLineDash([DOTTED_SEGMENT_LENGTH, stroke.width * DOTTED_GAP_RATIO]);
+            } else {
+                ctx.setLineDash([]);
+            }
 
             ctx.beginPath();
-            ctx.moveTo(p0.x, p0.y);
+            ctx.moveTo(shaftStartX, shaftStartY);
             ctx.lineTo(shaftEndX, shaftEndY);
             ctx.stroke();
+            ctx.restore();
 
-            ctx.beginPath();
-            ctx.moveTo(p1.x, p1.y);
-            ctx.lineTo(p1.x - headLength * Math.cos(angle - spread), p1.y - headLength * Math.sin(angle - spread));
-            ctx.lineTo(p1.x - headLength * Math.cos(angle + spread), p1.y - headLength * Math.sin(angle + spread));
-            ctx.closePath();
-            ctx.fill();
+            // Draw primary head (at p1)
+            if (isOpenHead) {
+                ctx.beginPath();
+                ctx.moveTo(p1.x - headLength * Math.cos(angle - SPREAD_ANGLE), p1.y - headLength * Math.sin(angle - SPREAD_ANGLE));
+                ctx.lineTo(p1.x, p1.y);
+                ctx.lineTo(p1.x - headLength * Math.cos(angle + SPREAD_ANGLE), p1.y - headLength * Math.sin(angle + SPREAD_ANGLE));
+                ctx.stroke();
+            } else {
+                ctx.beginPath();
+                ctx.moveTo(p1.x, p1.y);
+                ctx.lineTo(p1.x - headLength * Math.cos(angle - SPREAD_ANGLE), p1.y - headLength * Math.sin(angle - SPREAD_ANGLE));
+                ctx.lineTo(p1.x - headLength * Math.cos(angle + SPREAD_ANGLE), p1.y - headLength * Math.sin(angle + SPREAD_ANGLE));
+                ctx.closePath();
+                ctx.fill();
+            }
+
+            // Draw secondary head (at p0) if double-headed
+            if (isDoubleHead) {
+                const oppositeAngle = angle + Math.PI;
+                ctx.beginPath();
+                ctx.moveTo(p0.x, p0.y);
+                ctx.lineTo(p0.x - headLength * Math.cos(oppositeAngle - SPREAD_ANGLE), p0.y - headLength * Math.sin(oppositeAngle - SPREAD_ANGLE));
+                ctx.lineTo(p0.x - headLength * Math.cos(oppositeAngle + SPREAD_ANGLE), p0.y - headLength * Math.sin(oppositeAngle + SPREAD_ANGLE));
+                ctx.closePath();
+                ctx.fill();
+            }
         }
 
     } else if (stroke.tool === "redact") {

--- a/components/StrokeProperties.js
+++ b/components/StrokeProperties.js
@@ -12,4 +12,7 @@ function copyStrokeProperties(source, target) {
     if (source.hasBackground !== undefined) target.hasBackground = source.hasBackground;
     if (source.cornerRadius !== undefined) target.cornerRadius = source.cornerRadius;
     if (source.borderWidth !== undefined) target.borderWidth = source.borderWidth;
+    if (source.lineStyle !== undefined) target.lineStyle = source.lineStyle;
+    if (source.arrowLineStyle !== undefined) target.arrowLineStyle = source.arrowLineStyle;
+    if (source.arrowHeadStyle !== undefined) target.arrowHeadStyle = source.arrowHeadStyle;
 }


### PR DESCRIPTION
### Description
This Pull Request introduces customizable styles for the Arrow tool by adding an `ArrowOptionsToolbar` and updating the canvas renderer to draw various arrow head and line style combinations.

### Key Changes
- Created [ArrowOptionsToolbar.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/ArrowOptionsToolbar.qml) containing a 2-row layout:
  - **Top Row**: Arrow Head Styles (Filled Chevron, Open Chevron, Double-headed Filled).
  - **Bottom Row**: Arrow Line Styles (Solid, Dashed, Dotted).
  - A clean separator line dividing the two rows.
- Linked `Shift + Right Click` when the `arrow` tool is active to open the `ArrowOptionsToolbar`.
- Added state synchronization in `QuickCaptureModal.qml` to update selection properties when an arrow is selected or styled.
- Improved Arrow rendering math in `DrawingRenderer.js` to align the shaft line perfectly with filled bases or open chevron tips, removing any gap.

## Summary by Sourcery

Introduce configurable arrow styling with a dedicated options toolbar and synchronized canvas state.

New Features:
- Add an ArrowOptionsToolbar for choosing arrow head and line styles.
- Support solid, dashed, and dotted line styles for the arrow tool.
- Support single filled, single open, and double filled arrow head styles.

Enhancements:
- Refine arrow shaft and head rendering to align precisely and avoid visual gaps.
- Propagate active arrow style selections to new and existing arrow strokes in the canvas state.