### PR TITLE
feat: implement Clean Text Eraser redact mode

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -59,6 +59,22 @@ DankModal {
     property string colorPickerMode: "draw" // draw, copy
     property color hoveredColor: "transparent"
     property string activeLineStyle: "solid"
+    property string activeRedactMode: "solid" // solid, blur, clean
+    onActiveRedactModeChanged: {
+        if (window.selectedStroke && window.selectedStroke.tool === "redact") {
+            window.selectedStroke.redactMode = window.activeRedactMode;
+            window.selectedStroke.cachedCleanColor = undefined;
+            const idx = window.strokes.indexOf(window.selectedStroke);
+            if (idx !== -1) {
+                window.strokes[idx] = window.selectedStroke;
+                window.strokes = [...window.strokes];
+            }
+        }
+        if (window.currentStroke && window.currentStroke.tool === "redact") {
+            window.currentStroke.redactMode = window.activeRedactMode;
+        }
+        if (window.activeCanvas) window.activeCanvas.requestPaint();
+    }
     onActiveLineStyleChanged: {
         if (window.selectedStroke && window.selectedStroke.tool === "line") {
             window.selectedStroke.lineStyle = window.activeLineStyle;
@@ -199,6 +215,9 @@ DankModal {
     onCurrentColorChanged: {
         if (window.selectedStroke) {
             window.selectedStroke.color = window.currentColor.toString();
+            if (window.selectedStroke.tool === "redact") {
+                window.selectedStroke.cachedCleanColor = undefined;
+            }
             const idx = window.strokes.indexOf(window.selectedStroke);
             if (idx !== -1) {
                 window.strokes[idx] = window.selectedStroke;
@@ -487,6 +506,7 @@ DankModal {
     property int preGrabSpotlightIntensity: 50
     property int preGrabCalloutZoom: 150
     property color preGrabColor: Theme.primary
+    property string preGrabRedactMode: "solid"
     property point pressCoords: Qt.point(0, 0)
     property var originalPoints: []
 
@@ -876,8 +896,10 @@ DankModal {
         if (window.currentTool === "select") {
             window.preGrabStrokeWidth = window.strokeWidth;
             window.preGrabColor = window.currentColor;
+            window.preGrabRedactMode = window.activeRedactMode;
             window.strokeWidth = pasted.width;
             window.currentColor = pasted.color;
+            if (pasted.tool === "redact" && pasted.redactMode) window.activeRedactMode = pasted.redactMode;
             window.selectedStroke = pasted;
             window.pressCoords = absPt;
             window.originalPoints = newPoints;
@@ -1387,6 +1409,7 @@ DankModal {
                             window.activeCanvas.loadImage(source);
                         }
                         contrastSampler.requestPaint();
+                        offscreenSampler.requestPaint();
                     }
                 }
 
@@ -1909,6 +1932,7 @@ DankModal {
                                 roundRect: window.roundRect,
                                 roundHighlighter: window.roundHighlighter,
                                 bgImageItem: window.bgImageItem,
+                                offscreenSampler: offscreenSampler,
                                 canvasWidth: window.canvasWidth,
                                 canvasHeight: window.canvasHeight,
                                 canvasMinX: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.x : 0,
@@ -1967,7 +1991,10 @@ DankModal {
                                             }
                                             window.selectedStroke.points = newPoints;
                                         }
-                                        drawingCanvas.requestPaint();
+                                         if (window.selectedStroke.tool === "redact") {
+                                             window.selectedStroke.cachedCleanColor = undefined;
+                                         }
+                                         drawingCanvas.requestPaint();
                                     } else {
                                         hoveredStrokeIdx = window.findStrokeAt(absPt.x, absPt.y);
                                     }
@@ -2117,6 +2144,9 @@ DankModal {
                                         } else if (window.currentTool === "arrow") {
                                             arrowOptionsToolbar.open(mapped.x, mapped.y);
                                             return;
+                                        } else if (window.currentTool === "redact") {
+                                            redactOptionsToolbar.open(mapped.x, mapped.y);
+                                            return;
                                         }
                                     }
                                     radialMenu.open(mapped.x, mapped.y);
@@ -2152,6 +2182,7 @@ DankModal {
                                             window.preGrabSpotlightIntensity = window.spotlightIntensity;
                                             window.preGrabCalloutZoom = window.calloutZoom;
                                             window.preGrabColor = window.currentColor;
+                                            window.preGrabRedactMode = window.activeRedactMode;
                                         }
                                         
                                         window.selectedStroke = stroke;
@@ -2162,6 +2193,9 @@ DankModal {
                                         if (stroke.tool === "arrow") {
                                             if (stroke.arrowLineStyle) window.activeArrowLineStyle = stroke.arrowLineStyle;
                                             if (stroke.arrowHeadStyle) window.activeArrowHeadStyle = stroke.arrowHeadStyle;
+                                        }
+                                        if (stroke.tool === "redact" && stroke.redactMode) {
+                                            window.activeRedactMode = stroke.redactMode;
                                         }
 
                                         // Detection for callout destination dragging
@@ -2301,17 +2335,17 @@ DankModal {
                                     return;
                                 }
 
-                                // Standard drawing stroke
-                                window.currentStroke = {
-                                    tool: window.currentTool,
-                                    color: window.currentColor.toString(),
-                                    width: window.activeIntensity,
-                                    points: [getAbsolutePoint(mouse.x, mouse.y)],
-                                    lineStyle: window.currentTool === "line" ? window.activeLineStyle : "solid",
-                                    arrowLineStyle: window.currentTool === "arrow" ? window.activeArrowLineStyle : "solid",
-                                    arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled"
-                                };
-                                drawingCanvas.requestPaint();
+                                 window.currentStroke = {
+                                     tool: window.currentTool,
+                                     color: window.currentColor.toString(),
+                                     width: window.activeIntensity,
+                                     points: [getAbsolutePoint(mouse.x, mouse.y)],
+                                     lineStyle: window.currentTool === "line" ? window.activeLineStyle : "solid",
+                                     arrowLineStyle: window.currentTool === "arrow" ? window.activeArrowLineStyle : "solid",
+                                     arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled",
+                                     redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid"
+                                 };
+                                 drawingCanvas.requestPaint();
                             }
 
                             onReleased: (mouse) => {
@@ -2323,6 +2357,7 @@ DankModal {
                                      window.spotlightIntensity = window.preGrabSpotlightIntensity;
                                      window.calloutZoom = window.preGrabCalloutZoom;
                                      window.currentColor = window.preGrabColor;
+                                     window.activeRedactMode = window.preGrabRedactMode;
                                      window.calloutDestDragging = false;
                                      window.originalPoints = [];
                                      drawingCanvas.requestPaint();
@@ -2772,6 +2807,13 @@ DankModal {
                     onHeadStyleSelected: (style) => window.activeArrowHeadStyle = style
                 }
 
+                RedactOptionsToolbar {
+                    id: redactOptionsToolbar
+                    toolbarPosition: window.toolbarPosition
+                    currentMode: window.activeRedactMode
+                    onModeSelected: (mode) => window.activeRedactMode = mode
+                }
+
                 MoreToolsMenu {
                     id: moreToolsMenu
                     onRotateRequested: window.rotateScreenshot()
@@ -2876,6 +2918,18 @@ DankModal {
                                 window.backdropSolidColor = colors.start;
                             }
                         }
+                    }
+                }
+
+                Canvas {
+                    id: offscreenSampler
+                    visible: false
+                    width: window.bgImageItem ? window.bgImageItem.sourceSize.width : 1
+                    height: window.bgImageItem ? window.bgImageItem.sourceSize.height : 1
+                    onPaint: {
+                        var ctx = getContext("2d");
+                        ctx.clearRect(0, 0, width, height);
+                        ctx.drawImage(bgImage, 0, 0, width, height);
                     }
                 }
             }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -221,25 +221,59 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
     } else if (stroke.tool === "redact") {
         const p0 = stroke.points[0];
         const p1 = stroke.points[stroke.points.length - 1];
-        const rx = Math.min(p0.x, p1.x);
-        const ry = Math.min(p0.y, p1.y);
-        const rw = Math.abs(p1.x - p0.x);
-        const rh = Math.abs(p1.y - p0.y);
-        const radius = config.roundRect ? Math.min(Theme.cornerRadius, Math.min(rw, rh) / 2) : 0;
+        const rx = Math.floor(Math.min(p0.x, p1.x));
+        const ry = Math.floor(Math.min(p0.y, p1.y));
+        const rw = Math.floor(Math.abs(p1.x - p0.x));
+        const rh = Math.floor(Math.abs(p1.y - p0.y));
+        
+        if (rw > 0 && rh > 0) {
+            const radius = config.roundRect ? Math.min(Theme.cornerRadius, Math.min(rw, rh) / 2) : 0;
+            const mode = stroke.redactMode || "solid";
 
-        ctx.fillStyle = stroke.color;
-        ctx.beginPath();
-        ctx.moveTo(rx + radius, ry);
-        ctx.lineTo(rx + rw - radius, ry);
-        ctx.arcTo(rx + rw, ry, rx + rw, ry + radius, radius);
-        ctx.lineTo(rx + rw, ry + rh - radius);
-        ctx.arcTo(rx + rw, ry + rh, rx + rw - radius, ry + rh, radius);
-        ctx.lineTo(rx + radius, ry + rh);
-        ctx.arcTo(rx, ry + rh, rx, ry + rh - radius, radius);
-        ctx.lineTo(rx, ry + radius);
-        ctx.arcTo(rx, ry, rx + radius, ry, radius);
-        ctx.closePath();
-        ctx.fill();
+            ctx.save();
+            ctx.beginPath();
+            ctx.moveTo(rx + radius, ry);
+            ctx.lineTo(rx + rw - radius, ry);
+            ctx.arcTo(rx + rw, ry, rx + rw, ry + radius, radius);
+            ctx.lineTo(rx + rw, ry + rh - radius);
+            ctx.arcTo(rx + rw, ry + rh, rx + rw - radius, ry + rh, radius);
+            ctx.lineTo(rx + radius, ry + rh);
+            ctx.arcTo(rx, ry + rh, rx, ry + rh - radius, radius);
+            ctx.lineTo(rx, ry + radius);
+            ctx.arcTo(rx, ry, rx + radius, ry, radius);
+            ctx.closePath();
+
+            if (mode === "clean" && config.offscreenSampler) {
+                if (stroke.isCurrent) {
+                    // Extremely cheap 1x1 pixel read for 60 FPS real-time preview dragging
+                    try {
+                        const octx = config.offscreenSampler.getContext("2d");
+                        const imgData = octx.getImageData(rx, ry, 1, 1);
+                        ctx.fillStyle = Qt.rgba(imgData.data[0] / 255, imgData.data[1] / 255, imgData.data[2] / 255, 1.0);
+                    } catch (e) {
+                        ctx.fillStyle = "rgba(128, 128, 128, 0.5)";
+                    }
+                } else {
+                    // Compute accurate dominant color exactly once and cache it on the stroke!
+                    if (!stroke.cachedCleanColor) {
+                        stroke.cachedCleanColor = Helpers.getBoundaryColorOrGradient(ctx, rx, ry, rw, rh, config.offscreenSampler, Qt);
+                    }
+                    ctx.fillStyle = stroke.cachedCleanColor;
+                }
+                ctx.fill();
+            } else {
+                ctx.fillStyle = stroke.color;
+                ctx.fill();
+            }
+
+            if (stroke.isCurrent) {
+                ctx.strokeStyle = "rgba(255, 255, 255, 0.6)";
+                ctx.lineWidth = 1;
+                ctx.setLineDash([4, 4]);
+                ctx.stroke();
+            }
+            ctx.restore();
+        }
 
     } else if (stroke.tool === "pixelate") {
         if (stroke.points.length >= 2) {

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -469,3 +469,89 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
     }
     return -1;
 }
+
+
+function getBoundaryColorOrGradient(ctx, rx, ry, rw, rh, offscreenSampler, Qt) {
+    if (!offscreenSampler) return "transparent";
+    const octx = offscreenSampler.getContext("2d");
+    
+    const border = 3;
+    const sampleX = Math.max(0, Math.min(offscreenSampler.width - 1, rx - border));
+    const sampleY = Math.max(0, Math.min(offscreenSampler.height - 1, ry - border));
+    const sampleW = Math.max(1, Math.min(offscreenSampler.width - sampleX, rw + border * 2));
+    const sampleH = Math.max(1, Math.min(offscreenSampler.height - sampleY, rh + border * 2));
+    
+    if (sampleW <= 0 || sampleH <= 0) return "transparent";
+    
+    let imgData;
+    try {
+        imgData = octx.getImageData(sampleX, sampleY, sampleW, sampleH);
+    } catch (e) {
+        return "transparent";
+    }
+    const data = imgData.data;
+    
+    const counts = {};
+    let maxCount = 0;
+    let dominantColorKey = null;
+    
+    for (let y = 0; y < sampleH; y++) {
+        for (let x = 0; x < sampleW; x++) {
+            const isBorder = (x < border) || (x >= sampleW - border) || (y < border) || (y >= sampleH - border);
+            if (isBorder) {
+                const idx = (y * sampleW + x) * 4;
+                const r = data[idx];
+                const g = data[idx + 1];
+                const b = data[idx + 2];
+                const a = data[idx + 3];
+                if (a === 0) continue;
+                
+                const qr = Math.round(r / 8) * 8;
+                const qg = Math.round(g / 8) * 8;
+                const qb = Math.round(b / 8) * 8;
+                
+                const key = (qr << 16) | (qg << 8) | qb;
+                counts[key] = (counts[key] || 0) + 1;
+                if (counts[key] > maxCount) {
+                    maxCount = counts[key];
+                    dominantColorKey = key;
+                }
+            }
+        }
+    }
+    
+    if (dominantColorKey === null) return "transparent";
+    
+    let rSum = 0, gSum = 0, bSum = 0, count = 0;
+    for (let y = 0; y < sampleH; y++) {
+        for (let x = 0; x < sampleW; x++) {
+            const isBorder = (x < border) || (x >= sampleW - border) || (y < border) || (y >= sampleH - border);
+            if (isBorder) {
+                const idx = (y * sampleW + x) * 4;
+                const r = data[idx];
+                const g = data[idx + 1];
+                const b = data[idx + 2];
+                const a = data[idx + 3];
+                if (a === 0) continue;
+                
+                const qr = Math.round(r / 8) * 8;
+                const qg = Math.round(g / 8) * 8;
+                const qb = Math.round(b / 8) * 8;
+                const key = (qr << 16) | (qg << 8) | qb;
+                if (key === dominantColorKey) {
+                    rSum += r;
+                    gSum += g;
+                    bSum += b;
+                    count++;
+                }
+            }
+        }
+    }
+    
+    const finalR = Math.round(rSum / count);
+    const finalG = Math.round(gSum / count);
+    const finalB = Math.round(bSum / count);
+    
+    return Qt.rgba(finalR / 255, finalG / 255, finalB / 255, 1.0);
+}
+

--- a/components/RedactOptionsToolbar.qml
+++ b/components/RedactOptionsToolbar.qml
@@ -1,0 +1,116 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+import ".."
+
+Item {
+    id: root
+    z: 2000
+    anchors.fill: parent
+
+    ToolbarConstants { id: tc }
+
+    property bool visibleState: false
+    visible: opacity > 0
+    opacity: 0
+
+    property real menuX: 0
+    property real menuY: 0
+
+    property string currentMode: "solid"
+    property string toolbarPosition: "top"
+
+    signal modeSelected(string mode)
+
+    states: [
+        State {
+            name: "visible"
+            when: root.visibleState
+            PropertyChanges { target: root; opacity: 1.0 }
+            PropertyChanges { target: menuContent; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { target: root; property: "opacity"; duration: 120; easing.type: Easing.OutQuad }
+            NumberAnimation { target: menuContent; property: "scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open(x, y) {
+        root.menuX = x;
+        root.menuY = y;
+        root.visibleState = true;
+    }
+
+    function close() {
+        root.visibleState = false;
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: (mouse) => {
+            root.close();
+            mouse.accepted = false;
+        }
+    }
+
+    Rectangle {
+        id: menuContent
+        width: contentRow.implicitWidth + Theme.spacingM * 2
+        height: tc.subToolbarHeight
+        x: Math.max(10, Math.min(root.width - width - 10, root.menuX - width / 2))
+        y: root.toolbarPosition === "bottom"
+            ? Math.max(10, Math.min(root.height - height - 10, root.menuY - height - 20))
+            : Math.max(10, Math.min(root.height - height - 10, root.menuY + 20))
+        scale: 0.95
+
+        color: Theme.surfaceContainer
+        border.color: Theme.withAlpha(Theme.outline, 0.15)
+        border.width: 1
+        radius: Theme.cornerRadius
+        
+        Row {
+            id: contentRow
+            anchors.centerIn: parent
+            spacing: Theme.spacingS
+
+            // Group: Redact Modes (Solid, Clean)
+            Repeater {
+                model: [
+                    { icon: "square", mode: "solid", tooltip: qsTr("Solid Fill") },
+                    { icon: "auto_fix_high", mode: "clean", tooltip: qsTr("Clean Text Eraser") }
+                ]
+
+                delegate: Rectangle {
+                    width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
+                    radius: Theme.cornerRadius - 2
+                    color: root.currentMode === modelData.mode 
+                        ? Theme.withAlpha(Theme.primary, 0.15) 
+                        : (modeMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                    border.color: root.currentMode === modelData.mode ? Theme.primary : "transparent"
+                    border.width: 1
+
+                    DankIcon {
+                        anchors.centerIn: parent
+                        name: modelData.icon
+                        size: tc.subToolbarIconSize
+                        color: root.currentMode === modelData.mode ? Theme.primary : Theme.surfaceText
+                    }
+
+                    MouseArea {
+                        id: modeMouse
+                        anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            root.modeSelected(modelData.mode);
+                            root.close();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/StrokeProperties.js
+++ b/components/StrokeProperties.js
@@ -15,4 +15,5 @@ function copyStrokeProperties(source, target) {
     if (source.lineStyle !== undefined) target.lineStyle = source.lineStyle;
     if (source.arrowLineStyle !== undefined) target.arrowLineStyle = source.arrowLineStyle;
     if (source.arrowHeadStyle !== undefined) target.arrowHeadStyle = source.arrowHeadStyle;
+    if (source.redactMode !== undefined) target.redactMode = source.redactMode;
 }


### PR DESCRIPTION
### What
- **Redact Sub-mode (Clean Text Eraser):** Added a new `"clean"` mode option to the Redact tool that automatically samples the boundary pixels of the redact rectangle, identifies the dominant background color (excluding text), and fills the redact box with it.
- **RedactOptionsToolbar:** Introduced a new selector toolbar `RedactOptionsToolbar.qml` accessible via `Shift + Right click` when using the Redact tool, allowing users to toggle between solid fill and clean eraser modes.
- **Performance Caching:** Optimized rendering by performing a cheap 1x1 pixel read for 60 FPS real-time dragging, and caching the computed dominant boundary color once the stroke is finalized.

### Why
- Provides an automated, seamless way to erase text while matching the screenshot's background color without manual color picking.

### How tested
- Verified real-time drawing performance is 60 FPS during drag interaction.
- Confirmed correct dominant color detection on uniform and noisy screenshot backgrounds.
- Verified state serialization and property synchronization during select dragging.

## Summary by Sourcery

Add a clean text eraser mode to the redact tool that matches screenshot backgrounds using sampled colors and expose it via a contextual redact options toolbar.

New Features:
- Introduce a redact mode selector that supports solid and clean text eraser modes for redact strokes.
- Add an offscreen sampling canvas to analyze screenshot pixels for background color matching when redacting.

Enhancements:
- Cache computed clean eraser colors on redact strokes for efficient re-rendering and preserve redact mode in stroke copy/paste and selection workflows.