### PR TITLE
feat(toolbar): implement keyboard shortcut badges on tool buttons

### DIFF
--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -7,19 +7,19 @@ QtObject {
     property var pluginData: ({})
 
     readonly property var toolButtons: [
-        { id: "pen", icon: "edit", tooltip: qsTr("Freehand Pen (1)") },
-        { id: "line", icon: "horizontal_rule", tooltip: qsTr("Straight Line (2)") },
-        { id: "arrow", icon: "trending_flat", tooltip: qsTr("Arrow Vector (3)") },
-        { id: "rect", icon: "crop_square", tooltip: qsTr("Rectangle Outline (4)") },
-        { id: "ellipse", icon: "radio_button_unchecked", tooltip: qsTr("Ellipse / Circle (Q)") },
-        { id: "text", icon: "text_fields", tooltip: qsTr("Text Note (W)") },
-        { id: "pixelate", icon: "blur_on", tooltip: qsTr("Pixelate (E)") },
-        { id: "redact", icon: "ad_off", tooltip: qsTr("Redact (R)") },
-        { id: "stamp", icon: "looks_one", tooltip: qsTr("Number Stamp (A)") },
-        { id: "highlighter", icon: "border_color", tooltip: qsTr("Highlighter (S)") },
-        { id: "spotlight", icon: "highlight", tooltip: qsTr("Focus Spotlight (D)") },
-        { id: "callout", icon: "zoom_in", tooltip: qsTr("Area Zoom (Z) | Hold G for Loupe") },
-        { id: "backdrop", icon: "wallpaper", tooltip: qsTr("Image Backdrop (B)") }
+        { id: "pen", icon: "edit", shortcut: "1", tooltip: qsTr("Freehand Pen (1)") },
+        { id: "line", icon: "horizontal_rule", shortcut: "2", tooltip: qsTr("Straight Line (2)") },
+        { id: "arrow", icon: "trending_flat", shortcut: "3", tooltip: qsTr("Arrow Vector (3)") },
+        { id: "rect", icon: "crop_square", shortcut: "4", tooltip: qsTr("Rectangle Outline (4)") },
+        { id: "ellipse", icon: "radio_button_unchecked", shortcut: "Q", tooltip: qsTr("Ellipse / Circle (Q)") },
+        { id: "text", icon: "text_fields", shortcut: "W", tooltip: qsTr("Text Note (W)") },
+        { id: "pixelate", icon: "blur_on", shortcut: "E", tooltip: qsTr("Pixelate (E)") },
+        { id: "redact", icon: "ad_off", shortcut: "R", tooltip: qsTr("Redact (R)") },
+        { id: "stamp", icon: "looks_one", shortcut: "A", tooltip: qsTr("Number Stamp (A)") },
+        { id: "highlighter", icon: "border_color", shortcut: "S", tooltip: qsTr("Highlighter (S)") },
+        { id: "spotlight", icon: "highlight", shortcut: "D", tooltip: qsTr("Focus Spotlight (D)") },
+        { id: "callout", icon: "zoom_in", shortcut: "Z", tooltip: qsTr("Area Zoom (Z) | Hold G for Loupe") },
+        { id: "backdrop", icon: "wallpaper", shortcut: "B", tooltip: qsTr("Image Backdrop (B)") }
     ]
 
     readonly property string selectedPreset: pluginData["color_palette_preset"] || "adaptive"

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -528,6 +528,20 @@ PluginSettings {
             visible: showToolbar.value
             height: visible ? 36 : 0
         }
+
+        Separator {
+            visible: showToolbar.value
+            height: visible ? 1 : 0
+        }
+
+        ToggleSettingPlus {
+            id: showShortcutHints
+            settingKey: "show_shortcut_hints"
+            label: I18n.tr("Show Keyboard Shortcut Hints")
+            defaultValue: false
+            visible: showToolbar.value
+            height: visible ? 36 : 0
+        }
     }
 
     SettingsCard {

--- a/components/DankShortcutActionButton.qml
+++ b/components/DankShortcutActionButton.qml
@@ -1,0 +1,22 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+DankActionButton {
+    id: button
+
+    property string shortcutText: ""
+    property bool showShortcut: false
+
+    Text {
+        text: button.shortcutText
+        font.pixelSize: 9
+        font.weight: Font.Bold
+        color: button.enabled ? Theme.withAlpha(Theme.surfaceText, 0.5) : Theme.withAlpha(Theme.surfaceText, 0.25)
+        anchors.bottom: button.bottom
+        anchors.right: button.right
+        anchors.rightMargin: 4
+        anchors.bottomMargin: 2
+        visible: button.shortcutText !== "" && button.showShortcut
+    }
+}

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -18,6 +18,7 @@ Rectangle {
     property bool canUndo: false
     property bool isVertical: false
     property bool showAnnotations: true
+    readonly property bool showShortcutHints: root.pluginData["show_shortcut_hints"] ?? false
 
     // Backdrop configuration properties
     property string backdropMode: "none"
@@ -138,11 +139,13 @@ Rectangle {
                     delegate: Item {
                         width: tc.btnSize
                         height: tc.btnSize
-                        DankActionButton {
+                        DankShortcutActionButton {
                             anchors.fill: parent
                             iconName: modelData.icon; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: modelData.tooltip
                             backgroundColor: root.currentTool === modelData.id ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                             iconColor: root.currentTool === modelData.id ? Theme.primary : Theme.surfaceText
+                            shortcutText: modelData.shortcut || ""
+                            showShortcut: root.showShortcutHints
                             onClicked: root.toolSelected(modelData.id)
                         }
 
@@ -271,11 +274,13 @@ Rectangle {
                     delegate: Item {
                         width: tc.btnSize
                         height: tc.btnSize
-                        DankActionButton {
+                        DankShortcutActionButton {
                             anchors.fill: parent
-                            iconName: modelData.icon; buttonSize: tc.btnSize; iconSize: tc.iconSize
+                            iconName: modelData.icon; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: modelData.tooltip
                             backgroundColor: root.currentTool === modelData.id ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                             iconColor: root.currentTool === modelData.id ? Theme.primary : Theme.surfaceText
+                            shortcutText: modelData.shortcut || ""
+                            showShortcut: root.showShortcutHints
                             onClicked: root.toolSelected(modelData.id)
                         }
 


### PR DESCRIPTION
### What
- **Keyboard Shortcut Badges:** Replaced the drawing tool buttons on the toolbar with a custom `DankShortcutActionButton` that overlays a subtle keyboard shortcut hint in the bottom-right corner of each tool icon.
- **Configurable Toggle:** Added the `"show_shortcut_hints"` setting to `QuickCaptureSettings.qml` to show/hide the badges on the toolbar. 
- **Default State:** The shortcut hints layer is set to `false` (off) by default to keep the toolbar clean.

### Why
- Provides an inline reminder for keyboard shortcut mappings while drawing.

### How tested
- Verified correct text overlay positioning on vertical/horizontal layouts.
- Confirmed that toggling the preference updates the toolbar instantly.

## Summary by Sourcery

Add configurable keyboard shortcut hints to drawing toolbar tool buttons.

New Features:
- Overlay keyboard shortcut badges on drawing tool buttons using a new shortcut-aware action button component.
- Introduce a user setting to toggle display of keyboard shortcut hints on the quick capture toolbar.

Enhancements:
- Extend toolbar tool button configuration with explicit shortcut metadata for each drawing tool.