### PR TITLE
feat(pen): add freehand drawing smoothing and configurable auto-close

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -951,6 +951,8 @@ DankModal {
     property bool hasSelection: false
     readonly property bool roundRect: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.roundRect !== undefined ? window.parentWidget.pluginData.roundRect : true
     readonly property bool roundHighlighter: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.roundHighlighter !== undefined ? window.parentWidget.pluginData.roundHighlighter : false
+    readonly property bool penAutoClose: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.penAutoClose !== undefined ? window.parentWidget.pluginData.penAutoClose : true
+
     property string activeHandle: "none" // "tl", "tr", "bl", "br", "new", "none"
     property point selectStart: Qt.point(0, 0)
     property rect ocrRect: Qt.rect(0, 0, 0, 0)
@@ -2444,6 +2446,23 @@ DankModal {
                                         return;
                                     }
                                 }
+                                if (stroke.tool === "pen" && stroke.points.length >= 3) {
+                                    stroke.points = Helpers.smoothStrokePoints(stroke.points, 6, Qt);
+
+                                    // Auto-close: if start and end are within 20 screen-px, snap closed
+                                    if (window.penAutoClose) {
+                                        const snapThreshold = 20 / window.editScale;
+                                        const fp = stroke.points[0];
+                                        const lp = stroke.points[stroke.points.length - 1];
+                                        const dx = lp.x - fp.x;
+                                        const dy = lp.y - fp.y;
+                                        if (Math.sqrt(dx * dx + dy * dy) < snapThreshold) {
+                                            stroke.points = [...stroke.points, Qt.point(fp.x, fp.y)];
+                                            stroke.isClosed = true;
+                                        }
+                                    }
+                                }
+
                                 window.pushStroke(window.currentStroke);
                                 window.currentStroke = null;
                             }

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -1481,12 +1481,13 @@ PluginSettings {
         SectionTitle {
             text: I18n.tr("Drawing")
             icon: "brush"
-            showReset: defaultToolMode.isDirty || defaultPresetIndex.isDirty || defaultTool.isDirty || defaultThickness.isDirty
+            showReset: defaultToolMode.isDirty || defaultPresetIndex.isDirty || defaultTool.isDirty || defaultThickness.isDirty || penAutoClose.isDirty
             onResetClicked: {
                 defaultToolMode.resetToDefault();
                 defaultPresetIndex.resetToDefault();
                 defaultTool.resetToDefault();
                 defaultThickness.resetToDefault();
+                penAutoClose.resetToDefault();
             }
         }
 
@@ -1589,7 +1590,18 @@ PluginSettings {
             visible: defaultToolMode.value === "custom"
         }
 
+        Separator {
+            visible: defaultToolMode.value === "custom"
+        }
 
+
+        ToggleSettingPlus {
+            id: penAutoClose
+            settingKey: "penAutoClose"
+            label: I18n.tr("Pen Auto-Close")
+            description: I18n.tr("Automatically close the loop when ending close to the start point.")
+            defaultValue: true
+        }
     }
 
     SettingsCard {

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -49,7 +49,11 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
             const yc = (pts[i].y + pts[i + 1].y) / 2;
             ctx.quadraticCurveTo(pts[i].x, pts[i].y, xc, yc);
         }
-        ctx.quadraticCurveTo(pts[len - 2].x, pts[len - 2].y, pts[len - 1].x, pts[len - 1].y);
+        if (stroke.isClosed) {
+            ctx.closePath();
+        } else {
+            ctx.quadraticCurveTo(pts[len - 2].x, pts[len - 2].y, pts[len - 1].x, pts[len - 1].y);
+        }
         ctx.stroke();
 
     } else if (stroke.tool === "line") {

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -49,10 +49,9 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
             const yc = (pts[i].y + pts[i + 1].y) / 2;
             ctx.quadraticCurveTo(pts[i].x, pts[i].y, xc, yc);
         }
+        ctx.quadraticCurveTo(pts[len - 2].x, pts[len - 2].y, pts[len - 1].x, pts[len - 1].y);
         if (stroke.isClosed) {
             ctx.closePath();
-        } else {
-            ctx.quadraticCurveTo(pts[len - 2].x, pts[len - 2].y, pts[len - 1].x, pts[len - 1].y);
         }
         ctx.stroke();
 

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -470,11 +470,36 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
     return -1;
 }
 
+/**
+ * Smooths a polyline using a multi-pass weighted moving average.
+ * Each pass replaces every interior point with:
+ *   0.25 * prev + 0.5 * current + 0.25 * next
+ * Endpoints are kept fixed. Running multiple passes compounds the effect.
+ *
+ * @param {Array} points - Array of {x, y} points.
+ * @param {number} passes - Number of smoothing passes (recommended: 4-8).
+ * @returns {Array} New smoothed array of Qt.point objects.
+ */
+function smoothStrokePoints(points, passes, Qt) {
+    if (!points || points.length < 3) return points;
+    let pts = points;
+    for (let p = 0; p < passes; p++) {
+        const next = [pts[0]]; // keep start fixed
+        for (let i = 1; i < pts.length - 1; i++) {
+            next.push(Qt.point(
+                0.25 * pts[i - 1].x + 0.5 * pts[i].x + 0.25 * pts[i + 1].x,
+                0.25 * pts[i - 1].y + 0.5 * pts[i].y + 0.25 * pts[i + 1].y
+            ));
+        }
+        next.push(pts[pts.length - 1]); // keep end fixed
+        pts = next;
+    }
+    return pts;
+}
 
 function getBoundaryColorOrGradient(ctx, rx, ry, rw, rh, offscreenSampler, Qt) {
     if (!offscreenSampler) return "transparent";
     const octx = offscreenSampler.getContext("2d");
-    
     const border = 3;
     const sampleX = Math.max(0, Math.min(offscreenSampler.width - 1, rx - border));
     const sampleY = Math.max(0, Math.min(offscreenSampler.height - 1, ry - border));


### PR DESCRIPTION
### What
- Applies a multi-pass weighted moving average (6 passes) to smooth freehand pen drawing strokes upon mouse release.
- Automatically snaps the pen stroke closed (isClosed = true and closePath) if the start and end points are within 20 screen-pixels of each other.
- Adds a toggle preference for "Pen Auto-Close" (default: true) under the Drawing settings card.

### Why
- Provides smoother freehand drawings by post-processing raw mouse coordinates.
- Allows users to draw clean closed loops (e.g. circles, loops) easily.

### How tested
- Drawn paths verified to snap closed and render cleanly when endpoints are close.
- Verified toggle switch properly turns the snapping feature on/off.

## Summary by Sourcery

Add smoothing and optional auto-closing behavior to freehand pen strokes and expose a user preference for the feature.

New Features:
- Smooth freehand pen strokes using a multi-pass weighted moving average after drawing completes.
- Automatically close pen strokes when their endpoints are sufficiently close, controlled by a new Pen Auto-Close setting in Drawing preferences.

Enhancements:
- Update stroke rendering to respect closed paths by using canvas path closing for closed pen strokes.
- Extend drawing settings reset behavior to include the new Pen Auto-Close preference.