### PR TITLE
fix(toolbar): adjust moreToolsMenu positioning dynamically based on toolbarPosition to prevent cutoff

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1578,11 +1578,19 @@ DankModal {
                         } else {
                             var pt = buttonItem.mapToItem(contentRoot, 0, 0);
                             if (toolbarCard.isVertical) {
-                                moreToolsMenu.x = pt.x + buttonItem.width + Theme.spacingS;
-                                moreToolsMenu.y = pt.y;
+                                if (window.toolbarPosition === "right") {
+                                    moreToolsMenu.x = pt.x - moreToolsMenu.width - Theme.spacingS;
+                                } else {
+                                    moreToolsMenu.x = pt.x + buttonItem.width + Theme.spacingS;
+                                }
+                                moreToolsMenu.y = Math.max(Theme.spacingS, Math.min(pt.y, contentRoot.height - moreToolsMenu.height - Theme.spacingS));
                             } else {
-                                moreToolsMenu.x = pt.x;
-                                moreToolsMenu.y = pt.y + buttonItem.height + Theme.spacingS;
+                                moreToolsMenu.x = Math.max(Theme.spacingS, Math.min(pt.x, contentRoot.width - moreToolsMenu.width - Theme.spacingS));
+                                if (window.toolbarPosition === "bottom") {
+                                    moreToolsMenu.y = pt.y - moreToolsMenu.height - Theme.spacingS;
+                                } else {
+                                    moreToolsMenu.y = pt.y + buttonItem.height + Theme.spacingS;
+                                }
                             }
                             moreToolsMenu.open();
                         }


### PR DESCRIPTION
## What
Fix `MoreToolsMenu` getting cut off when the toolbar is positioned at the bottom or right of the screen.

## Why
The previous menu position coordinates were hardcoded to open downwards or rightwards, causing it to render off-screen if the toolbar itself was placed near those edges.

## How tested
Verified correct positioning calculations under all toolbar configurations (top, bottom, left, right).

## Summary by Sourcery

Bug Fixes:
- Prevent the MoreToolsMenu from rendering off-screen when the toolbar is positioned at the bottom or right edges of the window.