### PR TITLE
feat(colorpicker): support customizing color palette slots with eyedropper and custom RGB picker

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -54,6 +54,11 @@ DankModal {
     property var parentWidget: null
 
     // State Variables
+    property var paletteWarningDialogRef: null
+    property var toolbarItem: null
+    property int activeColorSlotIndex: 0
+    property color pendingColorToSave: "transparent"
+    property int pendingSlotToSave: -1
     property string currentTool: "crop" // crop, select, pen, line, arrow, rect, ellipse, text, pixelate, redact, stamp, highlighter, eraser, spotlight, backdrop
     property string lastActiveTool: "pen"
     property string colorPickerMode: "draw" // draw, copy
@@ -1027,6 +1032,68 @@ DankModal {
         return "#" + r + g + b;
     }
 
+    function updateColorSlot(slotIdx, colorValue) {
+        const hex = window.formatHexColor(colorValue).toUpperCase();
+        if (config.selectedPreset !== "custom") {
+            window.pendingColorToSave = colorValue;
+            window.pendingSlotToSave = slotIdx;
+            if (window.paletteWarningDialogRef) window.paletteWarningDialogRef.open();
+        } else {
+            window.currentColor = colorValue;
+            window.writeColorSlotToCustom(slotIdx, hex);
+        }
+    }
+
+    function writeColorSlotToCustom(slotIdx, hex) {
+        if (!window.parentWidget || !window.parentWidget.pluginService || slotIdx < 0) return;
+        
+        let pData = Object.assign({}, window.parentWidget.pluginData);
+        pData["color_palette_preset"] = "custom";
+        
+        const key = slotIdx === 0 ? "toolbar_color_primary" : "toolbar_color_" + (slotIdx - 1);
+        pData[key] = hex;
+        
+        window.parentWidget.pluginData = pData;
+        
+        window.parentWidget.pluginService.savePluginData("quickCapture", "color_palette_preset", "custom");
+        window.parentWidget.pluginService.savePluginData("quickCapture", key, hex);
+    }
+
+    function switchPresetToCustom(copyCurrent) {
+        if (!window.parentWidget || !window.parentWidget.pluginService) return;
+        
+        let pData = Object.assign({}, window.parentWidget.pluginData);
+        pData["color_palette_preset"] = "custom";
+        window.parentWidget.pluginService.savePluginData("quickCapture", "color_palette_preset", "custom");
+        
+        if (copyCurrent) {
+            const currentPalette = window.toolbarItem ? window.toolbarItem.toolbarPalette : [];
+            if (currentPalette && currentPalette.length >= 8) {
+                pData["toolbar_color_primary"] = window.formatHexColor(currentPalette[0]).toUpperCase();
+                window.parentWidget.pluginService.savePluginData("quickCapture", "toolbar_color_primary", pData["toolbar_color_primary"]);
+                
+                for (let i = 0; i < 7; i++) {
+                    const key = "toolbar_color_" + i;
+                    pData[key] = window.formatHexColor(currentPalette[i + 1]).toUpperCase();
+                    window.parentWidget.pluginService.savePluginData("quickCapture", key, pData[key]);
+                }
+            }
+        }
+        
+        if (window.pendingSlotToSave >= 0) {
+            const hex = window.formatHexColor(window.pendingColorToSave).toUpperCase();
+            const key = window.pendingSlotToSave === 0 ? "toolbar_color_primary" : "toolbar_color_" + (window.pendingSlotToSave - 1);
+            pData[key] = hex;
+            window.parentWidget.pluginService.savePluginData("quickCapture", key, hex);
+            
+            window.parentWidget.pluginData = pData;
+            window.currentColor = window.pendingColorToSave;
+        }
+        
+        window.pendingColorToSave = "transparent";
+        window.pendingSlotToSave = -1;
+    }
+
     function sampleCanvasColor(mouseX, mouseY) {
         if (!window.activeCanvas) return window.currentColor;
         
@@ -1189,6 +1256,10 @@ DankModal {
         if (hasCtrl) {
             const colorShortcut = config.findByKey(config.colorShortcuts, token);
             if (colorShortcut) {
+                let idx = config.colorShortcuts.indexOf(colorShortcut);
+                if (idx !== -1) {
+                    window.activeColorSlotIndex = idx;
+                }
                 window.currentColor = window.shortcutColor(colorShortcut.color);
                 event.accepted = true;
             }
@@ -1435,6 +1506,7 @@ DankModal {
 
                 QuickCaptureToolbar {
                     id: toolbarCard
+                    Component.onCompleted: window.toolbarItem = toolbarCard
                     z: 100
                     visible: window.toolbarVisible
                     pluginData: (window.parentWidget && window.parentWidget.pluginData) ? window.parentWidget.pluginData : ({})
@@ -1455,6 +1527,7 @@ DankModal {
                     currentTool: window.currentTool
                     activeToolType: window.effectiveTool
                     currentColor: window.currentColor
+                    activeColorSlotIndex: window.activeColorSlotIndex
 
                     strokeWidth: window.activeIntensity
                     canUndo: window.strokes.length > 0
@@ -1537,9 +1610,21 @@ DankModal {
                             window.currentTool = tool;
                         }
                     }
-                    onColorSelected: (color) => {
+                    onColorSelected: (color, index) => {
                         moreToolsMenu.close();
+                        window.activeColorSlotIndex = index;
                         window.currentColor = color;
+                    }
+                    onColorPickerRightClicked: (buttonItem) => {
+                        moreToolsMenu.close();
+                        if (typeof PopoutService !== "undefined" && PopoutService && PopoutService.colorPickerModal) {
+                            PopoutService.colorPickerModal.selectedColor = window.currentColor;
+                            PopoutService.colorPickerModal.pickerTitle = I18n.tr("Choose Color");
+                            PopoutService.colorPickerModal.onColorSelectedCallback = function (selectedColor) {
+                                window.updateColorSlot(window.activeColorSlotIndex, selectedColor);
+                            };
+                            PopoutService.colorPickerModal.show();
+                        }
                     }
                     onStrokeWidthSelected: (width) => {
                         moreToolsMenu.close();
@@ -2265,8 +2350,8 @@ DankModal {
                                                  ToastService.showInfo(I18n.tr("Color copied to clipboard: %1").arg(hexStr));
                                              }
                                          } else {
-                                             window.currentColor = pickedColor;
-                                         }
+                                              window.updateColorSlot(window.activeColorSlotIndex, pickedColor);
+                                          }
                                          window.currentTool = window.lastActiveTool;
                                      }
                                      return;
@@ -2863,6 +2948,30 @@ DankModal {
                     onCopyColorRequested: {
                         window.colorPickerMode = "copy";
                         window.currentTool = "colorpicker";
+                    }
+                }
+
+
+
+                PaletteWarningDialog {
+                    id: paletteWarningDialog
+                    Component.onCompleted: window.paletteWarningDialogRef = paletteWarningDialog
+                    currentPaletteColors: toolbarCard.toolbarPalette
+                    customPaletteColors: {
+                        var customList = [];
+                        var primaryRaw = config.pluginData["toolbar_color_primary"] || "primary";
+                        customList.push(primaryRaw === "primary" ? Theme.primary : Qt.color(primaryRaw));
+                        for (var i = 0; i < 7; i++) {
+                            var val = config.pluginData["toolbar_color_" + i] || config.adaptiveColors[i];
+                            customList.push(Qt.color(val));
+                        }
+                        return customList;
+                    }
+                    onCopyAndSwitch: {
+                        window.switchPresetToCustom(true);
+                    }
+                    onSwitchOnly: {
+                        window.switchPresetToCustom(false);
                     }
                 }
 

--- a/components/PaletteWarningDialog.qml
+++ b/components/PaletteWarningDialog.qml
@@ -1,0 +1,198 @@
+import QtQuick
+import QtQuick.Controls
+import qs.Common
+import qs.Widgets
+import "../dms-common"
+
+Popup {
+    id: warningDialog
+    width: 560
+    height: 310
+    padding: 0
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    anchors.centerIn: parent
+
+    property var currentPaletteColors: []
+    property var customPaletteColors: []
+
+    signal copyAndSwitch()
+    signal switchOnly()
+
+    background: Rectangle {
+        color: "transparent"
+    }
+
+    contentItem: Rectangle {
+        color: Theme.surfaceContainer
+        radius: Theme.cornerRadius
+        border.color: Theme.withAlpha(Theme.outline, 0.15)
+        border.width: 1
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: Theme.spacingM
+            spacing: Theme.spacingM
+
+            StyledText {
+                text: I18n.tr("Edit Color Palette")
+                font.bold: true
+                font.pixelSize: Theme.fontSizeMedium
+                color: Theme.surfaceText
+            }
+
+            StyledText {
+                width: parent.width
+                text: I18n.tr("This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:")
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.surfaceTextMedium
+                wrapMode: Text.Wrap
+            }
+
+            Row {
+                width: parent.width
+                spacing: Theme.spacingM
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                // Option 1: Copy & Switch
+                Rectangle {
+                    width: (parent.width - Theme.spacingM) / 2
+                    height: 150
+                    radius: Theme.cornerRadius
+                    color: opt1MouseArea.containsMouse ? Theme.surfaceHover : Theme.surfaceContainerHigh
+                    border.color: opt1MouseArea.containsMouse ? Theme.primary : Theme.withAlpha(Theme.outline, 0.15)
+                    border.width: opt1MouseArea.containsMouse ? 2 : 1
+                    clip: true
+
+                    Column {
+                        anchors.fill: parent
+                        anchors.margins: Theme.spacingM
+                        spacing: Theme.spacingS
+
+                        StyledText {
+                            text: I18n.tr("Copy Current Palette")
+                            font.bold: true
+                            font.pixelSize: Theme.fontSizeMedium
+                            color: Theme.surfaceText
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Copy and customize this preset")
+                            font.pixelSize: Theme.fontSizeSmall - 1
+                            color: Theme.surfaceTextMedium
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+
+                        Grid {
+                            columns: 4
+                            spacing: Theme.spacingXS
+                            anchors.horizontalCenter: parent.horizontalCenter
+
+                            Repeater {
+                                model: warningDialog.currentPaletteColors
+                                delegate: Rectangle {
+                                    width: 24
+                                    height: 24
+                                    radius: 12
+                                    color: modelData
+                                    border.color: Theme.withAlpha(Theme.outline, 0.2)
+                                    border.width: 1
+                                }
+                            }
+                        }
+                    }
+
+                    MouseArea {
+                        id: opt1MouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            warningDialog.copyAndSwitch();
+                            warningDialog.close();
+                        }
+                    }
+                }
+
+                // Option 2: Switch Only
+                Rectangle {
+                    width: (parent.width - Theme.spacingM) / 2
+                    height: 150
+                    radius: Theme.cornerRadius
+                    color: opt2MouseArea.containsMouse ? Theme.surfaceHover : Theme.surfaceContainerHigh
+                    border.color: opt2MouseArea.containsMouse ? Theme.primary : Theme.withAlpha(Theme.outline, 0.15)
+                    border.width: opt2MouseArea.containsMouse ? 2 : 1
+                    clip: true
+
+                    Column {
+                        anchors.fill: parent
+                        anchors.margins: Theme.spacingM
+                        spacing: Theme.spacingS
+
+                        StyledText {
+                            text: I18n.tr("Use Existing Custom")
+                            font.bold: true
+                            font.pixelSize: Theme.fontSizeMedium
+                            color: Theme.surfaceText
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+
+                        StyledText {
+                            text: I18n.tr("Switch to your custom preset")
+                            font.pixelSize: Theme.fontSizeSmall - 1
+                            color: Theme.surfaceTextMedium
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+
+                        Grid {
+                            columns: 4
+                            spacing: Theme.spacingXS
+                            anchors.horizontalCenter: parent.horizontalCenter
+
+                            Repeater {
+                                model: warningDialog.customPaletteColors
+                                delegate: Rectangle {
+                                    width: 24
+                                    height: 24
+                                    radius: 12
+                                    color: modelData
+                                    border.color: Theme.withAlpha(Theme.outline, 0.2)
+                                    border.width: 1
+                                }
+                            }
+                        }
+                    }
+
+                    MouseArea {
+                        id: opt2MouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            warningDialog.switchOnly();
+                            warningDialog.close();
+                        }
+                    }
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: 28
+
+                DankButton {
+                    text: I18n.tr("Cancel")
+                    backgroundColor: "transparent"
+                    textColor: Theme.surfaceTextMedium
+                    height: 28
+                    anchors.right: parent.right
+                    onClicked: {
+                        warningDialog.close();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -60,7 +60,9 @@ Rectangle {
     }
 
     signal toolSelected(string tool)
-    signal colorSelected(var color)
+    signal colorSelected(var color, int index)
+    signal colorPickerRightClicked(var buttonItem)
+    property int activeColorSlotIndex: 0
     signal strokeWidthSelected(int width)
     signal undoRequested()
     signal floatRequested()
@@ -170,21 +172,46 @@ Rectangle {
                     model: root.toolbarPalette
                     delegate: Rectangle {
                         width: tc.swatchSize; height: tc.swatchSize; radius: tc.swatchRadius; color: modelData
-                        border.color: Qt.colorEqual(root.currentColor, modelData) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: Qt.colorEqual(root.currentColor, modelData) ? 2 : 1
-                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.colorSelected(modelData) }
+                        border.color: (root.activeColorSlotIndex === index && Qt.colorEqual(root.currentColor, modelData)) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: (root.activeColorSlotIndex === index && Qt.colorEqual(root.currentColor, modelData)) ? 2 : 1
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.activeColorSlotIndex = index;
+                                root.colorSelected(modelData, index);
+                            }
+                        }
                     }
                 }
             }
 
-            DankActionButton {
-                iconName: "colorize"
-                buttonSize: tc.btnSize
-                iconSize: tc.iconSize
-                tooltipText: qsTr("Color Picker (F)")
-                backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
-                onClicked: root.toolSelected("colorpicker-draw")
+            Item {
+                width: tc.btnSize
+                height: tc.btnSize
+                anchors.verticalCenter: parent.verticalCenter
+                DankActionButton {
+                    id: colorPickerButton
+                    anchors.fill: parent
+                    iconName: "colorize"
+                    buttonSize: tc.btnSize
+                    iconSize: tc.iconSize
+                    tooltipText: qsTr("Color Picker (F / Right-Click for RGB)")
+                    backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: mouse => {
+                        if (mouse.button === Qt.RightButton) {
+                            root.colorPickerRightClicked(colorPickerButton);
+                        } else {
+                            root.toolSelected("colorpicker-draw");
+                        }
+                    }
+                }
             }
 
             Rectangle { width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
@@ -307,22 +334,46 @@ Rectangle {
                     model: root.toolbarPalette
                     delegate: Rectangle {
                         width: tc.swatchSizeVert; height: tc.swatchSizeVert; radius: tc.swatchRadiusVert; color: modelData
-                        border.color: Qt.colorEqual(root.currentColor, modelData) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: 1
-                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.colorSelected(modelData) }
+                        border.color: (root.activeColorSlotIndex === index && Qt.colorEqual(root.currentColor, modelData)) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: (root.activeColorSlotIndex === index && Qt.colorEqual(root.currentColor, modelData)) ? 2 : 1
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.activeColorSlotIndex = index;
+                                root.colorSelected(modelData, index);
+                            }
+                        }
                     }
                 }
             }
 
-            DankActionButton {
-                iconName: "colorize"
-                buttonSize: tc.btnSize
-                iconSize: tc.iconSize
-                tooltipText: qsTr("Color Picker (F)")
-                backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
-                iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
+            Item {
+                width: tc.btnSize
+                height: tc.btnSize
                 anchors.horizontalCenter: parent.horizontalCenter
-                onClicked: root.toolSelected("colorpicker-draw")
+                DankActionButton {
+                    id: colorPickerVerticalButton
+                    anchors.fill: parent
+                    iconName: "colorize"
+                    buttonSize: tc.btnSize
+                    iconSize: tc.iconSize
+                    tooltipText: qsTr("Color Picker (F / Right-Click for RGB)")
+                    backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
+                    iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: mouse => {
+                        if (mouse.button === Qt.RightButton) {
+                            root.colorPickerRightClicked(colorPickerVerticalButton);
+                        } else {
+                            root.toolSelected("colorpicker-draw");
+                        }
+                    }
+                }
             }
 
             Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }


### PR DESCRIPTION
Closes #70 

This Pull Request implements custom color palette slot editing with both left-click (eyedropper) and right-click (DMS standard color picker modal).

### What
- Extended `QuickCaptureToolbar` and `QuickCaptureModal` to support index-based swatch highlights and click interactions.
- Left-clicking the eyedropper color picker changes the color of the *currently active palette slot*.
- Right-clicking the eyedropper color picker opens the standard DMS Color Picker Modal (`PopoutService.colorPickerModal`) to configure the active color slot.
- Attempting to edit a read-only palette preset shows a redesigned visual warning dialog (`PaletteWarningDialog`) with circular color swatches, allowing the user to copy current colors to the "Custom" preset or switch to the Custom preset immediately.

### How tested
- Checked that right-clicking opens the DMS color picker modal and updates the custom slots properly.
- Validated warning dialog layout and circular color swatch sizing.

## Summary by Sourcery

Enable editing of color palette slots from the quick capture toolbar using both the eyedropper and a modal RGB color picker, with safeguards for read-only presets.

New Features:
- Allow selecting and highlighting an active color palette slot in the quick capture toolbar and modal.
- Support left-click eyedropper sampling to update the currently active palette slot color.
- Add right-click on the color picker button to open the DMS RGB color picker modal for the active palette slot.
- Introduce a palette warning dialog that guides users when attempting to edit read-only presets and lets them copy or switch to a custom palette.

Enhancements:
- Persist custom palette slot changes via plugin data when switching or copying to the custom preset.