### PR TITLE
feat(colorpicker): swap Left/Right click actions and F shortcut behavior

### DIFF
--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -186,7 +186,7 @@ QtObject {
     function resolveColor(rawColor) {
         if (!rawColor) return Theme.primary;
         if (typeof rawColor !== "string") {
-            return Qt.color(rawColor);
+            return rawColor;
         }
         let resolved = rawColor;
         if (rawColor === "primary") {
@@ -201,7 +201,7 @@ QtObject {
                 resolved = accentColors[slotIdx - 1];
             }
         }
-        return Qt.color(resolved);
+        return typeof resolved === "string" ? Qt.color(resolved) : resolved;
     }
 
     function formatWatermarkText(pattern) { return Helpers.formatWatermarkText(pattern, Quickshell); }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1044,6 +1044,19 @@ DankModal {
         }
     }
 
+    function openColorPickerModal() {
+        if (typeof PopoutService !== "undefined" && PopoutService && PopoutService.colorPickerModal) {
+            PopoutService.colorPickerModal.selectedColor = window.currentColor;
+            PopoutService.colorPickerModal.pickerTitle = I18n.tr("Choose Color");
+            PopoutService.colorPickerModal.onColorSelectedCallback = function (selectedColor) {
+                window.updateColorSlot(window.activeColorSlotIndex, selectedColor);
+            };
+            PopoutService.colorPickerModal.show();
+            return true;
+        }
+        return false;
+    }
+
     function writeColorSlotToCustom(slotIdx, hex) {
         if (!window.parentWidget || !window.parentWidget.pluginService || slotIdx < 0) return;
         
@@ -1280,14 +1293,24 @@ DankModal {
 
         const toolShortcut = config.findByKey(config.toolShortcuts, token);
         if (toolShortcut) {
+            if (toolShortcut.tool === "colorpicker") {
+                if (!window.openColorPickerModal()) {
+                    if (window.currentTool === "colorpicker") {
+                        window.currentTool = window.lastActiveTool;
+                    } else {
+                        window.colorPickerMode = "draw";
+                        window.currentTool = "colorpicker";
+                    }
+                }
+                event.accepted = true;
+                return;
+            }
+
             if (window.currentTool === toolShortcut.tool) {
-                if (toolShortcut.tool === "backdrop" || toolShortcut.tool === "crop" || toolShortcut.tool === "colorpicker") {
+                if (toolShortcut.tool === "backdrop" || toolShortcut.tool === "crop") {
                     window.currentTool = window.lastActiveTool;
                 }
             } else {
-                if (toolShortcut.tool === "colorpicker") {
-                    window.colorPickerMode = "draw";
-                }
                 window.currentTool = toolShortcut.tool;
             }
             event.accepted = true;
@@ -1615,15 +1638,15 @@ DankModal {
                         window.activeColorSlotIndex = index;
                         window.currentColor = color;
                     }
-                    onColorPickerRightClicked: (buttonItem) => {
+                    onCustomColorPickerRequested: (buttonItem) => {
                         moreToolsMenu.close();
-                        if (typeof PopoutService !== "undefined" && PopoutService && PopoutService.colorPickerModal) {
-                            PopoutService.colorPickerModal.selectedColor = window.currentColor;
-                            PopoutService.colorPickerModal.pickerTitle = I18n.tr("Choose Color");
-                            PopoutService.colorPickerModal.onColorSelectedCallback = function (selectedColor) {
-                                window.updateColorSlot(window.activeColorSlotIndex, selectedColor);
-                            };
-                            PopoutService.colorPickerModal.show();
+                        if (!window.openColorPickerModal()) {
+                            if (window.currentTool === "colorpicker") {
+                                window.currentTool = window.lastActiveTool;
+                            } else {
+                                window.colorPickerMode = "draw";
+                                window.currentTool = "colorpicker";
+                            }
                         }
                     }
                     onStrokeWidthSelected: (width) => {
@@ -2960,10 +2983,11 @@ DankModal {
                     customPaletteColors: {
                         var customList = [];
                         var primaryRaw = config.pluginData["toolbar_color_primary"] || "primary";
-                        customList.push(primaryRaw === "primary" ? Theme.primary : Qt.color(primaryRaw));
+                        var primaryColor = primaryRaw === "primary" ? Theme.primary : primaryRaw;
+                        customList.push(typeof primaryColor === "string" ? Qt.color(primaryColor) : primaryColor);
                         for (var i = 0; i < 7; i++) {
                             var val = config.pluginData["toolbar_color_" + i] || config.adaptiveColors[i];
-                            customList.push(Qt.color(val));
+                            customList.push(typeof val === "string" ? Qt.color(val) : val);
                         }
                         return customList;
                     }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -61,7 +61,7 @@ Rectangle {
 
     signal toolSelected(string tool)
     signal colorSelected(var color, int index)
-    signal colorPickerRightClicked(var buttonItem)
+    signal customColorPickerRequested(var buttonItem)
     property int activeColorSlotIndex: 0
     signal strokeWidthSelected(int width)
     signal undoRequested()
@@ -196,7 +196,7 @@ Rectangle {
                     iconName: "colorize"
                     buttonSize: tc.btnSize
                     iconSize: tc.iconSize
-                    tooltipText: qsTr("Color Picker (F / Right-Click for RGB)")
+                    tooltipText: qsTr("Color Picker (F for RGB / Right-Click for Eyedropper)")
                     backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                     iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
                 }
@@ -206,9 +206,9 @@ Rectangle {
                     cursorShape: Qt.PointingHandCursor
                     onClicked: mouse => {
                         if (mouse.button === Qt.RightButton) {
-                            root.colorPickerRightClicked(colorPickerButton);
-                        } else {
                             root.toolSelected("colorpicker-draw");
+                        } else {
+                            root.customColorPickerRequested(colorPickerButton);
                         }
                     }
                 }
@@ -358,7 +358,7 @@ Rectangle {
                     iconName: "colorize"
                     buttonSize: tc.btnSize
                     iconSize: tc.iconSize
-                    tooltipText: qsTr("Color Picker (F / Right-Click for RGB)")
+                    tooltipText: qsTr("Color Picker (F for RGB / Right-Click for Eyedropper)")
                     backgroundColor: root.currentTool === "colorpicker" ? Theme.withAlpha(Theme.primary, 0.15) : "transparent"
                     iconColor: root.currentTool === "colorpicker" ? Theme.primary : Theme.surfaceText
                 }
@@ -368,9 +368,9 @@ Rectangle {
                     cursorShape: Qt.PointingHandCursor
                     onClicked: mouse => {
                         if (mouse.button === Qt.RightButton) {
-                            root.colorPickerRightClicked(colorPickerVerticalButton);
-                        } else {
                             root.toolSelected("colorpicker-draw");
+                        } else {
+                            root.customColorPickerRequested(colorPickerVerticalButton);
                         }
                     }
                 }


### PR DESCRIPTION
This Pull Request swaps the mouse actions on the colorpicker button (icon `colorize`) and updates the shortcut behavior of `F` for better UX. It also fixes color object conversion warnings.

### What
- **Action Swap**: Left-clicking (or regular clicking) the colorpicker button on the toolbar now triggers the standard DMS RGB Color Picker Modal. Right-clicking now activates the canvas eyedropper tool (`colorpicker-draw`).
- **Shortcut Update**: Pressing the keyboard shortcut `F` now opens the DMS RGB Color Picker Modal directly instead of entering the canvas eyedropper mode.
- **Tooltip Sync**: Updated tooltips on the toolbar to match the new behavior: `"Color Picker (F for RGB / Right-Click for Eyedropper)"`.
- **Bug Fix**: Resolved QML warning `"[object Object] is not a valid color name"` by properly checking if color variables are already color objects before converting them via `Qt.color()`.

### How tested
- Verified that left-clicking opens the RGB color picker modal.
- Verified that right-clicking opens the eyedropper canvas.
- Verified pressing `F` opens the RGB color picker modal.
- Checked system logs to ensure QML type warnings are fully eliminated.

## Summary by Sourcery

Swap color picker toolbar interactions and shortcut behavior while hardening color value handling.

New Features:
- Make the F keyboard shortcut open the RGB color picker modal instead of toggling the canvas eyedropper tool.
- Change the color picker toolbar button so left-click opens the RGB color picker modal and right-click activates the canvas eyedropper tool.

Bug Fixes:
- Prevent QML warnings about invalid color names by avoiding redundant Qt.color() conversion when values are already color objects.

Enhancements:
- Align toolbar tooltips and signals with the new color picker and eyedropper behavior across horizontal and vertical toolbars.
- Refine custom palette color resolution to handle both string and color-object inputs safely.
- Simplify color resolution logic to return non-string colors directly without re-wrapping them.