### PR TITLE
feat(backdrop): make backdrop swatches circular and add colorpicker button

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1575,6 +1575,28 @@ DankModal {
                         window.hasUserCustomizedBackdrop = true;
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     }
+                    onBackdropColorPickerRequested: (currentColor) => {
+                        moreToolsMenu.close();
+                        if (typeof PopoutService !== "undefined" && PopoutService && PopoutService.colorPickerModal) {
+                            PopoutService.colorPickerModal.selectedColor = currentColor;
+                            PopoutService.colorPickerModal.pickerTitle = I18n.tr("Choose Color");
+                            PopoutService.colorPickerModal.onColorSelectedCallback = function (selectedColor) {
+                                if (window.backdropMode === "solid") {
+                                    window.backdropSolidColor = selectedColor;
+                                } else {
+                                    const activeSlot = (window.toolbarItem ? window.toolbarItem.gradientActiveSlot : "start");
+                                    if (activeSlot === "start") {
+                                        window.backdropGradientStart = selectedColor;
+                                    } else {
+                                        window.backdropGradientEnd = selectedColor;
+                                    }
+                                }
+                                window.hasUserCustomizedBackdrop = true;
+                                if (window.activeCanvas) window.activeCanvas.requestPaint();
+                            };
+                            PopoutService.colorPickerModal.show();
+                        }
+                    }
                     onChangeBackdropGradientStart: (col) => {
                         window.backdropGradientStart = col;
                         window.hasUserCustomizedBackdrop = true;

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -15,13 +15,14 @@ Row {
 
     signal setGradientActiveSlot(string slot)
     signal autoColorBalanceRequested()
+    signal colorPickerRequested(color currentColor)
 
     spacing: Theme.spacingXS
     anchors.verticalCenter: parent.verticalCenter
 
     Rectangle {
         visible: controlRoot.backdropMode === "solid"
-        width: controlRoot.itemSize; height: controlRoot.itemSize; radius: Math.round(controlRoot.itemSize * 0.16)
+        width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
         color: controlRoot.backdropSolidColor
         border.color: Theme.withAlpha(Theme.outline, 0.3)
         border.width: 1
@@ -35,7 +36,7 @@ Row {
         anchors.verticalCenter: parent.verticalCenter
 
         Rectangle {
-            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: Math.round(controlRoot.itemSize * 0.16)
+            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
             color: controlRoot.backdropGradientStart
             border.color: controlRoot.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
             border.width: controlRoot.gradientActiveSlot === "start" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
@@ -46,7 +47,7 @@ Row {
             }
         }
         Rectangle {
-            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: Math.round(controlRoot.itemSize * 0.16)
+            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
             color: controlRoot.backdropGradientEnd
             border.color: controlRoot.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
             border.width: controlRoot.gradientActiveSlot === "end" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
@@ -55,6 +56,19 @@ Row {
                 cursorShape: Qt.PointingHandCursor
                 onClicked: controlRoot.setGradientActiveSlot("end")
             }
+        }
+    }
+
+    DankActionButton {
+        buttonSize: controlRoot.itemSize
+        iconName: "colorize"
+        iconSize: controlRoot.iconSize
+        backgroundColor: "transparent"
+        iconColor: Theme.primary
+        onClicked: {
+            let col = controlRoot.backdropMode === "solid" ? controlRoot.backdropSolidColor :
+                      (controlRoot.gradientActiveSlot === "start" ? controlRoot.backdropGradientStart : controlRoot.backdropGradientEnd);
+            controlRoot.colorPickerRequested(col);
         }
     }
 

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -71,6 +71,24 @@ Rectangle {
     signal copyAndSaveRequested()
     signal closeRequested()
     signal annotationsToggled()
+    signal backdropColorPickerRequested(color currentColor)
+
+    function toHex6(c) {
+        if (c === undefined || c === null) return "";
+        var col = (typeof c === "string") ? Qt.color(c) : c;
+        if (!col) return "";
+        var r = Math.round((col.r || 0) * 255).toString(16);
+        if (r.length < 2) r = "0" + r;
+        var g = Math.round((col.g || 0) * 255).toString(16);
+        if (g.length < 2) g = "0" + g;
+        var b = Math.round((col.b || 0) * 255).toString(16);
+        if (b.length < 2) b = "0" + b;
+        return ("#" + r + g + b).toLowerCase();
+    }
+
+    function colorEquals(c1, c2) {
+        return toHex6(c1) === toHex6(c2);
+    }
 
     width: isVertical ? 56 : (contentLayout.width + Theme.spacingM * 2)
     height: isVertical ? (contentLayout.height + Theme.spacingM * 2) : 56
@@ -172,8 +190,8 @@ Rectangle {
                     model: root.toolbarPalette
                     delegate: Rectangle {
                         width: tc.swatchSize; height: tc.swatchSize; radius: tc.swatchRadius; color: modelData
-                        border.color: (root.activeColorSlotIndex === index && Qt.colorEqual(root.currentColor, modelData)) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: (root.activeColorSlotIndex === index && Qt.colorEqual(root.currentColor, modelData)) ? 2 : 1
+                        border.color: (root.activeColorSlotIndex === index && root.colorEquals(root.currentColor, modelData)) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: (root.activeColorSlotIndex === index && root.colorEquals(root.currentColor, modelData)) ? 2 : 1
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
@@ -334,8 +352,8 @@ Rectangle {
                     model: root.toolbarPalette
                     delegate: Rectangle {
                         width: tc.swatchSizeVert; height: tc.swatchSizeVert; radius: tc.swatchRadiusVert; color: modelData
-                        border.color: (root.activeColorSlotIndex === index && Qt.colorEqual(root.currentColor, modelData)) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: (root.activeColorSlotIndex === index && Qt.colorEqual(root.currentColor, modelData)) ? 2 : 1
+                        border.color: (root.activeColorSlotIndex === index && root.colorEquals(root.currentColor, modelData)) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                        border.width: (root.activeColorSlotIndex === index && root.colorEquals(root.currentColor, modelData)) ? 2 : 1
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
@@ -603,6 +621,7 @@ Rectangle {
                     iconSize: 14
                     onSetGradientActiveSlot: (slot) => root.gradientActiveSlot = slot
                     onAutoColorBalanceRequested: root.autoColorBalanceRequested()
+                    onColorPickerRequested: (currentColor) => root.backdropColorPickerRequested(currentColor)
                 }
                 
                 Grid {
@@ -833,10 +852,11 @@ Rectangle {
                     backdropGradientStart: root.backdropGradientStart
                     backdropGradientEnd: root.backdropGradientEnd
                     gradientActiveSlot: root.gradientActiveSlot
-                    itemSize: 18
-                    iconSize: 10
+                    itemSize: 24
+                    iconSize: 14
                     onSetGradientActiveSlot: (slot) => root.gradientActiveSlot = slot
                     onAutoColorBalanceRequested: root.autoColorBalanceRequested()
+                    onColorPickerRequested: (currentColor) => root.backdropColorPickerRequested(currentColor)
                 }
                 
                 Grid {


### PR DESCRIPTION
This Pull Request addresses the user request to improve backdrop color selection:

### What
- **Circular Swatches**: Changed the color rectangles in [BackdropColorSelectors.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/BackdropColorSelectors.qml) to be circular (`radius: itemSize / 2`), matching the design of primary toolbar swatches.
- **Larger Swatches**: Resized the backdrop color swatches in vertical layout to `24x24px` (previously `18x18px`) for consistency and visual clarity.
- **Colorpicker Button**: Added a dedicated Colorpicker button (icon `colorize`) to the right of the backdrop swatches. Left-clicking this button opens the system RGB Color Picker Modal (`PopoutService.colorPickerModal`) to edit the active backdrop color (Solid or Gradient Start/End).
- **Case-Insensitive Color Comparison Fix**: Implemented a robust `colorEquals` helper utilizing custom hex normalization to avoid highlight mismatch errors caused by character-casing or format differences.

### How tested
- Verified that color swatches display as perfect circles.
- Verified that clicking the colorpicker button opens the RGB modal and correctly updates backdrop colors.
- Verified that active swatches get correctly highlighted regardless of capitalization.

## Summary by Sourcery

Update backdrop color controls to use circular swatches, larger sizing, and a new color picker entry point, while improving color comparison logic for active state highlighting.

New Features:
- Add a dedicated backdrop color picker button that opens the RGB color picker modal for the currently active backdrop color.

Bug Fixes:
- Normalize colors to a consistent lowercase hex format before comparison to prevent active swatch highlighting mismatches due to differing color string representations.

Enhancements:
- Change backdrop swatches to circular shapes and increase their size in the vertical layout for consistency with toolbar swatches and better visibility.
- Reuse a custom color equality helper across toolbar swatch components to ensure consistent active color detection.