### PR TITLE
feat(callout): support 1 or 2 connecting lines customization

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -242,13 +242,15 @@ DankModal {
     property int calloutLinkLines: 1 // 1, 2
     onCalloutLinkLinesChanged: {
         if (selectedStroke && selectedStroke.tool === "callout") {
-            selectedStroke.calloutLinkLines = calloutLinkLines;
-            const idx = window.strokes.indexOf(selectedStroke);
-            if (idx !== -1) {
-                window.strokes[idx] = selectedStroke;
-                window.strokes = [...window.strokes];
+            if (selectedStroke.calloutLinkLines !== calloutLinkLines) {
+                selectedStroke.calloutLinkLines = calloutLinkLines;
+                const idx = window.strokes.indexOf(selectedStroke);
+                if (idx !== -1) {
+                    window.strokes[idx] = selectedStroke;
+                    window.strokes = [...window.strokes];
+                }
+                if (window.activeCanvas) window.activeCanvas.requestPaint();
             }
-            if (window.activeCanvas) window.activeCanvas.requestPaint();
         }
     }
     property bool isScreenshotDark: false

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -239,6 +239,18 @@ DankModal {
     onStampCounterFormatChanged: {
         window.reindexStamps();
     }
+    property int calloutLinkLines: 1 // 1, 2
+    onCalloutLinkLinesChanged: {
+        if (selectedStroke && selectedStroke.tool === "callout") {
+            selectedStroke.calloutLinkLines = calloutLinkLines;
+            const idx = window.strokes.indexOf(selectedStroke);
+            if (idx !== -1) {
+                window.strokes[idx] = selectedStroke;
+                window.strokes = [...window.strokes];
+            }
+            if (window.activeCanvas) window.activeCanvas.requestPaint();
+        }
+    }
     property bool isScreenshotDark: false
     property bool hasSampledContrast: false
     property real previewX: 0
@@ -518,6 +530,7 @@ DankModal {
     property int preGrabCalloutZoom: 150
     property color preGrabColor: Theme.primary
     property string preGrabRedactMode: "solid"
+    property int preGrabCalloutLinkLines: 1
     property point pressCoords: Qt.point(0, 0)
     property var originalPoints: []
 
@@ -908,6 +921,7 @@ DankModal {
             window.preGrabStrokeWidth = window.strokeWidth;
             window.preGrabColor = window.currentColor;
             window.preGrabRedactMode = window.activeRedactMode;
+            window.preGrabCalloutLinkLines = window.calloutLinkLines;
             window.strokeWidth = pasted.width;
             window.currentColor = pasted.color;
             if (pasted.tool === "redact" && pasted.redactMode) window.activeRedactMode = pasted.redactMode;
@@ -2334,6 +2348,9 @@ DankModal {
                                         } else if (window.currentTool === "redact") {
                                             redactOptionsToolbar.open(mapped.x, mapped.y);
                                             return;
+                                        } else if (window.currentTool === "callout") {
+                                            calloutOptionsToolbar.open(mapped.x, mapped.y);
+                                            return;
                                         }
                                     }
                                     radialMenu.open(mapped.x, mapped.y);
@@ -2367,6 +2384,7 @@ DankModal {
                                             window.preGrabCalloutZoom = window.calloutZoom;
                                             window.preGrabColor = window.currentColor;
                                             window.preGrabRedactMode = window.activeRedactMode;
+                                            window.preGrabCalloutLinkLines = window.calloutLinkLines;
                                         }
                                         
                                         window.selectedStroke = stroke;
@@ -2380,6 +2398,9 @@ DankModal {
                                         }
                                         if (stroke.tool === "redact" && stroke.redactMode) {
                                             window.activeRedactMode = stroke.redactMode;
+                                        }
+                                        if (stroke.tool === "callout") {
+                                            window.calloutLinkLines = stroke.calloutLinkLines !== undefined ? stroke.calloutLinkLines : 1;
                                         }
 
                                         // Detection for callout destination dragging
@@ -2528,7 +2549,8 @@ DankModal {
                                      lineStyle: window.currentTool === "line" ? window.activeLineStyle : "solid",
                                      arrowLineStyle: window.currentTool === "arrow" ? window.activeArrowLineStyle : "solid",
                                      arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled",
-                                     redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid"
+                                     redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid",
+                                     calloutLinkLines: window.currentTool === "callout" ? window.calloutLinkLines : 1
                                  };
                                  drawingCanvas.requestPaint();
                             }
@@ -2543,6 +2565,7 @@ DankModal {
                                      window.calloutZoom = window.preGrabCalloutZoom;
                                      window.currentColor = window.preGrabColor;
                                      window.activeRedactMode = window.preGrabRedactMode;
+                                     window.calloutLinkLines = window.preGrabCalloutLinkLines;
                                      window.calloutDestDragging = false;
                                      window.originalPoints = [];
                                      drawingCanvas.requestPaint();
@@ -3014,6 +3037,13 @@ DankModal {
                     toolbarPosition: window.toolbarPosition
                     currentMode: window.activeRedactMode
                     onModeSelected: (mode) => window.activeRedactMode = mode
+                }
+
+                CalloutOptionsToolbar {
+                    id: calloutOptionsToolbar
+                    toolbarPosition: window.toolbarPosition
+                    currentLinkLines: window.calloutLinkLines
+                    onLinkLinesSelected: (count) => window.calloutLinkLines = count
                 }
 
                 MoreToolsMenu {

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ binds {
   - **Line tool**: Line styles (dashed, dotted)
   - **Rectangle tool**: Border styles (dashed, dotted)
   - **Redact tool**: Clean text eraser (dominant color/gradient background matcher)
+  - **Callout tool**: Ellipse callout shape support
 
 ## Credits
 

--- a/components/CalloutOptionsToolbar.qml
+++ b/components/CalloutOptionsToolbar.qml
@@ -1,0 +1,118 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+import ".."
+
+Item {
+    id: root
+    z: 2000
+    anchors.fill: parent
+
+    ToolbarConstants { id: tc }
+
+    property bool visibleState: false
+    visible: opacity > 0
+    opacity: 0
+
+    property real menuX: 0
+    property real menuY: 0
+
+    property int currentLinkLines: 1
+    property string toolbarPosition: "top"
+
+    signal linkLinesSelected(int count)
+
+    states: [
+        State {
+            name: "visible"
+            when: root.visibleState
+            PropertyChanges { target: root; opacity: 1.0 }
+            PropertyChanges { target: menuContent; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { target: root; property: "opacity"; duration: 120; easing.type: Easing.OutQuad }
+            NumberAnimation { target: menuContent; property: "scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open(x, y) {
+        root.menuX = x;
+        root.menuY = y;
+        root.visibleState = true;
+    }
+
+    function close() {
+        root.visibleState = false;
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: (mouse) => {
+            root.close();
+            mouse.accepted = false;
+        }
+    }
+
+    Rectangle {
+        id: menuContent
+        width: contentRow.implicitWidth + Theme.spacingM * 2
+        height: tc.subToolbarHeight
+        x: Math.max(10, Math.min(root.width - width - 10, root.menuX - width / 2))
+        y: root.toolbarPosition === "bottom"
+            ? Math.max(10, Math.min(root.height - height - 10, root.menuY - height - 20))
+            : Math.max(10, Math.min(root.height - height - 10, root.menuY + 20))
+        scale: 0.95
+
+        color: Theme.surfaceContainer
+        border.color: Theme.withAlpha(Theme.outline, 0.15)
+        border.width: 1
+        radius: Theme.cornerRadius
+
+        Row {
+            id: contentRow
+            anchors.centerIn: parent
+            spacing: Theme.spacingS
+
+            // Group: Connecting Lines (1 Line, 2 Lines)
+            Row {
+                spacing: Theme.spacingXS
+                Repeater {
+                    model: [
+                        { icon: "remove", count: 1, tooltip: qsTr("1 Connecting Line") },
+                        { icon: "density_medium", count: 2, tooltip: qsTr("2 Connecting Lines") }
+                    ]
+                    delegate: Rectangle {
+                        width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
+                        radius: Theme.cornerRadius - 2
+                        color: root.currentLinkLines === modelData.count
+                            ? Theme.withAlpha(Theme.primary, 0.15)
+                            : (linesMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                        border.color: root.currentLinkLines === modelData.count ? Theme.primary : "transparent"
+                        border.width: 1
+
+                        DankIcon {
+                            anchors.centerIn: parent
+                            name: modelData.icon
+                            size: tc.subToolbarIconSize
+                            color: root.currentLinkLines === modelData.count ? Theme.primary : Theme.surfaceText
+                        }
+
+                        MouseArea {
+                            id: linesMouse
+                            anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.linkLinesSelected(modelData.count);
+                                root.close();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -401,20 +401,39 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 const bW = stroke.borderWidth !== undefined ? stroke.borderWidth : 2;
 
                 // 1. Draw connecting lines (dynamic corners) using semi-transparent stroke color
+                const linkLines = stroke.calloutLinkLines !== undefined ? stroke.calloutLinkLines : 1;
                 ctx.strokeStyle = Qt.rgba(rgb.r, rgb.g, rgb.b, 0.6);
                 ctx.lineWidth = bW;
                 ctx.beginPath();
                 
-                // Simple logic: connect closest horizontal corners
-                if (dx > sx + sw) { // Dest is to the right
-                    ctx.moveTo(srcP1.x, srcP0.y); ctx.lineTo(dstP0.x, dstP0.y);
-                    ctx.moveTo(srcP1.x, srcP1.y); ctx.lineTo(dstP0.x, dstP1.y);
-                } else if (dx + dw < sx) { // Dest is to the left
-                    ctx.moveTo(srcP0.x, srcP0.y); ctx.lineTo(dstP1.x, dstP0.y);
-                    ctx.moveTo(srcP0.x, srcP1.y); ctx.lineTo(dstP1.x, dstP1.y);
-                } else { // Dest is above/below
-                    ctx.moveTo(srcP0.x, srcP1.y); ctx.lineTo(dstP0.x, dstP0.y);
-                    ctx.moveTo(srcP1.x, srcP1.y); ctx.lineTo(dstP1.x, dstP0.y);
+                if (linkLines === 2) {
+                    // Simple logic: connect closest horizontal corners
+                    if (dx > sx + sw) { // Dest is to the right
+                        ctx.moveTo(srcP1.x, srcP0.y); ctx.lineTo(dstP0.x, dstP0.y);
+                        ctx.moveTo(srcP1.x, srcP1.y); ctx.lineTo(dstP0.x, dstP1.y);
+                    } else if (dx + dw < sx) { // Dest is to the left
+                        ctx.moveTo(srcP0.x, srcP0.y); ctx.lineTo(dstP1.x, dstP0.y);
+                        ctx.moveTo(srcP0.x, srcP1.y); ctx.lineTo(dstP1.x, dstP1.y);
+                    } else { // Dest is above/below
+                        ctx.moveTo(srcP0.x, srcP1.y); ctx.lineTo(dstP0.x, dstP0.y);
+                        ctx.moveTo(srcP1.x, srcP1.y); ctx.lineTo(dstP1.x, dstP0.y);
+                    }
+                } else { // 1 Line
+                    if (dx > sx + sw) { // Dest is to the right
+                        ctx.moveTo(sx + sw, sy + sh / 2);
+                        ctx.lineTo(dx, dy + dh / 2);
+                    } else if (dx + dw < sx) { // Dest is to the left
+                        ctx.moveTo(sx, sy + sh / 2);
+                        ctx.lineTo(dx + dw, dy + dh / 2);
+                    } else { // Dest is above/below
+                        if (dy > sy + sh) { // Dest is below
+                            ctx.moveTo(sx + sw / 2, sy + sh);
+                            ctx.lineTo(dx + dw / 2, dy);
+                        } else { // Dest is above
+                            ctx.moveTo(sx + sw / 2, sy);
+                            ctx.lineTo(dx + dw / 2, dy + dh);
+                        }
+                    }
                 }
                 ctx.stroke();
 

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -401,7 +401,7 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 const bW = stroke.borderWidth !== undefined ? stroke.borderWidth : 2;
 
                 // 1. Draw connecting lines (dynamic corners) using semi-transparent stroke color
-                const linkLines = stroke.calloutLinkLines !== undefined ? stroke.calloutLinkLines : 1;
+                const linkLines = stroke.calloutLinkLines !== undefined ? stroke.calloutLinkLines : 2;
                 ctx.strokeStyle = Qt.rgba(rgb.r, rgb.g, rgb.b, 0.6);
                 ctx.lineWidth = bW;
                 ctx.beginPath();


### PR DESCRIPTION
This Pull Request adds customization options for the connecting lines in the Area Zoom (Callout) annotation tool.

### What
1. **Simplified Option Toolbar**:
   * Created a clean [CalloutOptionsToolbar.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/CalloutOptionsToolbar.qml) sub-toolbar equipped with:
     - **1 Line** (Icon `remove`, new default style)
     - **2 Lines** (Icon `density_medium`, legacy side-lines style)
2. **Interactive Rendering Updates**:
   * Modified the connecting lines drawing paths in [components/DrawingRenderer.js](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/DrawingRenderer.js):
     - In **1 Line Mode**, the path joins the midpoint of the closest bounding box edges (left, right, top, or bottom) of the source and destination zoom areas to present a clean single line.
     - In **2 Lines Mode**, the legacy double connecting lines are drawn as before.
3. **Integration**:
   * Linked `calloutLinkLines` properties inside [QuickCaptureModal.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/QuickCaptureModal.qml).
   * Enabled toolbar triggering on `Shift+RightClick` when the callout tool is active or when a callout vector is selected.
4. **Roadmap**:
   * Added the "Ellipse callout shape support" to the roadmap in `README.md` for future releases.

### How tested
* Placed a callout and pressed `Shift+RightClick` to toggle between 1 and 2 connecting lines.
* Verified that both modes render properly relative to the source and destination boxes coordinates.

## Summary by Sourcery

Add configurable connecting-line styles for callout annotations and integrate a dedicated options toolbar for selecting one or two link lines.

New Features:
- Introduce a Callout options sub-toolbar to choose between one or two connecting lines for callout annotations.
- Allow callout strokes to store and use a calloutLinkLines property when creating or editing annotations.

Enhancements:
- Update callout rendering logic so single-line mode connects midpoints of the nearest edges between source and destination regions while preserving the legacy double-line behavior.
- Wire callout link line preferences into pre-grab/restore flows and context interactions, including Shift+RightClick access to the callout options toolbar.

Documentation:
- Note future ellipse callout shape support in the roadmap section of the README.