### PR TITLE
feat(daemon): add compositor guard check for window capture mode

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -47,8 +47,24 @@ PluginComponent {
 
     function triggerCapture(mode) {
         root.restoringFromFloat = false;
-        root.activeIpcMode = mode || "";
-        root.startCaptureAfterDelay();
+        const targetMode = mode ? mode : root.captureMode;
+        
+        if (targetMode === "window") {
+            const checkCmd = "if [ -n \"$HYPRLAND_INSTANCE_SIGNATURE\" ] || pgrep -x dwl >/dev/null; then echo \"SUPPORTED\"; else echo \"UNSUPPORTED\"; fi";
+            Proc.runCommand("check-compositor", ["sh", "-c", checkCmd], (stdout, exitCode) => {
+                if (stdout.trim() !== "SUPPORTED") {
+                    if (typeof ToastService !== "undefined" && ToastService) {
+                        ToastService.showError(qsTr("Window capture mode is only supported on Hyprland or DWL."));
+                    }
+                    return;
+                }
+                root.activeIpcMode = mode || "";
+                root.startCaptureAfterDelay();
+            });
+        } else {
+            root.activeIpcMode = mode || "";
+            root.startCaptureAfterDelay();
+        }
     }
 
     function closeControlCenter() {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -52,9 +52,9 @@ PluginComponent {
         if (targetMode === "window") {
             const checkCmd = "if [ -n \"$HYPRLAND_INSTANCE_SIGNATURE\" ] || pgrep -x dwl >/dev/null; then echo \"SUPPORTED\"; else echo \"UNSUPPORTED\"; fi";
             Proc.runCommand("check-compositor", ["sh", "-c", checkCmd], (stdout, exitCode) => {
-                if (stdout.trim() !== "SUPPORTED") {
+                if (!stdout || stdout.trim() !== "SUPPORTED") {
                     if (typeof ToastService !== "undefined" && ToastService) {
-                        ToastService.showError(qsTr("Window capture mode is only supported on Hyprland or DWL."));
+                        ToastService.showError(I18n.tr("Window capture mode is only supported on Hyprland or DWL."));
                     }
                     return;
                 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -56,5 +56,6 @@
   "Text Note": "Text Note",
   "Thickness": "Thickness",
   "Tool": "Tool",
-  "Underline": "Underline"
+  "Underline": "Underline",
+  "Window capture mode is only supported on Hyprland or DWL.": "Window capture mode is only supported on Hyprland or DWL."
 }


### PR DESCRIPTION
This Pull Request adds a Wayland compositor check guard for `window` capture mode to prevent crashes on non-supported environments (e.g. Niri).

### What
1. **Compositor Verification**:
   - Before taking a screenshot, the daemon resolves the target capture mode (whether explicitly passed as arguments or loaded dynamically from the plugin settings `captureMode`).
   - If the resolved mode is `"window"`, the daemon checks compositor support by verifying the `HYPRLAND_INSTANCE_SIGNATURE` environment variable (for Hyprland) or checking if the `dwl` compositor process is running.
2. **Error Handling**:
   - If the environment is unsupported, the screenshot is aborted, and a Toast error notification `Window capture mode is only supported on Hyprland or DWL.` is shown.

### How tested
* Triggered fullscreen capture (`dms ipc call quickCapture screenshot full`) -> runs normally.
* Triggered window capture (`dms ipc call quickCapture screenshot window`) on an unsupported environment -> aborts gracefully with a Toast error notification.

## Summary by Sourcery

Guard window capture mode with a compositor compatibility check to avoid crashes on unsupported Wayland environments.

New Features:
- Display a toast error when window capture mode is used on unsupported compositors.
- Resolve the effective capture mode from IPC argument or configured captureMode before triggering a screenshot.

Bug Fixes:
- Prevent daemon crashes by aborting window capture when the compositor is not Hyprland or DWL.