### PR TITLE
fix(toolbar): preserve activeColorSlotIndex property binding by avoiding direct internal assignments

### DIFF
--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -182,7 +182,6 @@ Rectangle {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
                             onClicked: {
-                                root.activeColorSlotIndex = index;
                                 root.colorSelected(modelData, index);
                             }
                         }
@@ -344,7 +343,6 @@ Rectangle {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
                             onClicked: {
-                                root.activeColorSlotIndex = index;
                                 root.colorSelected(modelData, index);
                             }
                         }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -181,9 +181,7 @@ Rectangle {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                root.colorSelected(modelData, index);
-                            }
+                            onClicked: root.colorSelected(modelData, index)
                         }
                     }
                 }
@@ -342,9 +340,7 @@ Rectangle {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                root.colorSelected(modelData, index);
-                            }
+                            onClicked: root.colorSelected(modelData, index)
                         }
                     }
                 }


### PR DESCRIPTION
This Pull Request fixes the visual color selection indicator (circle) getting stuck on the toolbar when color shortcuts are used.

### What
1. **Binding Preservation**:
   * Removed direct assignments of `root.activeColorSlotIndex = index;` inside both horizontal and vertical swatch groups of [components/QuickCaptureToolbar.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/QuickCaptureToolbar.qml).
   * Swatches will only emit the `colorSelected(modelData, index)` signal when clicked.
2. **State Sync**:
   * The parent context [QuickCaptureModal.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/QuickCaptureModal.qml) already listens to `onColorSelected` and updates `window.activeColorSlotIndex = index`.
   * This successfully triggers the property binding back into the toolbar, ensuring both mouse clicks and keyboard shortcuts (`Ctrl + 1-4`, `Ctrl + Q-R`) update the visual indicator properly.

### How tested
* Selected colors using shortcuts (`Ctrl + 1`, `Ctrl + Q`, etc.) -> verified the circle indicator on the toolbar correctly slides to the newly active slot.
* Clicked color swatches with the mouse -> verified the indicator moves correctly and drawing color changes successfully.

## Summary by Sourcery

Bug Fixes:
- Fix toolbar color selection indicator getting stuck when using keyboard color shortcuts by relying on the existing colorSelected flow instead of mutating activeColorSlotIndex directly.