### PR TITLE
perf: reduce editor resolution default to 720p and rename backdrop opacity to overlay opacity

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -262,10 +262,10 @@ DankModal {
 
     // --- Proxy Editing Optimization ---
     readonly property real maxEditDimension: {
-        const q = (window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.editQuality) || "720";
+        const q = (window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.editQuality) || String(Constants.defaultEditQuality);
         if (q === "original") return Infinity;
         const val = parseInt(q);
-        return (isNaN(val) || val <= 0) ? 720 : val;
+        return (isNaN(val) || val <= 0) ? Constants.defaultEditQuality : val;
     }
     readonly property real editScale: {
         if (!window.bgImageItem) return 1.0;
@@ -544,7 +544,7 @@ DankModal {
     // Helper to decode hex color to RGB
     function hexToRgb(hex) { return Helpers.hexToRgb(hex, Qt); }
 
-    backgroundOpacity: (window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.overlayOpacity !== undefined ? window.parentWidget.pluginData.overlayOpacity : window.parentWidget.pluginData.modalOpacity !== undefined ? window.parentWidget.pluginData.modalOpacity : 60) / 100
+    backgroundOpacity: (window.parentWidget && window.parentWidget.pluginData ? (window.parentWidget.pluginData.overlayOpacity !== undefined ? window.parentWidget.pluginData.overlayOpacity : window.parentWidget.pluginData.modalOpacity !== undefined ? window.parentWidget.pluginData.modalOpacity : 60) : 60) / 100
     backgroundColor: Theme.withAlpha(Theme.surfaceContainer, Theme.popupTransparency)
 
     readonly property bool textMonospace: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textMonospace !== undefined ? window.parentWidget.pluginData.textMonospace : false

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -262,10 +262,10 @@ DankModal {
 
     // --- Proxy Editing Optimization ---
     readonly property real maxEditDimension: {
-        const q = (window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.editQuality) || "1080";
+        const q = (window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.editQuality) || "720";
         if (q === "original") return Infinity;
         const val = parseInt(q);
-        return (isNaN(val) || val <= 0) ? 1080 : val;
+        return (isNaN(val) || val <= 0) ? 720 : val;
     }
     readonly property real editScale: {
         if (!window.bgImageItem) return 1.0;
@@ -544,7 +544,7 @@ DankModal {
     // Helper to decode hex color to RGB
     function hexToRgb(hex) { return Helpers.hexToRgb(hex, Qt); }
 
-    backgroundOpacity: (window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.modalOpacity !== undefined ? window.parentWidget.pluginData.modalOpacity : 60) / 100
+    backgroundOpacity: (window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.overlayOpacity !== undefined ? window.parentWidget.pluginData.overlayOpacity : window.parentWidget.pluginData.modalOpacity !== undefined ? window.parentWidget.pluginData.modalOpacity : 60) / 100
     backgroundColor: Theme.withAlpha(Theme.surfaceContainer, Theme.popupTransparency)
 
     readonly property bool textMonospace: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textMonospace !== undefined ? window.parentWidget.pluginData.textMonospace : false

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -1,4 +1,5 @@
 import "./dms-common"
+import "components/Constants.js" as Constants
 import QtQuick
 import Quickshell
 import qs.Common
@@ -798,7 +799,7 @@ PluginSettings {
                 { label: I18n.tr("2160px (4K)"), value: "2160" },
                 { label: I18n.tr("Original (Unscaled)"), value: "original" }
             ]
-            defaultValue: "720"
+            defaultValue: String(Constants.defaultEditQuality)
         }
 
         InfoText {

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -1,5 +1,4 @@
 import "./dms-common"
-import "components/Constants.js" as Constants
 import QtQuick
 import Quickshell
 import qs.Common
@@ -799,7 +798,7 @@ PluginSettings {
                 { label: I18n.tr("2160px (4K)"), value: "2160" },
                 { label: I18n.tr("Original (Unscaled)"), value: "original" }
             ]
-            defaultValue: String(Constants.defaultEditQuality)
+            defaultValue: "720"
         }
 
         InfoText {

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -727,9 +727,9 @@ PluginSettings {
         SectionTitle {
             text: I18n.tr("Styles")
             icon: "aspect_ratio"
-            showReset: modalOpacity.isDirty || showCanvasBorder.isDirty || editQuality.isDirty || modalDisplayTarget.isDirty
+            showReset: overlayOpacity.isDirty || showCanvasBorder.isDirty || editQuality.isDirty || modalDisplayTarget.isDirty
             onResetClicked: {
-                modalOpacity.resetToDefault();
+                overlayOpacity.resetToDefault();
                 showCanvasBorder.resetToDefault();
                 editQuality.resetToDefault();
                 modalDisplayTarget.resetToDefault();
@@ -763,9 +763,9 @@ PluginSettings {
         Separator {}
 
         SliderSettingPlus {
-            id: modalOpacity
-            settingKey: "modalOpacity"
-            label: I18n.tr("Backdrop Opacity")
+            id: overlayOpacity
+            settingKey: "overlayOpacity"
+            label: I18n.tr("Overlay Opacity")
             defaultValue: 60
             minimum: 0
             maximum: 100
@@ -798,7 +798,7 @@ PluginSettings {
                 { label: I18n.tr("2160px (4K)"), value: "2160" },
                 { label: I18n.tr("Original (Unscaled)"), value: "original" }
             ]
-            defaultValue: "1080"
+            defaultValue: "720"
         }
 
         InfoText {

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -1,6 +1,7 @@
 .pragma library
 
 // Configuration defaults
+const defaultEditQuality = 720;
 const defaultBackdropPadding = 40;
 const defaultBackdropCornerRadius = 12;
 const defaultBackdropShadowStrength = 50;


### PR DESCRIPTION
## Summary

Two enhancements to improve clarity and performance:

### perf: Reduce editor resolution limit default to 720p (#86)
- Change `editQuality` default from `1080` to `720`
- Higher options (1440px, 2160px, Original) still available for powerful machines
- Reduces GPU/CPU load for most users

### refactor: Rename "Backdrop Opacity" to "Overlay Opacity" (#87)
- Rename setting label + key from `modalOpacity` → `overlayOpacity`
- Actual controls the dim overlay outside canvas, NOT the backdrop feature
- Backward compatible: reads old `modalOpacity` key as fallback

Closes #86
Closes #87

## Summary by Sourcery

Lower the default editor resolution to 720p and rename the overlay opacity setting for clarity while keeping existing configs compatible.

Enhancements:
- Rename the visual dimming setting from Backdrop Opacity to Overlay Opacity and update its setting key to overlayOpacity.
- Adjust the editor proxy editing logic to use 720p as the default maximum edit dimension instead of 1080p while keeping higher resolutions available.

Chores:
- Maintain backward compatibility by falling back to the legacy modalOpacity setting when overlayOpacity is not present.