### PR TITLE
feat: treat very small region selections as dismiss/cancel action

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -95,8 +95,7 @@ PluginComponent {
                             root.isCapturing = false;
                             root.activeIpcMode = "";
                             root.resolvedDmsPath = "dms"; // reset to default path on success
-                            modal.shouldBeVisible = true;
-                            modal.openCentered();
+                            root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
                         } else {
                             // File not written — user cancelled with ESC. Reset silently.
                             root.isCapturing = false;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2576,7 +2576,11 @@ DankModal {
 
                                 if (window.currentTool === "crop") {
                                     if (window.activeHandle === "new" || window.activeHandle === "tl" || window.activeHandle === "tr" || window.activeHandle === "bl" || window.activeHandle === "br") {
-                                        if (window.cropRect.width > 10 && window.cropRect.height > 10) {
+                                        if (window.cropRect.width <= 3 && window.cropRect.height <= 3) {
+                                            window.discardAndClose();
+                                            return;
+                                        }
+                                        if (window.cropRect.width >= 16 && window.cropRect.height >= 16) {
                                             window.hasSelection = true;
                                             // Automatically enter edit mode with the pen tool once selection is made/resized!
                                             window.currentTool = "pen";

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -544,7 +544,13 @@ DankModal {
     // Helper to decode hex color to RGB
     function hexToRgb(hex) { return Helpers.hexToRgb(hex, Qt); }
 
-    backgroundOpacity: (window.parentWidget && window.parentWidget.pluginData ? (window.parentWidget.pluginData.overlayOpacity !== undefined ? window.parentWidget.pluginData.overlayOpacity : window.parentWidget.pluginData.modalOpacity !== undefined ? window.parentWidget.pluginData.modalOpacity : 60) : 60) / 100
+    backgroundOpacity: {
+        const data = window.parentWidget && window.parentWidget.pluginData;
+        if (!data) return 0.6;
+        if (data.overlayOpacity !== undefined) return data.overlayOpacity / 100;
+        if (data.modalOpacity !== undefined) return data.modalOpacity / 100;
+        return 0.6;
+    }
     backgroundColor: Theme.withAlpha(Theme.surfaceContainer, Theme.popupTransparency)
 
     readonly property bool textMonospace: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textMonospace !== undefined ? window.parentWidget.pluginData.textMonospace : false
@@ -2574,13 +2580,18 @@ DankModal {
                                      return;
                                 }
 
-                                if (window.currentTool === "crop") {
+                                 if (window.currentTool === "crop") {
                                     if (window.activeHandle === "new" || window.activeHandle === "tl" || window.activeHandle === "tr" || window.activeHandle === "bl" || window.activeHandle === "br") {
-                                        if (window.cropRect.width <= 3 && window.cropRect.height <= 3) {
-                                            window.discardAndClose();
+                                        if (Math.min(window.cropRect.width, window.cropRect.height) <= 3) {
+                                            if (window.strokes.length === 0) {
+                                                window.discardAndClose();
+                                            } else {
+                                                window.hasSelection = false;
+                                                window.cropRect = Qt.rect(0, 0, 0, 0);
+                                            }
                                             return;
                                         }
-                                        if (window.cropRect.width >= 16 && window.cropRect.height >= 16) {
+                                        if (Math.min(window.cropRect.width, window.cropRect.height) >= 16) {
                                             window.hasSelection = true;
                                             // Automatically enter edit mode with the pen tool once selection is made/resized!
                                             window.currentTool = "pen";


### PR DESCRIPTION
## Summary

When a user makes a tiny region selection (single click resulting in 1x1 or 2x2 pixels), instead of capturing a useless sliver, the screenshot is dismissed.

### Changes

**QuickCaptureDaemon.qml**
- Validate captured image dimensions before opening the annotation editor
- Reuses existing `validateAndOpenCapturedImage()` (min 16px threshold) which shows a toast "Image is too small" for tiny captures
- Previously, a 1x1 region selection would open the editor with an unusable image

**QuickCaptureModal.qml** (crop tool — for already-opened images)
- `<= 3px` → dismiss modal (click suông)
- `>= 16px` → accept selection, enter annotation mode
- 4–15px → clear selection (allow re-drag)

Closes #84

## Summary by Sourcery

Treat tiny region selections as cancellation and reuse captured image validation before opening the annotation editor.

New Features:
- Dismiss crop selections of 3x3 pixels or smaller as a cancel action instead of creating a tiny annotation region.

Enhancements:
- Require a minimum crop selection size before entering annotation mode in the modal.
- Route completed background captures through the existing captured image validation flow instead of opening the modal unconditionally.