### PR TITLE
fix: clip spotlight dim overlay to backdrop corner radius

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1987,9 +1987,9 @@ DankModal {
                                         
                                         // Clip to backdrop corner radius if backdrop is active
                                         if (window.effectiveBackdropMode !== "none" && window.backdropCornerRadius > 0) {
-                                            const r = window.backdropCornerRadius;
                                             const sw = window.screenshotWidth;
                                             const sh = window.screenshotHeight;
+                                            const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
                                             ctx.beginPath();
                                             ctx.moveTo(r, 0);
                                             ctx.lineTo(sw - r, 0);
@@ -2916,9 +2916,9 @@ DankModal {
                                     
                                     // Clip to backdrop corner radius if backdrop is active
                                     if (window.effectiveBackdropMode !== "none" && window.backdropCornerRadius > 0) {
-                                        const r = window.backdropCornerRadius;
                                         const sw = window.screenshotWidth;
                                         const sh = window.screenshotHeight;
+                                        const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
                                         ctx.beginPath();
                                         ctx.moveTo(r, 0);
                                         ctx.lineTo(sw - r, 0);

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1985,6 +1985,25 @@ DankModal {
                                     if (spotlights.length > 0) {
                                         ctx.save();
                                         
+                                        // Clip to backdrop corner radius if backdrop is active
+                                        if (window.effectiveBackdropMode !== "none" && window.backdropCornerRadius > 0) {
+                                            const r = window.backdropCornerRadius;
+                                            const sw = window.screenshotWidth;
+                                            const sh = window.screenshotHeight;
+                                            ctx.beginPath();
+                                            ctx.moveTo(r, 0);
+                                            ctx.lineTo(sw - r, 0);
+                                            ctx.arcTo(sw, 0, sw, r, r);
+                                            ctx.lineTo(sw, sh - r);
+                                            ctx.arcTo(sw, sh, sw - r, sh, r);
+                                            ctx.lineTo(r, sh);
+                                            ctx.arcTo(0, sh, 0, sh - r, r);
+                                            ctx.lineTo(0, r);
+                                            ctx.arcTo(0, 0, r, 0, r);
+                                            ctx.closePath();
+                                            ctx.clip();
+                                        }
+                                        
                                         // Determine which intensity to use for the global dimming opacity
                                         let activeInt = window.spotlightIntensity;
                                         if (window.currentTool === "select" && window.selectedStroke && window.selectedStroke.tool === "spotlight") {
@@ -2894,6 +2913,25 @@ DankModal {
 
                                 if (spotlights.length > 0) {
                                     ctx.save();
+                                    
+                                    // Clip to backdrop corner radius if backdrop is active
+                                    if (window.effectiveBackdropMode !== "none" && window.backdropCornerRadius > 0) {
+                                        const r = window.backdropCornerRadius;
+                                        const sw = window.screenshotWidth;
+                                        const sh = window.screenshotHeight;
+                                        ctx.beginPath();
+                                        ctx.moveTo(r, 0);
+                                        ctx.lineTo(sw - r, 0);
+                                        ctx.arcTo(sw, 0, sw, r, r);
+                                        ctx.lineTo(sw, sh - r);
+                                        ctx.arcTo(sw, sh, sw - r, sh, r);
+                                        ctx.lineTo(r, sh);
+                                        ctx.arcTo(0, sh, 0, sh - r, r);
+                                        ctx.lineTo(0, r);
+                                        ctx.arcTo(0, 0, r, 0, r);
+                                        ctx.closePath();
+                                        ctx.clip();
+                                    }
                                     
                                     let activeInt = window.spotlightIntensity;
                                     if (window.currentTool === "select" && window.selectedStroke && window.selectedStroke.tool === "spotlight") {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1985,24 +1985,8 @@ DankModal {
                                     if (spotlights.length > 0) {
                                         ctx.save();
                                         
-                                        // Clip to backdrop corner radius if backdrop is active
-                                        if (window.effectiveBackdropMode !== "none" && window.backdropCornerRadius > 0) {
-                                            const sw = window.screenshotWidth;
-                                            const sh = window.screenshotHeight;
-                                            const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
-                                            ctx.beginPath();
-                                            ctx.moveTo(r, 0);
-                                            ctx.lineTo(sw - r, 0);
-                                            ctx.arcTo(sw, 0, sw, r, r);
-                                            ctx.lineTo(sw, sh - r);
-                                            ctx.arcTo(sw, sh, sw - r, sh, r);
-                                            ctx.lineTo(r, sh);
-                                            ctx.arcTo(0, sh, 0, sh - r, r);
-                                            ctx.lineTo(0, r);
-                                            ctx.arcTo(0, 0, r, 0, r);
-                                            ctx.closePath();
-                                            ctx.clip();
-                                        }
+                                        const sw = window.screenshotWidth;
+                                        const sh = window.screenshotHeight;
                                         
                                         // Determine which intensity to use for the global dimming opacity
                                         let activeInt = window.spotlightIntensity;
@@ -2015,14 +1999,23 @@ DankModal {
 
                                         const spotlightOpacity = activeInt / 100.0;
                                         
-                                        const dimmingX = 0;
-                                        const dimmingY = 0;
-                                        const dimmingW = window.screenshotWidth;
-                                        const dimmingH = window.screenshotHeight;
-
                                         ctx.beginPath();
-                                        // Outer rectangle covering the whole view
-                                        ctx.rect(dimmingX, dimmingY, dimmingW, dimmingH);
+                                        // Outer rectangle covering the whole view (rounded if backdrop active)
+                                        if (window.effectiveBackdropMode !== "none" && window.backdropCornerRadius > 0) {
+                                            const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
+                                            ctx.moveTo(r, 0);
+                                            ctx.lineTo(sw - r, 0);
+                                            ctx.arcTo(sw, 0, sw, r, r);
+                                            ctx.lineTo(sw, sh - r);
+                                            ctx.arcTo(sw, sh, sw - r, sh, r);
+                                            ctx.lineTo(r, sh);
+                                            ctx.arcTo(0, sh, 0, sh - r, r);
+                                            ctx.lineTo(0, r);
+                                            ctx.arcTo(0, 0, r, 0, r);
+                                            ctx.closePath();
+                                        } else {
+                                            ctx.rect(0, 0, sw, sh);
+                                        }
                                         
                                         for (let s of spotlights) {
                                             if (s.points.length >= 2) {
@@ -2914,24 +2907,8 @@ DankModal {
                                 if (spotlights.length > 0) {
                                     ctx.save();
                                     
-                                    // Clip to backdrop corner radius if backdrop is active
-                                    if (window.effectiveBackdropMode !== "none" && window.backdropCornerRadius > 0) {
-                                        const sw = window.screenshotWidth;
-                                        const sh = window.screenshotHeight;
-                                        const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
-                                        ctx.beginPath();
-                                        ctx.moveTo(r, 0);
-                                        ctx.lineTo(sw - r, 0);
-                                        ctx.arcTo(sw, 0, sw, r, r);
-                                        ctx.lineTo(sw, sh - r);
-                                        ctx.arcTo(sw, sh, sw - r, sh, r);
-                                        ctx.lineTo(r, sh);
-                                        ctx.arcTo(0, sh, 0, sh - r, r);
-                                        ctx.lineTo(0, r);
-                                        ctx.arcTo(0, 0, r, 0, r);
-                                        ctx.closePath();
-                                        ctx.clip();
-                                    }
+                                    const sw = window.screenshotWidth;
+                                    const sh = window.screenshotHeight;
                                     
                                     let activeInt = window.spotlightIntensity;
                                     if (window.currentTool === "select" && window.selectedStroke && window.selectedStroke.tool === "spotlight") {
@@ -2944,7 +2921,22 @@ DankModal {
                                     const spotlightOpacity = activeInt / 100.0;
 
                                     ctx.beginPath();
-                                    ctx.rect(0, 0, window.screenshotWidth, window.screenshotHeight);
+                                    // Outer rectangle covering the whole view (rounded if backdrop active)
+                                    if (window.effectiveBackdropMode !== "none" && window.backdropCornerRadius > 0) {
+                                        const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
+                                        ctx.moveTo(r, 0);
+                                        ctx.lineTo(sw - r, 0);
+                                        ctx.arcTo(sw, 0, sw, r, r);
+                                        ctx.lineTo(sw, sh - r);
+                                        ctx.arcTo(sw, sh, sw - r, sh, r);
+                                        ctx.lineTo(r, sh);
+                                        ctx.arcTo(0, sh, 0, sh - r, r);
+                                        ctx.lineTo(0, r);
+                                        ctx.arcTo(0, 0, r, 0, r);
+                                        ctx.closePath();
+                                    } else {
+                                        ctx.rect(0, 0, sw, sh);
+                                    }
                                     
                                     for (let s of spotlights) {
                                         if (s.points.length >= 2) {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1991,7 +1991,16 @@ DankModal {
                                             const sh = window.screenshotHeight;
                                             const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
                                             ctx.beginPath();
-                                            ctx.roundRect(0, 0, sw, sh, r);
+                                            ctx.moveTo(r, 0);
+                                            ctx.lineTo(sw - r, 0);
+                                            ctx.arcTo(sw, 0, sw, r, r);
+                                            ctx.lineTo(sw, sh - r);
+                                            ctx.arcTo(sw, sh, sw - r, sh, r);
+                                            ctx.lineTo(r, sh);
+                                            ctx.arcTo(0, sh, 0, sh - r, r);
+                                            ctx.lineTo(0, r);
+                                            ctx.arcTo(0, 0, r, 0, r);
+                                            ctx.closePath();
                                             ctx.clip();
                                         }
                                         
@@ -2911,7 +2920,16 @@ DankModal {
                                         const sh = window.screenshotHeight;
                                         const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
                                         ctx.beginPath();
-                                        ctx.roundRect(0, 0, sw, sh, r);
+                                        ctx.moveTo(r, 0);
+                                        ctx.lineTo(sw - r, 0);
+                                        ctx.arcTo(sw, 0, sw, r, r);
+                                        ctx.lineTo(sw, sh - r);
+                                        ctx.arcTo(sw, sh, sw - r, sh, r);
+                                        ctx.lineTo(r, sh);
+                                        ctx.arcTo(0, sh, 0, sh - r, r);
+                                        ctx.lineTo(0, r);
+                                        ctx.arcTo(0, 0, r, 0, r);
+                                        ctx.closePath();
                                         ctx.clip();
                                     }
                                     

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1991,16 +1991,7 @@ DankModal {
                                             const sh = window.screenshotHeight;
                                             const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
                                             ctx.beginPath();
-                                            ctx.moveTo(r, 0);
-                                            ctx.lineTo(sw - r, 0);
-                                            ctx.arcTo(sw, 0, sw, r, r);
-                                            ctx.lineTo(sw, sh - r);
-                                            ctx.arcTo(sw, sh, sw - r, sh, r);
-                                            ctx.lineTo(r, sh);
-                                            ctx.arcTo(0, sh, 0, sh - r, r);
-                                            ctx.lineTo(0, r);
-                                            ctx.arcTo(0, 0, r, 0, r);
-                                            ctx.closePath();
+                                            ctx.roundRect(0, 0, sw, sh, r);
                                             ctx.clip();
                                         }
                                         
@@ -2920,16 +2911,7 @@ DankModal {
                                         const sh = window.screenshotHeight;
                                         const r = Math.min(window.backdropCornerRadius, sw / 2, sh / 2);
                                         ctx.beginPath();
-                                        ctx.moveTo(r, 0);
-                                        ctx.lineTo(sw - r, 0);
-                                        ctx.arcTo(sw, 0, sw, r, r);
-                                        ctx.lineTo(sw, sh - r);
-                                        ctx.arcTo(sw, sh, sw - r, sh, r);
-                                        ctx.lineTo(r, sh);
-                                        ctx.arcTo(0, sh, 0, sh - r, r);
-                                        ctx.lineTo(0, r);
-                                        ctx.arcTo(0, 0, r, 0, r);
-                                        ctx.closePath();
+                                        ctx.roundRect(0, 0, sw, sh, r);
                                         ctx.clip();
                                     }
                                     


### PR DESCRIPTION
## Summary

When using spotlight tool with a backdrop mode, the dim overlay had sharp corners instead of matching the backdrop's rounded corners.

### Root cause
The spotlight dim overlay draws a full rectangle over the screenshot area, but `drawScreenshotImage()` restores its rounded-rect clip immediately after drawing the image. The dim overlay was drawn after, so it never got clipped.

### Fix
Apply the same rounded-rect clip (using `backdropCornerRadius`) to the spotlight dim overlay in both the drawing canvas and export canvas, before the evenodd clip for spotlight holes.

The clips stack correctly: rounded rect ∩ (full area − holes) = rounded rect with transparent holes.

Closes #89

## Summary by Sourcery

Bug Fixes:
- Ensure spotlight dim overlay is clipped to the backdrop corner radius when a backdrop is active to avoid sharp corners.