### PR TITLE
feat: use native dms clipboard commands instead of wl-clipboard

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -136,7 +136,7 @@ PluginComponent {
     function fromClipboard() {
         root.restoringFromFloat = false;
         root.closeControlCenter();
-        const checkCmd = "if wl-paste -t image/png > /tmp/dms_capture_bg.png 2>/dev/null || xclip -selection clipboard -t image/png -o > /tmp/dms_capture_bg.png 2>/dev/null; then echo \"IMAGE\"; else TEXT=$(wl-paste -n 2>/dev/null || xclip -selection clipboard -o 2>/dev/null); if [ -n \"$TEXT\" ]; then echo \"TEXT:$TEXT\"; else echo \"EMPTY\"; fi; fi";
+        const checkCmd = "if wl-paste -t image/png > /tmp/dms_capture_bg.png 2>/dev/null; then echo \"IMAGE\"; else TEXT=$(dms cl paste 2>/dev/null); if [ -n \"$TEXT\" ]; then echo \"TEXT:$TEXT\"; else echo \"EMPTY\"; fi; fi";
         Proc.runCommand("smart-paste", ["sh", "-c", checkCmd], (stdout, exitCode) => {
             const output = stdout.trim();
             if (output === "IMAGE") {

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -214,7 +214,7 @@ PluginSettings {
                             let colorStr = swatchRoot.overrideColor !== null
                                 ? swatchRoot.overrideColor.toString()
                                 : swatchRoot.value.toString();
-                            Proc.runCommand("copy-color", ["wl-copy", "--", colorStr], function() {
+                            Proc.runCommand("copy-color", ["dms", "cl", "copy", colorStr], function() {
                                 if (typeof ToastService !== "undefined" && ToastService) {
                                     ToastService.showInfo(I18n.tr("Copied:") + " " + colorStr.toUpperCase());
                                 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Screenshot and vector annotation plugin for DankMaterialShell (DMS).
 - **img2pdf** (required for PDF export)
 - **tesseract** (required for OCR text scanner)
 - **zbar** (provides `zbarimg`, required for QR scanner)
-- **wl-clipboard** (provides `wl-copy`/`wl-paste`, required for clipboard operations)
+- **wl-clipboard** (provides `wl-paste`, optional — only needed for pasting images from clipboard into editor)
 
 ## Install
 


### PR DESCRIPTION
## Summary

Replace `wl-clipboard` commands with DMS native clipboard for tighter shell integration.

### Changes

| File | Before | After |
|------|--------|-------|
| `QuickCaptureDaemon.qml` | `wl-paste` for text + `xclip` fallback | `dms cl paste` for text, keep `wl-paste` for image |
| `QuickCaptureSettings.qml` | `wl-copy` for color copy | `dms cl copy` |
| `README.md` | `wl-clipboard` listed as required | Marked as optional (only for image paste) |

Closes #90

## Summary by Sourcery

Use DMS native clipboard commands for text operations instead of wl-clipboard, while retaining wl-paste for image handling and updating docs accordingly.

New Features:
- Integrate DMS native clipboard commands for text paste and copy operations in quick capture workflows.

Enhancements:
- Simplify clipboard command usage by removing the xclip fallback and standardizing on DMS clipboard for text.
- Clarify clipboard tooling requirements in documentation, marking wl-clipboard as optional and image-only.