### PR TITLE
fix: preserve backdrop state across float/unfloat cycle

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1536,6 +1536,7 @@ DankModal {
                             window.backdropCornerRadius = data.backdropCornerRadius;
                             window.backdropShadowStrength = data.backdropShadowStrength;
                             window.backdropAspectRatio = data.backdropAspectRatio;
+                            window.customAspectRatio = data.customAspectRatio;
                             window.hasUserCustomizedBackdrop = data.hasUserCustomizedBackdrop;
                             window.autoBackdropGradientStart = data.autoBackdropGradientStart;
                             window.autoBackdropGradientEnd = data.autoBackdropGradientEnd;
@@ -3231,7 +3232,7 @@ DankModal {
                             window.autoBackdropGradientEnd = colors.end;
                             window.autoBackdropSolidColor = colors.start;
 
-                            if (!window.hasUserCustomizedBackdrop) {
+                            if (!window.hasUserCustomizedBackdrop && !(window.parentWidget && window.parentWidget.restoringFromFloat)) {
                                 window.backdropGradientStart = colors.start;
                                 window.backdropGradientEnd = colors.end;
                                 window.backdropSolidColor = colors.start;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1526,6 +1526,21 @@ DankModal {
                             window.cropRect = Qt.rect(data.cropRect.x, data.cropRect.y, data.cropRect.width, data.cropRect.height);
                             window.hasSelection = (data.cropRect.width > 0 && data.cropRect.height > 0);
                         }
+                        if (data && data.backdropMode !== undefined) {
+                            window.backdropMode = data.backdropMode;
+                            window.backdropSolidColor = data.backdropSolidColor;
+                            window.backdropGradientStart = data.backdropGradientStart;
+                            window.backdropGradientEnd = data.backdropGradientEnd;
+                            window.backdropGradientAngle = data.backdropGradientAngle;
+                            window.backdropPadding = data.backdropPadding;
+                            window.backdropCornerRadius = data.backdropCornerRadius;
+                            window.backdropShadowStrength = data.backdropShadowStrength;
+                            window.backdropAspectRatio = data.backdropAspectRatio;
+                            window.hasUserCustomizedBackdrop = data.hasUserCustomizedBackdrop;
+                            window.autoBackdropGradientStart = data.autoBackdropGradientStart;
+                            window.autoBackdropGradientEnd = data.autoBackdropGradientEnd;
+                            window.autoBackdropSolidColor = data.autoBackdropSolidColor;
+                        }
                         if (window.activeCanvas) window.activeCanvas.requestPaint();
                     } catch (e) {
                         console.error("Failed to parse strokes json:", e);

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -327,7 +327,20 @@ QtObject {
                         width: root.modal.cropRect.width,
                         height: root.modal.cropRect.height
                     },
-                    hasSelection: root.modal.hasSelection
+                    hasSelection: root.modal.hasSelection,
+                    backdropMode: root.modal.backdropMode,
+                    backdropSolidColor: root.modal.backdropSolidColor,
+                    backdropGradientStart: root.modal.backdropGradientStart,
+                    backdropGradientEnd: root.modal.backdropGradientEnd,
+                    backdropGradientAngle: root.modal.backdropGradientAngle,
+                    backdropPadding: root.modal.backdropPadding,
+                    backdropCornerRadius: root.modal.backdropCornerRadius,
+                    backdropShadowStrength: root.modal.backdropShadowStrength,
+                    backdropAspectRatio: root.modal.backdropAspectRatio,
+                    hasUserCustomizedBackdrop: root.modal.hasUserCustomizedBackdrop,
+                    autoBackdropGradientStart: root.modal.autoBackdropGradientStart,
+                    autoBackdropGradientEnd: root.modal.autoBackdropGradientEnd,
+                    autoBackdropSolidColor: root.modal.autoBackdropSolidColor
                 };
 
                 let jsonStr = JSON.stringify(stateData);

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -337,6 +337,7 @@ QtObject {
                     backdropCornerRadius: root.modal.backdropCornerRadius,
                     backdropShadowStrength: root.modal.backdropShadowStrength,
                     backdropAspectRatio: root.modal.backdropAspectRatio,
+                    customAspectRatio: root.modal.customAspectRatio,
                     hasUserCustomizedBackdrop: root.modal.hasUserCustomizedBackdrop,
                     autoBackdropGradientStart: root.modal.autoBackdropGradientStart,
                     autoBackdropGradientEnd: root.modal.autoBackdropGradientEnd,


### PR DESCRIPTION
When restoring a floated capture back into the editor, the backdrop
configuration (mode, colors, gradient, padding, corner radius, shadow,
aspect ratio) was lost and reset to auto-balance defaults.

**Root cause:** `stateData` in `performFloatAction` only saved strokes
and crop rect — backdrop properties were never serialized. On un-float,
`hasUserCustomizedBackdrop` was unconditionally reset to `false`,
causing auto-balance to overwrite the user's backdrop.

**Fix:**
- Save all 14 backdrop properties into the float sidecar JSON
- Restore them when returning from float, preserving
  `hasUserCustomizedBackdrop` so auto-balance doesn't interfere

Closes #88

## Summary by Sourcery

Bug Fixes:
- Serialize and restore backdrop mode, colors, gradient, padding, corner radius, shadow, aspect ratio, and customization flags in float state data to prevent loss of backdrop settings when unfloating captures.