### PR TITLE
fix: sync first palette slot with selected preset

### DIFF
--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -30,6 +30,7 @@ QtObject {
         "#22c55e",
         "#eab308",
         "#a855f7",
+        "#f97316",
         "#ffffff",
         "#000000"
     ]
@@ -40,6 +41,7 @@ QtObject {
         "#a3be8c",
         "#ebcb8b",
         "#b48ead",
+        "#81a1c1",
         "#e5e9f0",
         "#2e3440"
     ]
@@ -50,6 +52,7 @@ QtObject {
         "#98971a",
         "#d79921",
         "#b16286",
+        "#83a598",
         "#ebdbb2",
         "#282828"
     ]
@@ -60,6 +63,7 @@ QtObject {
         "#50fa7b",
         "#f1fa8c",
         "#ff79c6",
+        "#6272a4",
         "#f8f8f2",
         "#282a36"
     ]
@@ -70,6 +74,7 @@ QtObject {
         "#a6e3a1",
         "#f9e2af",
         "#cba6f7",
+        "#94e2d5",
         "#cdd6f4",
         "#1e1e2e"
     ]
@@ -80,6 +85,7 @@ QtObject {
         "#a6da95",
         "#eed49f",
         "#c6a0f6",
+        "#8bd5ca",
         "#cad3f5",
         "#24273a"
     ]
@@ -90,6 +96,7 @@ QtObject {
         "#a6d189",
         "#e5c890",
         "#ca9ee6",
+        "#81c8be",
         "#c6d0f5",
         "#303446"
     ]
@@ -100,6 +107,7 @@ QtObject {
         "#40a02b",
         "#df8e1d",
         "#8839ef",
+        "#179299",
         "#4c4f69",
         "#eff1f5"
     ]
@@ -141,11 +149,14 @@ QtObject {
     readonly property var accentColors: {
         const list = [];
         const isCustom = selectedPreset === "custom";
+        const isAdaptive = selectedPreset === "adaptive";
         for (let i = 0; i < 7; i++) {
             if (isCustom) {
                 list.push(pluginData["toolbar_color_" + i] || adaptiveColors[i]);
-            } else {
+            } else if (isAdaptive) {
                 list.push(defaultAccentColors[i]);
+            } else {
+                list.push(defaultAccentColors[i + 1]);
             }
         }
         return list;
@@ -171,7 +182,7 @@ QtObject {
     ]
 
     readonly property var colorShortcuts: [
-        { key: "1", color: selectedPreset === "custom" ? (pluginData["toolbar_color_primary"] || "primary") : defaultAccentColors[0] },
+        { key: "1", color: selectedPreset === "custom" ? (pluginData["toolbar_color_primary"] || "primary") : (selectedPreset === "adaptive" ? "primary" : defaultAccentColors[0]) },
         { key: "2", color: accentColors[0] },
         { key: "3", color: accentColors[1] },
         { key: "4", color: accentColors[2] },
@@ -198,6 +209,8 @@ QtObject {
                 if (selectedPreset === "custom") {
                     const primaryColor = pluginData["toolbar_color_primary"] || "primary";
                     resolved = primaryColor === "primary" ? Theme.primary : primaryColor;
+                } else if (selectedPreset === "adaptive") {
+                    resolved = Theme.primary;
                 } else {
                     resolved = defaultAccentColors[0];
                 }

--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -171,7 +171,7 @@ QtObject {
     ]
 
     readonly property var colorShortcuts: [
-        { key: "1", color: pluginData["toolbar_color_primary"] || "primary" },
+        { key: "1", color: selectedPreset === "custom" ? (pluginData["toolbar_color_primary"] || "primary") : defaultAccentColors[0] },
         { key: "2", color: accentColors[0] },
         { key: "3", color: accentColors[1] },
         { key: "4", color: accentColors[2] },
@@ -195,8 +195,12 @@ QtObject {
             const parts = rawColor.split("_");
             const slotIdx = parseInt(parts[1]) - 1;
             if (slotIdx === 0) {
-                const primaryColor = pluginData["toolbar_color_primary"] || "primary";
-                resolved = primaryColor === "primary" ? Theme.primary : primaryColor;
+                if (selectedPreset === "custom") {
+                    const primaryColor = pluginData["toolbar_color_primary"] || "primary";
+                    resolved = primaryColor === "primary" ? Theme.primary : primaryColor;
+                } else {
+                    resolved = defaultAccentColors[0];
+                }
             } else if (slotIdx >= 1 && slotIdx <= 7) {
                 resolved = accentColors[slotIdx - 1];
             }

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -654,70 +654,70 @@ PluginSettings {
                 label: I18n.tr("Slot 1")
                 defaultValue: "primary"
                 readOnly: palettePresetSetting.value !== "custom"
-                overrideColor: palettePresetSetting.value !== "custom" ? Theme.primary : null
+                overrideColor: palettePresetSetting.value !== "custom" ? (palettePresetSetting.value === "adaptive" ? Theme.primary : captureConfig.defaultAccentColors[0]) : null
             }
 
             CompactColorSetting {
                 id: c0
                 settingKey: "toolbar_color_0"
                 label: I18n.tr("Slot 2")
-                defaultValue: captureConfig.defaultAccentColors[0]
+                defaultValue: captureConfig.adaptiveColors[0]
                 readOnly: palettePresetSetting.value !== "custom"
-                overrideColor: palettePresetSetting.value !== "custom" ? captureConfig.defaultAccentColors[0] : null
+                overrideColor: palettePresetSetting.value !== "custom" ? (palettePresetSetting.value === "adaptive" ? captureConfig.adaptiveColors[0] : captureConfig.defaultAccentColors[1]) : null
             }
 
             CompactColorSetting {
                 id: c1
                 settingKey: "toolbar_color_1"
                 label: I18n.tr("Slot 3")
-                defaultValue: captureConfig.defaultAccentColors[1]
+                defaultValue: captureConfig.adaptiveColors[1]
                 readOnly: palettePresetSetting.value !== "custom"
-                overrideColor: palettePresetSetting.value !== "custom" ? captureConfig.defaultAccentColors[1] : null
+                overrideColor: palettePresetSetting.value !== "custom" ? (palettePresetSetting.value === "adaptive" ? captureConfig.adaptiveColors[1] : captureConfig.defaultAccentColors[2]) : null
             }
 
             CompactColorSetting {
                 id: c2
                 settingKey: "toolbar_color_2"
                 label: I18n.tr("Slot 4")
-                defaultValue: captureConfig.defaultAccentColors[2]
+                defaultValue: captureConfig.adaptiveColors[2]
                 readOnly: palettePresetSetting.value !== "custom"
-                overrideColor: palettePresetSetting.value !== "custom" ? captureConfig.defaultAccentColors[2] : null
+                overrideColor: palettePresetSetting.value !== "custom" ? (palettePresetSetting.value === "adaptive" ? captureConfig.adaptiveColors[2] : captureConfig.defaultAccentColors[3]) : null
             }
 
             CompactColorSetting {
                 id: c3
                 settingKey: "toolbar_color_3"
                 label: I18n.tr("Slot 5")
-                defaultValue: captureConfig.defaultAccentColors[3]
+                defaultValue: captureConfig.adaptiveColors[3]
                 readOnly: palettePresetSetting.value !== "custom"
-                overrideColor: palettePresetSetting.value !== "custom" ? captureConfig.defaultAccentColors[3] : null
+                overrideColor: palettePresetSetting.value !== "custom" ? (palettePresetSetting.value === "adaptive" ? captureConfig.adaptiveColors[3] : captureConfig.defaultAccentColors[4]) : null
             }
 
             CompactColorSetting {
                 id: c4
                 settingKey: "toolbar_color_4"
                 label: I18n.tr("Slot 6")
-                defaultValue: captureConfig.defaultAccentColors[4]
+                defaultValue: captureConfig.adaptiveColors[4]
                 readOnly: palettePresetSetting.value !== "custom"
-                overrideColor: palettePresetSetting.value !== "custom" ? captureConfig.defaultAccentColors[4] : null
+                overrideColor: palettePresetSetting.value !== "custom" ? (palettePresetSetting.value === "adaptive" ? captureConfig.adaptiveColors[4] : captureConfig.defaultAccentColors[5]) : null
             }
 
             CompactColorSetting {
                 id: c5
                 settingKey: "toolbar_color_5"
                 label: I18n.tr("Slot 7")
-                defaultValue: captureConfig.defaultAccentColors[5]
+                defaultValue: captureConfig.adaptiveColors[5]
                 readOnly: palettePresetSetting.value !== "custom"
-                overrideColor: palettePresetSetting.value !== "custom" ? captureConfig.defaultAccentColors[5] : null
+                overrideColor: palettePresetSetting.value !== "custom" ? (palettePresetSetting.value === "adaptive" ? captureConfig.adaptiveColors[5] : captureConfig.defaultAccentColors[6]) : null
             }
 
             CompactColorSetting {
                 id: c6
                 settingKey: "toolbar_color_6"
                 label: I18n.tr("Slot 8")
-                defaultValue: captureConfig.defaultAccentColors[6]
+                defaultValue: captureConfig.adaptiveColors[6]
                 readOnly: palettePresetSetting.value !== "custom"
-                overrideColor: palettePresetSetting.value !== "custom" ? captureConfig.defaultAccentColors[6] : null
+                overrideColor: palettePresetSetting.value !== "custom" ? (palettePresetSetting.value === "adaptive" ? captureConfig.adaptiveColors[6] : captureConfig.defaultAccentColors[7]) : null
             }
         }
     }

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -89,14 +89,9 @@ PluginSettings {
         readonly property bool isDirty: value.toString() !== defaultValue.toString()
 
         readonly property color resolvedColor: {
-            if (overrideColor !== null) {
-                var c = Qt.color(overrideColor);
-                if (c.valid) return c;
-                return Theme.primary;
-            }
+            if (overrideColor !== null) return Qt.color(overrideColor);
             if (value === "primary") return Theme.primary;
-            var c = Qt.color(value);
-            return c.valid ? c : Theme.primary;
+            return Qt.color(value);
         }
 
         function resetToDefault() {

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -89,9 +89,14 @@ PluginSettings {
         readonly property bool isDirty: value.toString() !== defaultValue.toString()
 
         readonly property color resolvedColor: {
-            if (overrideColor !== null) return Qt.color(overrideColor);
+            if (overrideColor !== null) {
+                var c = Qt.color(overrideColor);
+                if (c.valid) return c;
+                return Theme.primary;
+            }
             if (value === "primary") return Theme.primary;
-            return Qt.color(value);
+            var c = Qt.color(value);
+            return c.valid ? c : Theme.primary;
         }
 
         function resetToDefault() {

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -55,9 +55,13 @@ Rectangle {
     signal autoColorBalanceRequested()
 
     readonly property var toolbarPalette: {
-        const p1 = root.pluginData["toolbar_color_primary"] || "primary";
-        const slot1 = p1 === "primary" ? Theme.primary : p1;
-        return [slot1].concat(config.accentColors);
+        const isCustom = config.selectedPreset === "custom";
+        if (isCustom) {
+            const p1 = root.pluginData["toolbar_color_primary"] || "primary";
+            const slot1 = p1 === "primary" ? Theme.primary : p1;
+            return [slot1].concat(config.accentColors);
+        }
+        return [config.defaultAccentColors[0]].concat(config.accentColors);
     }
 
     signal toolSelected(string tool)

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -56,8 +56,9 @@ Rectangle {
 
     readonly property var toolbarPalette: {
         const isCustom = config.selectedPreset === "custom";
-        if (isCustom) {
-            const p1 = root.pluginData["toolbar_color_primary"] || "primary";
+        const isAdaptive = config.selectedPreset === "adaptive";
+        if (isCustom || isAdaptive) {
+            const p1 = isAdaptive ? "primary" : (root.pluginData["toolbar_color_primary"] || "primary");
             const slot1 = p1 === "primary" ? Theme.primary : p1;
             return [slot1].concat(config.accentColors);
         }

--- a/dms-common/ColorSettingPlus.qml
+++ b/dms-common/ColorSettingPlus.qml
@@ -24,7 +24,8 @@ Item {
 
     readonly property color resolvedColor: {
         if (value === "primary") return Theme.primary;
-        return Qt.color(value);
+        var c = Qt.color(value);
+        return c.valid ? c : Theme.primary;
     }
 
     function resetToDefault() {

--- a/dms-common/ColorSettingPlus.qml
+++ b/dms-common/ColorSettingPlus.qml
@@ -24,8 +24,8 @@ Item {
 
     readonly property color resolvedColor: {
         if (value === "primary") return Theme.primary;
-        var c = Qt.color(value);
-        return c.valid ? c : Theme.primary;
+        if (typeof value === "string" && value.indexOf("slot_") === 0) return Theme.primary;
+        return Qt.color(value);
     }
 
     function resetToDefault() {


### PR DESCRIPTION
When switching palette presets in settings, the first color slot (Slot 1 /
index 0) in the toolbar stayed on the previous/default color while all
other slots updated correctly.

**Root cause:** `toolbarPalette[0]` was hardwired to `Theme.primary`
(via `pluginData["toolbar_color_primary"]`) regardless of the active
preset, while slots 2-8 correctly read from `defaultAccentColors` which
changes with the preset.

**Fix (3 locations):**
- `QuickCaptureToolbar.qml` — `toolbarPalette[0]` uses
  `config.defaultAccentColors[0]` for non-custom presets
- `CaptureConfig.qml` — `colorShortcuts` key "1" uses
  `defaultAccentColors[0]` for non-custom presets
- `CaptureConfig.qml` — `resolveColor` slot_0 returns
  `defaultAccentColors[0]` for non-custom presets

For "custom" preset mode, slot 1 continues using the saved
`toolbar_color_primary` value (existing behavior preserved).

Closes #83

## Summary by Sourcery

Align the first toolbar palette slot and related color shortcut resolution with the active palette preset while preserving behavior for the custom preset.

Bug Fixes:
- Ensure the first toolbar color slot updates with the selected non-custom palette preset instead of always using the primary theme color.

Enhancements:
- Unify color resolution logic for slot 1 across toolbar palette and capture configuration to respect the selected preset mode.