### PR TITLE
feat: add default backdrop behavior settings

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -142,7 +142,7 @@ DankModal {
             window.hoveredColor = window.sampleCanvasColor(window.cursorX * window.editScale, window.cursorY * window.editScale);
         }
         if (currentTool === "backdrop" && window.backdropMode === "none") {
-            window.backdropMode = config.pluginData && config.pluginData["backdropDefaultMode"] || "solid";
+            window.backdropMode = backdropConfigValue("backdropDefaultMode", Constants.defaultBackdropMode, false);
         }
         if (window.activeCanvas) {
             window.activeCanvas.requestPaint();
@@ -1028,6 +1028,12 @@ DankModal {
         return Qt.rect(cx, cy, cw, ch);
     }
 
+    function backdropConfigValue(key, defaultValue, numeric) {
+        const pd = config && config.pluginData;
+        if (!pd || pd[key] === undefined || pd[key] === null) return defaultValue;
+        return numeric ? parseInt(pd[key], 10) : pd[key];
+    }
+
     function constrainSquarePoint(start, point) {
         return Helpers.constrainSquarePoint(start, point, Qt);
     }
@@ -1502,11 +1508,11 @@ DankModal {
         window.hasSampledContrast = false;
         window.hasUserCustomizedBackdrop = false;
         window.backdropMode = "none";
-        window.backdropPadding = config.pluginData && config.pluginData["backdropDefaultPadding"] !== undefined ? parseInt(config.pluginData["backdropDefaultPadding"]) : Constants.defaultBackdropPadding;
-        window.backdropCornerRadius = config.pluginData && config.pluginData["backdropDefaultRadius"] !== undefined ? parseInt(config.pluginData["backdropDefaultRadius"]) : Constants.defaultBackdropCornerRadius;
-        window.backdropShadowStrength = config.pluginData && config.pluginData["backdropDefaultShadow"] !== undefined ? parseInt(config.pluginData["backdropDefaultShadow"]) : Constants.defaultBackdropShadowStrength;
-        window.backdropGradientAngle = config.pluginData && config.pluginData["backdropDefaultAngle"] !== undefined ? parseInt(config.pluginData["backdropDefaultAngle"]) : Constants.defaultBackdropGradientAngle;
-        window.backdropAspectRatio = config.pluginData && config.pluginData["backdropDefaultAspectRatio"] !== undefined ? config.pluginData["backdropDefaultAspectRatio"] : "auto";
+        window.backdropPadding = backdropConfigValue("backdropDefaultPadding", Constants.defaultBackdropPadding, true);
+        window.backdropCornerRadius = backdropConfigValue("backdropDefaultRadius", Constants.defaultBackdropCornerRadius, true);
+        window.backdropShadowStrength = backdropConfigValue("backdropDefaultShadow", Constants.defaultBackdropShadowStrength, true);
+        window.backdropGradientAngle = backdropConfigValue("backdropDefaultAngle", Constants.defaultBackdropGradientAngle, true);
+        window.backdropAspectRatio = backdropConfigValue("backdropDefaultAspectRatio", Constants.defaultBackdropAspectRatio, false);
         window.cropRect = Qt.rect(0, 0, 0, 0);
         window.hasSelection = false;
         window.activeHandle = "none";

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -142,7 +142,8 @@ DankModal {
             window.hoveredColor = window.sampleCanvasColor(window.cursorX * window.editScale, window.cursorY * window.editScale);
         }
         if (currentTool === "backdrop" && window.backdropMode === "none") {
-            window.backdropMode = backdropConfigValue("backdropDefaultMode", Constants.defaultBackdropMode, false);
+            const bm = backdropConfigValue("backdropDefaultMode", Constants.defaultBackdropMode, false);
+            window.backdropMode = bm !== "none" ? bm : "solid";
         }
         if (window.activeCanvas) {
             window.activeCanvas.requestPaint();

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -142,7 +142,7 @@ DankModal {
             window.hoveredColor = window.sampleCanvasColor(window.cursorX * window.editScale, window.cursorY * window.editScale);
         }
         if (currentTool === "backdrop" && window.backdropMode === "none") {
-            window.backdropMode = "solid";
+            window.backdropMode = config.pluginData && config.pluginData["backdropDefaultMode"] || "solid";
         }
         if (window.activeCanvas) {
             window.activeCanvas.requestPaint();
@@ -1501,6 +1501,12 @@ DankModal {
         window.isScreenshotDark = false;
         window.hasSampledContrast = false;
         window.hasUserCustomizedBackdrop = false;
+        window.backdropMode = "none";
+        window.backdropPadding = config.pluginData && config.pluginData["backdropDefaultPadding"] !== undefined ? parseInt(config.pluginData["backdropDefaultPadding"]) : Constants.defaultBackdropPadding;
+        window.backdropCornerRadius = config.pluginData && config.pluginData["backdropDefaultRadius"] !== undefined ? parseInt(config.pluginData["backdropDefaultRadius"]) : Constants.defaultBackdropCornerRadius;
+        window.backdropShadowStrength = config.pluginData && config.pluginData["backdropDefaultShadow"] !== undefined ? parseInt(config.pluginData["backdropDefaultShadow"]) : Constants.defaultBackdropShadowStrength;
+        window.backdropGradientAngle = config.pluginData && config.pluginData["backdropDefaultAngle"] !== undefined ? parseInt(config.pluginData["backdropDefaultAngle"]) : Constants.defaultBackdropGradientAngle;
+        window.backdropAspectRatio = config.pluginData && config.pluginData["backdropDefaultAspectRatio"] !== undefined ? config.pluginData["backdropDefaultAspectRatio"] : "auto";
         window.cropRect = Qt.rect(0, 0, 0, 0);
         window.hasSelection = false;
         window.activeHandle = "none";

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -142,8 +142,7 @@ DankModal {
             window.hoveredColor = window.sampleCanvasColor(window.cursorX * window.editScale, window.cursorY * window.editScale);
         }
         if (currentTool === "backdrop" && window.backdropMode === "none") {
-            const bm = backdropConfigValue("backdropDefaultMode", Constants.defaultBackdropMode, false);
-            window.backdropMode = bm !== "none" ? bm : "solid";
+            window.backdropMode = Constants.defaultBackdropMode;
         }
         if (window.activeCanvas) {
             window.activeCanvas.requestPaint();
@@ -1031,14 +1030,13 @@ DankModal {
 
     function backdropConfigValue(key, defaultValue, numeric) {
         const pd = config && config.pluginData;
-        if (!pd || pd["backdropAutoApply"] !== true) return defaultValue;
-        if (pd[key] === undefined || pd[key] === null) return defaultValue;
+        if (!pd || pd[key] === undefined || pd[key] === null) return defaultValue;
         return numeric ? parseInt(pd[key], 10) : pd[key];
     }
 
     function backdropConfigColor(key, defaultValue) {
         const pd = config && config.pluginData;
-        if (!pd || pd["backdropAutoApply"] !== true) return defaultValue;
+        if (!pd) return defaultValue;
         const val = pd[key];
         if (!val || val === "primary") return Theme.primary;
         return Qt.color(val);
@@ -1518,14 +1516,15 @@ DankModal {
         window.hasSampledContrast = false;
         window.hasUserCustomizedBackdrop = false;
         window.backdropMode = "none";
+        if (config && config.pluginData && config.pluginData["backdropAutoApply"] === true) {
+            const bm = config.pluginData["backdropDefaultMode"];
+            if (bm) window.backdropMode = bm;
+        }
         window.backdropPadding = backdropConfigValue("backdropDefaultPadding", Constants.defaultBackdropPadding, true);
         window.backdropCornerRadius = backdropConfigValue("backdropDefaultRadius", Constants.defaultBackdropCornerRadius, true);
         window.backdropShadowStrength = backdropConfigValue("backdropDefaultShadow", Constants.defaultBackdropShadowStrength, true);
         window.backdropGradientAngle = backdropConfigValue("backdropDefaultAngle", Constants.defaultBackdropGradientAngle, true);
         window.backdropAspectRatio = backdropConfigValue("backdropDefaultAspectRatio", Constants.defaultBackdropAspectRatio, false);
-        window.backdropSolidColor = backdropConfigColor("backdropDefaultSolidColor", Theme.primary);
-        window.backdropGradientStart = backdropConfigColor("backdropDefaultGradientStart", Theme.primary);
-        window.backdropGradientEnd = backdropConfigColor("backdropDefaultGradientEnd", Theme.secondary);
         window.cropRect = Qt.rect(0, 0, 0, 0);
         window.hasSelection = false;
         window.activeHandle = "none";

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1031,8 +1031,17 @@ DankModal {
 
     function backdropConfigValue(key, defaultValue, numeric) {
         const pd = config && config.pluginData;
-        if (!pd || pd[key] === undefined || pd[key] === null) return defaultValue;
+        if (!pd || pd["backdropAutoApply"] !== true) return defaultValue;
+        if (pd[key] === undefined || pd[key] === null) return defaultValue;
         return numeric ? parseInt(pd[key], 10) : pd[key];
+    }
+
+    function backdropConfigColor(key, defaultValue) {
+        const pd = config && config.pluginData;
+        if (!pd || pd["backdropAutoApply"] !== true) return defaultValue;
+        const val = pd[key];
+        if (!val || val === "primary") return Theme.primary;
+        return Qt.color(val);
     }
 
     function constrainSquarePoint(start, point) {
@@ -1514,6 +1523,9 @@ DankModal {
         window.backdropShadowStrength = backdropConfigValue("backdropDefaultShadow", Constants.defaultBackdropShadowStrength, true);
         window.backdropGradientAngle = backdropConfigValue("backdropDefaultAngle", Constants.defaultBackdropGradientAngle, true);
         window.backdropAspectRatio = backdropConfigValue("backdropDefaultAspectRatio", Constants.defaultBackdropAspectRatio, false);
+        window.backdropSolidColor = backdropConfigColor("backdropDefaultSolidColor", Theme.primary);
+        window.backdropGradientStart = backdropConfigColor("backdropDefaultGradientStart", Theme.primary);
+        window.backdropGradientEnd = backdropConfigColor("backdropDefaultGradientEnd", Theme.secondary);
         window.cropRect = Qt.rect(0, 0, 0, 0);
         window.hasSelection = false;
         window.activeHandle = "none";

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -811,13 +811,10 @@ PluginSettings {
         SectionTitle {
             text: I18n.tr("Backdrop Defaults")
             icon: "wallpaper"
-            showReset: backdropAutoApply.isDirty || backdropDefaultMode.isDirty || backdropDefaultSolidColor.isDirty || backdropDefaultGradientStart.isDirty || backdropDefaultGradientEnd.isDirty || backdropDefaultPadding.isDirty || backdropDefaultRadius.isDirty || backdropDefaultShadow.isDirty || backdropDefaultAngle.isDirty || backdropDefaultAspectRatio.isDirty
+            showReset: backdropAutoApply.isDirty || backdropDefaultMode.isDirty || backdropDefaultPadding.isDirty || backdropDefaultRadius.isDirty || backdropDefaultShadow.isDirty || backdropDefaultAngle.isDirty || backdropDefaultAspectRatio.isDirty
             onResetClicked: {
                 backdropAutoApply.resetToDefault();
                 backdropDefaultMode.resetToDefault();
-                backdropDefaultSolidColor.resetToDefault();
-                backdropDefaultGradientStart.resetToDefault();
-                backdropDefaultGradientEnd.resetToDefault();
                 backdropDefaultPadding.resetToDefault();
                 backdropDefaultRadius.resetToDefault();
                 backdropDefaultShadow.resetToDefault();
@@ -829,8 +826,8 @@ PluginSettings {
         ToggleSettingPlus {
             id: backdropAutoApply
             settingKey: "backdropAutoApply"
-            label: I18n.tr("Auto-apply backdrop defaults on tool switch")
-            description: I18n.tr("When enabled, switching to the backdrop tool will use the configured default mode, colors, and sizes below.")
+            label: I18n.tr("Auto-apply backdrop defaults")
+            description: I18n.tr("Enable backdrop automatically when opening the editor")
             defaultValue: false
         }
 
@@ -841,40 +838,12 @@ PluginSettings {
             settingKey: "backdropDefaultMode"
             label: I18n.tr("Default Backdrop Mode")
             options: [
-                { label: I18n.tr("None"), value: "none" },
                 { label: I18n.tr("Solid Color"), value: "solid" },
                 { label: I18n.tr("Linear Gradient"), value: "gradient" },
                 { label: I18n.tr("Radial Gradient"), value: "radial" },
                 { label: I18n.tr("Conic Gradient"), value: "conic" }
             ]
             defaultValue: "solid"
-        }
-
-        Separator {}
-
-        ColorSettingPlus {
-            id: backdropDefaultSolidColor
-            settingKey: "backdropDefaultSolidColor"
-            label: I18n.tr("Default Solid Color")
-            defaultValue: "primary"
-        }
-
-        Separator {}
-
-        ColorSettingPlus {
-            id: backdropDefaultGradientStart
-            settingKey: "backdropDefaultGradientStart"
-            label: I18n.tr("Default Gradient Start Color")
-            defaultValue: "primary"
-        }
-
-        Separator {}
-
-        ColorSettingPlus {
-            id: backdropDefaultGradientEnd
-            settingKey: "backdropDefaultGradientEnd"
-            label: I18n.tr("Default Gradient End Color")
-            defaultValue: Theme.secondary
         }
 
         Separator {}

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -808,6 +808,112 @@ PluginSettings {
     }
 
     SettingsCard {
+        SectionTitle {
+            text: I18n.tr("Backdrop Defaults")
+            icon: "wallpaper"
+            showReset: backdropDefaultMode.isDirty || backdropDefaultPadding.isDirty || backdropDefaultRadius.isDirty || backdropDefaultShadow.isDirty || backdropDefaultAngle.isDirty || backdropDefaultAspectRatio.isDirty
+            onResetClicked: {
+                backdropDefaultMode.resetToDefault();
+                backdropDefaultPadding.resetToDefault();
+                backdropDefaultRadius.resetToDefault();
+                backdropDefaultShadow.resetToDefault();
+                backdropDefaultAngle.resetToDefault();
+                backdropDefaultAspectRatio.resetToDefault();
+            }
+        }
+
+        SelectionSettingPlus {
+            id: backdropDefaultMode
+            settingKey: "backdropDefaultMode"
+            label: I18n.tr("Default Backdrop Mode")
+            options: [
+                { label: I18n.tr("None"), value: "none" },
+                { label: I18n.tr("Solid Color"), value: "solid" },
+                { label: I18n.tr("Linear Gradient"), value: "gradient" },
+                { label: I18n.tr("Radial Gradient"), value: "radial" },
+                { label: I18n.tr("Conic Gradient"), value: "conic" }
+            ]
+            defaultValue: "solid"
+        }
+
+        Separator {}
+
+        SliderSettingPlus {
+            id: backdropDefaultPadding
+            settingKey: "backdropDefaultPadding"
+            label: I18n.tr("Default Padding")
+            defaultValue: 40
+            minimum: 0
+            maximum: 150
+            unit: "px"
+            leftLabel: "0"
+            rightLabel: "150"
+        }
+
+        Separator {}
+
+        SliderSettingPlus {
+            id: backdropDefaultRadius
+            settingKey: "backdropDefaultRadius"
+            label: I18n.tr("Default Corner Radius")
+            defaultValue: 12
+            minimum: 0
+            maximum: 60
+            stepSize: 2
+            unit: "px"
+            leftLabel: "0"
+            rightLabel: "60"
+        }
+
+        Separator {}
+
+        SliderSettingPlus {
+            id: backdropDefaultShadow
+            settingKey: "backdropDefaultShadow"
+            label: I18n.tr("Default Shadow Strength")
+            defaultValue: 50
+            minimum: 0
+            maximum: 100
+            unit: "%"
+            leftLabel: "0"
+            rightLabel: "100"
+        }
+
+        Separator {}
+
+        SliderSettingPlus {
+            id: backdropDefaultAngle
+            settingKey: "backdropDefaultAngle"
+            label: I18n.tr("Default Gradient Angle")
+            defaultValue: 45
+            minimum: 0
+            maximum: 360
+            stepSize: 15
+            unit: "°"
+            leftLabel: "0"
+            rightLabel: "360"
+        }
+
+        Separator {}
+
+        SelectionSettingPlus {
+            id: backdropDefaultAspectRatio
+            settingKey: "backdropDefaultAspectRatio"
+            label: I18n.tr("Default Aspect Ratio")
+            options: [
+                { label: I18n.tr("Auto"), value: "auto" },
+                { label: "1:1", value: "1:1" },
+                { label: "16:9", value: "16:9" },
+                { label: "9:16", value: "9:16" },
+                { label: "4:3", value: "4:3" },
+                { label: "3:2", value: "3:2" },
+                { label: "21:9", value: "21:9" }
+            ]
+            defaultValue: "auto"
+        }
+    }
+
+    SettingsCard {
         id: radialMenuCard
 
         property int presetActiveIndex: 0

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -811,9 +811,13 @@ PluginSettings {
         SectionTitle {
             text: I18n.tr("Backdrop Defaults")
             icon: "wallpaper"
-            showReset: backdropDefaultMode.isDirty || backdropDefaultPadding.isDirty || backdropDefaultRadius.isDirty || backdropDefaultShadow.isDirty || backdropDefaultAngle.isDirty || backdropDefaultAspectRatio.isDirty
+            showReset: backdropAutoApply.isDirty || backdropDefaultMode.isDirty || backdropDefaultSolidColor.isDirty || backdropDefaultGradientStart.isDirty || backdropDefaultGradientEnd.isDirty || backdropDefaultPadding.isDirty || backdropDefaultRadius.isDirty || backdropDefaultShadow.isDirty || backdropDefaultAngle.isDirty || backdropDefaultAspectRatio.isDirty
             onResetClicked: {
+                backdropAutoApply.resetToDefault();
                 backdropDefaultMode.resetToDefault();
+                backdropDefaultSolidColor.resetToDefault();
+                backdropDefaultGradientStart.resetToDefault();
+                backdropDefaultGradientEnd.resetToDefault();
                 backdropDefaultPadding.resetToDefault();
                 backdropDefaultRadius.resetToDefault();
                 backdropDefaultShadow.resetToDefault();
@@ -821,6 +825,16 @@ PluginSettings {
                 backdropDefaultAspectRatio.resetToDefault();
             }
         }
+
+        ToggleSettingPlus {
+            id: backdropAutoApply
+            settingKey: "backdropAutoApply"
+            label: I18n.tr("Auto-apply backdrop defaults on tool switch")
+            description: I18n.tr("When enabled, switching to the backdrop tool will use the configured default mode, colors, and sizes below.")
+            defaultValue: false
+        }
+
+        Separator {}
 
         SelectionSettingPlus {
             id: backdropDefaultMode
@@ -834,6 +848,33 @@ PluginSettings {
                 { label: I18n.tr("Conic Gradient"), value: "conic" }
             ]
             defaultValue: "solid"
+        }
+
+        Separator {}
+
+        ColorSettingPlus {
+            id: backdropDefaultSolidColor
+            settingKey: "backdropDefaultSolidColor"
+            label: I18n.tr("Default Solid Color")
+            defaultValue: "primary"
+        }
+
+        Separator {}
+
+        ColorSettingPlus {
+            id: backdropDefaultGradientStart
+            settingKey: "backdropDefaultGradientStart"
+            label: I18n.tr("Default Gradient Start Color")
+            defaultValue: "primary"
+        }
+
+        Separator {}
+
+        ColorSettingPlus {
+            id: backdropDefaultGradientEnd
+            settingKey: "backdropDefaultGradientEnd"
+            label: I18n.tr("Default Gradient End Color")
+            defaultValue: Theme.secondary
         }
 
         Separator {}

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -859,7 +859,6 @@ PluginSettings {
             defaultValue: 12
             minimum: 0
             maximum: 60
-            stepSize: 2
             unit: "px"
             leftLabel: "0"
             rightLabel: "60"
@@ -888,7 +887,6 @@ PluginSettings {
             defaultValue: 45
             minimum: 0
             maximum: 360
-            stepSize: 15
             unit: "°"
             leftLabel: "0"
             rightLabel: "360"

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -6,6 +6,8 @@ const defaultBackdropPadding = 40;
 const defaultBackdropCornerRadius = 12;
 const defaultBackdropShadowStrength = 50;
 const defaultBackdropGradientAngle = 45;
+const defaultBackdropAspectRatio = "auto";
+const defaultBackdropMode = "solid";
 
 // Selection and threshold constants
 const selectionThresholdBase = 12;


### PR DESCRIPTION
**Closes:** #101

## Changes

Adds a new **Backdrop Defaults** settings card in QuickCaptureSettings.qml with 6 persistable settings:

| Setting | Key | Default | Range |
|---|---|---|---|
| Default Backdrop Mode | `backdropDefaultMode` | `solid` | none, solid, gradient, radial, conic |
| Default Padding | `backdropDefaultPadding` | 40px | 0-150 |
| Default Corner Radius | `backdropDefaultRadius` | 12px | 0-60 |
| Default Shadow Strength | `backdropDefaultShadow` | 50% | 0-100 |
| Default Gradient Angle | `backdropDefaultAngle` | 45° | 0-360 |
| Default Aspect Ratio | `backdropDefaultAspectRatio` | auto | auto, 1:1, 16:9, 9:16, 4:3, 3:2, 21:9 |

### How it works

- Settings are persisted to pluginData so they survive restarts
- Each new capture reads the defaults from pluginData and applies them
- When switching to backdrop tool with mode = "none", the default mode from settings is used instead of hardcoded `"solid"`
- Float restore still works correctly: JSON sidecar overrides defaults after async load

## Summary by Sourcery

Introduce configurable default backdrop behavior and apply these settings when starting new captures.

New Features:
- Add a Backdrop Defaults settings card to QuickCapture settings with options for mode, padding, corner radius, shadow strength, gradient angle, and aspect ratio.

Enhancements:
- Initialize backdrop properties from persisted pluginData on capture start, falling back to defined constants for defaults.
- Use the configured default backdrop mode when activating the backdrop tool from the none state instead of a hardcoded solid mode.