### PR TITLE
perf: coalesce canvas repaints during drawing

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -507,9 +507,7 @@ DankModal {
 
     property bool showAnnotations: true
     onShowAnnotationsChanged: {
-        if (window.activeCanvas) {
-            window.activeCanvas.requestPaint();
-        }
+        window.requestPaintAll();
     }
     property var copiedStroke: null
 
@@ -867,7 +865,6 @@ DankModal {
     property var exportCanvasItem: null
 
     onSelectedStrokeChanged: window.requestPaintAll()
-    onShowAnnotationsChanged: window.requestPaintAll()
     onEffectiveBackdropModeChanged: window.requestPaintAll()
     onBackdropSolidColorChanged: window.requestPaintAll()
     onBackdropGradientStartChanged: window.requestPaintAll()

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -536,6 +536,7 @@ DankModal {
     property int preGrabCalloutLinkLines: 1
     property point pressCoords: Qt.point(0, 0)
     property var originalPoints: []
+    property bool paintPending: false
 
     // Text Input Management
     property bool isTyping: false
@@ -881,6 +882,14 @@ DankModal {
     function requestPaintAll() {
         if (window.activeCanvas) window.activeCanvas.requestPaint();
         if (window.bakedCanvas) window.bakedCanvas.requestPaint();
+    }
+
+    function requestPaintCoalesced() {
+        if (!window.paintPending) {
+            if (window.activeCanvas) window.activeCanvas.requestPaint();
+            window.paintPending = true;
+            paintCooldownTimer.start();
+        }
     }
 
     // Radial Menu Presets & History
@@ -2469,7 +2478,7 @@ DankModal {
                                          if (window.selectedStroke.tool === "redact") {
                                              window.selectedStroke.cachedCleanColor = undefined;
                                          }
-                                         drawingCanvas.requestPaint();
+                                         window.requestPaintCoalesced();
                                     } else {
                                         hoveredStrokeIdx = window.findStrokeAt(absPt.x, absPt.y);
                                     }
@@ -2485,7 +2494,7 @@ DankModal {
                                         const w = Math.abs(ox - window.selectStart.x);
                                         const h = Math.abs(oy - window.selectStart.y);
                                         window.cropRect = window.clampCropRect(x1, y1, w, h);
-                                        drawingCanvas.requestPaint();
+                                        window.requestPaintCoalesced();
                                         return;
                                     }
 
@@ -2515,7 +2524,7 @@ DankModal {
                                             newH = Math.max(10, oy - cr.y);
                                         }
                                         window.cropRect = window.clampCropRect(newX, newY, newW, newH);
-                                        drawingCanvas.requestPaint();
+                                        window.requestPaintCoalesced();
                                         return;
                                     }
                                 } else if (window.currentTool === "ocr" || window.currentTool === "qr") {
@@ -2527,7 +2536,7 @@ DankModal {
                                         const w = Math.abs(ox - window.selectStart.x);
                                         const h = Math.abs(oy - window.selectStart.y);
                                         window.ocrRect = Qt.rect(x1, y1, w, h);
-                                        drawingCanvas.requestPaint();
+                                        window.requestPaintCoalesced();
                                     }
                                     return;
                                 } else {
@@ -2575,7 +2584,7 @@ DankModal {
                                              window.currentStroke.points.push(finalPt);
                                          }
                                      }
-                                    drawingCanvas.requestPaint();
+                                    window.requestPaintCoalesced();
                                 }
                             }
 
@@ -3082,6 +3091,17 @@ DankModal {
                         repeat: false
                         onTriggered: {
                             window.showSizePreview = false;
+                        }
+                    }
+
+                    Timer {
+                        id: paintCooldownTimer
+                        interval: 16
+                        running: false
+                        repeat: false
+                        onTriggered: {
+                            if (window.activeCanvas) window.activeCanvas.requestPaint();
+                            window.paintPending = false;
                         }
                     }
 


### PR DESCRIPTION
This PR resolves #122 by implementing coalesced paint requests during mouse drag/drawing events:
1. Adds `paintCooldownTimer` (16ms ~60fps) and `paintPending` boolean flag.
2. Introduces `requestPaintCoalesced()` to batch repaints, avoiding redundant QML-to-C++ calls during continuous dragging.
3. Fixes a duplicate `onShowAnnotationsChanged` compiler error.