### PR TITLE
feat: unify backdrop palette UI and enable eyedropper on right-click (#132)

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -161,6 +161,7 @@ DankModal {
     property string backdropAspectRatio: "auto"
     property real customAspectRatio: 1.50
     property string backdropAlignment: "center"
+    property string backdropColorPickingSlot: "none" // none, solid, start, end
     readonly property real customRatioMin: 0.50
     readonly property real customRatioMax: 2.50
     readonly property real customRatioStep: 0.05
@@ -1784,6 +1785,10 @@ DankModal {
                             PopoutService.colorPickerModal.show();
                         }
                     }
+                    onBackdropEyedropperRequested: (slot) => {
+                        window.backdropColorPickingSlot = slot;
+                        window.currentTool = "colorpicker";
+                    }
                     onChangeBackdropGradientStart: (col) => {
                         window.backdropGradientStart = col;
                         window.hasUserCustomizedBackdrop = true;
@@ -2741,21 +2746,32 @@ DankModal {
                                 }
 
                                  if (window.currentTool === "colorpicker") {
-                                     if (mouse.button === Qt.LeftButton) {
-                                         const pickedColor = window.sampleCanvasColor(mouse.x, mouse.y);
-                                         const hexStr = window.formatHexColor(pickedColor).toUpperCase();
-                                         if (window.colorPickerMode === "copy") {
-                                             Quickshell.execDetached(["dms", "cl", "copy", hexStr]);
-                                             if (typeof ToastService !== "undefined" && ToastService) {
-                                                 ToastService.showInfo(I18n.tr("Color copied to clipboard: %1").arg(hexStr));
-                                             }
-                                         } else {
-                                              window.updateColorSlot(window.activeColorSlotIndex, pickedColor);
+                                      if (mouse.button === Qt.LeftButton) {
+                                          const pickedColor = window.sampleCanvasColor(mouse.x, mouse.y);
+                                          if (window.backdropColorPickingSlot !== "none") {
+                                              if (window.backdropColorPickingSlot === "solid") {
+                                                  window.backdropSolidColor = pickedColor;
+                                              } else if (window.backdropColorPickingSlot === "start") {
+                                                  window.backdropGradientStart = pickedColor;
+                                              } else if (window.backdropColorPickingSlot === "end") {
+                                                  window.backdropGradientEnd = pickedColor;
+                                              }
+                                              window.backdropColorPickingSlot = "none";
+                                          } else {
+                                              const hexStr = window.formatHexColor(pickedColor).toUpperCase();
+                                              if (window.colorPickerMode === "copy") {
+                                                  Quickshell.execDetached(["dms", "cl", "copy", hexStr]);
+                                                  if (typeof ToastService !== "undefined" && ToastService) {
+                                                      ToastService.showInfo(I18n.tr("Color copied to clipboard: %1").arg(hexStr));
+                                                  }
+                                              } else {
+                                                   window.updateColorSlot(window.activeColorSlotIndex, pickedColor);
+                                               }
                                           }
-                                         window.currentTool = window.lastActiveTool;
-                                     }
-                                     return;
-                                 }
+                                          window.currentTool = window.lastActiveTool;
+                                      }
+                                      return;
+                                  }
 
                                 if (window.currentTool === "crop") {
                                     const ox = mouse.x / window.editScale;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1756,6 +1756,7 @@ DankModal {
                     backdropAspectRatio: window.backdropAspectRatio
                     customAspectRatio: window.customAspectRatio
                     backdropAlignment: window.backdropAlignment
+                    backdropColorPickingSlot: window.backdropColorPickingSlot
 
                     onChangeBackdropMode: (mode) => {
                         window.backdropMode = mode;

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -129,6 +129,9 @@ DankModal {
     property color _lastSampledColor: "transparent"
     readonly property real dpr: Screen.devicePixelRatio || 1.0
     onCurrentToolChanged: {
+        if (currentTool !== "colorpicker") {
+            window.backdropColorPickingSlot = "none";
+        }
         if (currentTool !== "text" && window.isTyping) {
             window.commitTypingText();
         }
@@ -2756,6 +2759,7 @@ DankModal {
                                               } else if (window.backdropColorPickingSlot === "end") {
                                                   window.backdropGradientEnd = pickedColor;
                                               }
+                                              window.hasUserCustomizedBackdrop = true;
                                               window.backdropColorPickingSlot = "none";
                                           } else {
                                               const hexStr = window.formatHexColor(pickedColor).toUpperCase();

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2762,6 +2762,7 @@ DankModal {
                                               }
                                               window.hasUserCustomizedBackdrop = true;
                                               window.backdropColorPickingSlot = "none";
+                                              window.currentTool = "backdrop";
                                           } else {
                                               const hexStr = window.formatHexColor(pickedColor).toUpperCase();
                                               if (window.colorPickerMode === "copy") {
@@ -2772,8 +2773,8 @@ DankModal {
                                               } else {
                                                    window.updateColorSlot(window.activeColorSlotIndex, pickedColor);
                                                }
+                                               window.currentTool = window.lastActiveTool;
                                           }
-                                          window.currentTool = window.lastActiveTool;
                                       }
                                       return;
                                   }

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -16,6 +16,7 @@ Row {
     signal setGradientActiveSlot(string slot)
     signal autoColorBalanceRequested()
     signal colorPickerRequested(color currentColor)
+    signal eyedropperRequested(string slot)
 
     spacing: Theme.spacingXS
     anchors.verticalCenter: parent.verticalCenter
@@ -26,6 +27,19 @@ Row {
         color: controlRoot.backdropSolidColor
         border.color: Theme.withAlpha(Theme.outline, 0.3)
         border.width: 1
+
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            cursorShape: Qt.PointingHandCursor
+            onClicked: (mouse) => {
+                if (mouse.button === Qt.RightButton) {
+                    controlRoot.eyedropperRequested("solid")
+                } else {
+                    controlRoot.colorPickerRequested(controlRoot.backdropSolidColor)
+                }
+            }
+        }
     }
 
     readonly property bool isGradient: backdropMode === "gradient" || backdropMode === "radial" || backdropMode === "conic"
@@ -42,8 +56,14 @@ Row {
             border.width: controlRoot.gradientActiveSlot === "start" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
             MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 cursorShape: Qt.PointingHandCursor
-                onClicked: controlRoot.setGradientActiveSlot("start")
+                onClicked: (mouse) => {
+                    controlRoot.setGradientActiveSlot("start")
+                    if (mouse.button === Qt.RightButton) {
+                        controlRoot.eyedropperRequested("start")
+                    }
+                }
             }
         }
         Rectangle {
@@ -53,22 +73,45 @@ Row {
             border.width: controlRoot.gradientActiveSlot === "end" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
             MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 cursorShape: Qt.PointingHandCursor
-                onClicked: controlRoot.setGradientActiveSlot("end")
+                onClicked: (mouse) => {
+                    controlRoot.setGradientActiveSlot("end")
+                    if (mouse.button === Qt.RightButton) {
+                        controlRoot.eyedropperRequested("end")
+                    }
+                }
             }
         }
     }
 
-    DankActionButton {
-        buttonSize: controlRoot.itemSize
-        iconName: "colorize"
-        iconSize: controlRoot.iconSize
-        backgroundColor: "transparent"
-        iconColor: Theme.primary
-        onClicked: {
-            let col = controlRoot.backdropMode === "solid" ? controlRoot.backdropSolidColor :
-                      (controlRoot.gradientActiveSlot === "start" ? controlRoot.backdropGradientStart : controlRoot.backdropGradientEnd);
-            controlRoot.colorPickerRequested(col);
+    Item {
+        width: controlRoot.itemSize
+        height: controlRoot.itemSize
+        anchors.verticalCenter: parent.verticalCenter
+
+        DankActionButton {
+            anchors.fill: parent
+            iconName: "colorize"
+            iconSize: controlRoot.iconSize
+            backgroundColor: "transparent"
+            iconColor: Theme.primary
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            cursorShape: Qt.PointingHandCursor
+            onClicked: (mouse) => {
+                let col = controlRoot.backdropMode === "solid" ? controlRoot.backdropSolidColor :
+                          (controlRoot.gradientActiveSlot === "start" ? controlRoot.backdropGradientStart : controlRoot.backdropGradientEnd);
+                let targetSlot = controlRoot.backdropMode === "solid" ? "solid" : controlRoot.gradientActiveSlot;
+                if (mouse.button === Qt.RightButton) {
+                    controlRoot.eyedropperRequested(targetSlot)
+                } else {
+                    controlRoot.colorPickerRequested(col)
+                }
+            }
         }
     }
 

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -36,6 +36,7 @@ Rectangle {
     property string backdropAlignment: "center"
 
     property string gradientActiveSlot: "start"
+    property string backdropColorPickingSlot: "none"
 
     signal changeBackdropMode(string mode)
     signal changeBackdropSolidColor(color col)
@@ -136,7 +137,7 @@ Rectangle {
             id: toolbarLoader
             anchors.centerIn: parent
             sourceComponent: {
-                if (root.currentTool === "backdrop") {
+                if (root.currentTool === "backdrop" || (root.currentTool === "colorpicker" && root.backdropColorPickingSlot !== "none")) {
                     return root.isVertical ? backdropVerticalLayout : backdropHorizontalLayout;
                 }
                 return root.isVertical ? verticalLayout : horizontalLayout;

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -80,6 +80,11 @@ Rectangle {
     signal closeRequested()
     signal annotationsToggled()
     signal backdropColorPickerRequested(color currentColor)
+    signal backdropEyedropperRequested(string slot)
+
+    readonly property color activeBackdropColor: root.backdropMode === "solid" ?
+        root.backdropSolidColor :
+        (root.gradientActiveSlot === "start" ? root.backdropGradientStart : root.backdropGradientEnd)
 
 
 
@@ -92,6 +97,34 @@ Rectangle {
     color: Theme.withAlpha(Theme.surfaceContainer, 0.95)
     border.color: showBorder ? Theme.primary : Theme.withAlpha(Theme.outline, 0.15)
     border.width: showBorder ? 1.5 : 1
+
+    component ColorPaletteGrid : Grid {
+        id: paletteGrid
+        property var paletteModel: root.toolbarPalette
+        property color activeColor: "transparent"
+        property int activeSlotIndex: -1
+        property int swatchSize: tc.swatchSize
+        property int swatchRadius: tc.swatchRadius
+        property int cols: 4
+        property int gridSpacingValue: tc.gridSpacing
+        signal colorSelected(color col, int index)
+        columns: cols
+        spacing: gridSpacingValue
+        Repeater {
+            model: paletteGrid.paletteModel
+            delegate: Rectangle {
+                width: paletteGrid.swatchSize; height: paletteGrid.swatchSize; radius: paletteGrid.swatchRadius; color: modelData
+                readonly property bool isActive: (paletteGrid.activeSlotIndex === -1 || paletteGrid.activeSlotIndex === index) && Helpers.colorEquals(paletteGrid.activeColor, modelData, Qt)
+                border.color: isActive ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                border.width: isActive ? 2 : 1
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: paletteGrid.colorSelected(modelData, index)
+                }
+            }
+        }
+    }
 
     Item {
         id: contentLayout
@@ -177,21 +210,14 @@ Rectangle {
             Rectangle { width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
             // Colors
-            Grid {
-                rows: 2; columns: 4; spacing: tc.gridSpacing; anchors.verticalCenter: parent.verticalCenter
-                Repeater {
-                    model: root.toolbarPalette
-                    delegate: Rectangle {
-                        width: tc.swatchSize; height: tc.swatchSize; radius: tc.swatchRadius; color: modelData
-                        border.color: (root.activeColorSlotIndex === index && Helpers.colorEquals(root.currentColor, modelData, Qt)) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: (root.activeColorSlotIndex === index && Helpers.colorEquals(root.currentColor, modelData, Qt)) ? 2 : 1
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root.colorSelected(modelData, index)
-                        }
-                    }
-                }
+            ColorPaletteGrid {
+                activeColor: root.currentColor
+                activeSlotIndex: root.activeColorSlotIndex
+                swatchSize: tc.swatchSize
+                swatchRadius: tc.swatchRadius
+                cols: 4
+                anchors.verticalCenter: parent.verticalCenter
+                onColorSelected: (col, idx) => root.colorSelected(col, idx)
             }
 
             Item {
@@ -336,21 +362,15 @@ Rectangle {
 
             Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
 
-            Grid {
-                columns: 2; spacing: tc.gridSpacing + 2; anchors.horizontalCenter: parent.horizontalCenter
-                Repeater {
-                    model: root.toolbarPalette
-                    delegate: Rectangle {
-                        width: tc.swatchSizeVert; height: tc.swatchSizeVert; radius: tc.swatchRadiusVert; color: modelData
-                        border.color: (root.activeColorSlotIndex === index && Helpers.colorEquals(root.currentColor, modelData, Qt)) ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-                        border.width: (root.activeColorSlotIndex === index && Helpers.colorEquals(root.currentColor, modelData, Qt)) ? 2 : 1
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root.colorSelected(modelData, index)
-                        }
-                    }
-                }
+            ColorPaletteGrid {
+                activeColor: root.currentColor
+                activeSlotIndex: root.activeColorSlotIndex
+                swatchSize: tc.swatchSizeVert
+                swatchRadius: tc.swatchRadiusVert
+                cols: 2
+                gridSpacingValue: tc.gridSpacing + 2
+                anchors.horizontalCenter: parent.horizontalCenter
+                onColorSelected: (col, idx) => root.colorSelected(col, idx)
             }
 
             Item {
@@ -607,8 +627,7 @@ Rectangle {
                 visible: root.backdropMode !== "none"
                 spacing: Theme.spacingS
                 anchors.verticalCenter: parent.verticalCenter
-                
-                BackdropColorSelectors {
+                                 BackdropColorSelectors {
                     backdropMode: root.backdropMode
                     backdropSolidColor: root.backdropSolidColor
                     backdropGradientStart: root.backdropGradientStart
@@ -619,30 +638,24 @@ Rectangle {
                     onSetGradientActiveSlot: (slot) => root.gradientActiveSlot = slot
                     onAutoColorBalanceRequested: root.autoColorBalanceRequested()
                     onColorPickerRequested: (currentColor) => root.backdropColorPickerRequested(currentColor)
+                    onEyedropperRequested: (slot) => root.backdropEyedropperRequested(slot)
                 }
                 
-                Grid {
-                    rows: 2; columns: 4; spacing: tc.gridSpacing; anchors.verticalCenter: parent.verticalCenter
-                    Repeater {
-                        model: root.toolbarPalette
-                        delegate: Rectangle {
-                            width: tc.swatchSizeSmall; height: tc.swatchSizeSmall; radius: tc.swatchRadiusSmall; color: modelData
-                            border.color: Theme.withAlpha(Theme.outline, 0.3)
-                            border.width: 1
-                            MouseArea {
-                                anchors.fill: parent
-                                cursorShape: Qt.PointingHandCursor
-                                onClicked: {
-                                    if (root.backdropMode === "solid") {
-                                        root.changeBackdropSolidColor(modelData);
-                                    } else if (root.backdropMode === "gradient" || root.backdropMode === "radial" || root.backdropMode === "conic") {
-                                        if (root.gradientActiveSlot === "start") {
-                                            root.changeBackdropGradientStart(modelData);
-                                        } else {
-                                            root.changeBackdropGradientEnd(modelData);
-                                        }
-                                    }
-                                }
+                ColorPaletteGrid {
+                    activeColor: root.activeBackdropColor
+                    activeSlotIndex: -1
+                    swatchSize: tc.swatchSize
+                    swatchRadius: tc.swatchRadius
+                    cols: 4
+                    anchors.verticalCenter: parent.verticalCenter
+                    onColorSelected: (col, idx) => {
+                        if (root.backdropMode === "solid") {
+                            root.changeBackdropSolidColor(col);
+                        } else if (root.backdropMode === "gradient" || root.backdropMode === "radial" || root.backdropMode === "conic") {
+                            if (root.gradientActiveSlot === "start") {
+                                root.changeBackdropGradientStart(col);
+                            } else {
+                                root.changeBackdropGradientEnd(col);
                             }
                         }
                     }
@@ -852,8 +865,7 @@ Rectangle {
                 visible: root.backdropMode !== "none"
                 spacing: Theme.spacingS
                 anchors.horizontalCenter: parent.horizontalCenter
-                
-                BackdropColorSelectors {
+                                 BackdropColorSelectors {
                     backdropMode: root.backdropMode
                     backdropSolidColor: root.backdropSolidColor
                     backdropGradientStart: root.backdropGradientStart
@@ -864,30 +876,24 @@ Rectangle {
                     onSetGradientActiveSlot: (slot) => root.gradientActiveSlot = slot
                     onAutoColorBalanceRequested: root.autoColorBalanceRequested()
                     onColorPickerRequested: (currentColor) => root.backdropColorPickerRequested(currentColor)
+                    onEyedropperRequested: (slot) => root.backdropEyedropperRequested(slot)
                 }
                 
-                Grid {
-                    columns: 2; spacing: tc.gridSpacing; anchors.horizontalCenter: parent.horizontalCenter
-                    Repeater {
-                        model: root.toolbarPalette
-                        delegate: Rectangle {
-                            width: tc.swatchSizeVertSmall; height: tc.swatchSizeVertSmall; radius: tc.swatchRadiusVertSmall; color: modelData
-                            border.color: Theme.withAlpha(Theme.outline, 0.3)
-                            border.width: 1
-                            MouseArea {
-                                anchors.fill: parent
-                                cursorShape: Qt.PointingHandCursor
-                                onClicked: {
-                                    if (root.backdropMode === "solid") {
-                                        root.changeBackdropSolidColor(modelData);
-                                    } else if (root.backdropMode === "gradient" || root.backdropMode === "radial" || root.backdropMode === "conic") {
-                                        if (root.gradientActiveSlot === "start") {
-                                            root.changeBackdropGradientStart(modelData);
-                                        } else {
-                                            root.changeBackdropGradientEnd(modelData);
-                                        }
-                                    }
-                                }
+                ColorPaletteGrid {
+                    activeColor: root.activeBackdropColor
+                    activeSlotIndex: -1
+                    swatchSize: tc.swatchSizeVert
+                    swatchRadius: tc.swatchRadiusVert
+                    cols: 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    onColorSelected: (col, idx) => {
+                        if (root.backdropMode === "solid") {
+                            root.changeBackdropSolidColor(col);
+                        } else if (root.backdropMode === "gradient" || root.backdropMode === "radial" || root.backdropMode === "conic") {
+                            if (root.gradientActiveSlot === "start") {
+                                root.changeBackdropGradientStart(col);
+                            } else {
+                                root.changeBackdropGradientEnd(col);
                             }
                         }
                     }


### PR DESCRIPTION
## What
- Refactored `QuickCaptureToolbar.qml` by extracting the repeating color palette grids into a single reusable inline QML component: `ColorPaletteGrid`.
- Enlarged the backdrop color swatches (`swatchSize` and `swatchSizeVert`) to match the size of the main toolbar's color slots (20px horizontal, 18px vertical).
- Added active border highlight to backdrop color swatches based on the current active backdrop/gradient color.
- Implemented right-click interaction for the backdrop color selectors (solid/gradient circles and colorizer button) to trigger the canvas-based color picker (eyedropper).

## Why
Resolves #132. Improves design consistency across the screenshot editor UI by unifying the size, active styling, and behaviors of the color selection widgets. It also enhances convenience by allowing users to quickly sample a backdrop color from the screenshot using the eyedropper.

## How Tested
- Enabled backdrop in different modes (Solid, Gradient) and verified that the active swatch is correctly highlighted with a 2px primary border.
- Verified that horizontal and vertical toolbar layouts align properly and the larger swatches do not overflow the toolbar boundaries.
- Right-clicked the backdrop solid/gradient color slots, verified it switches to canvas eyedropper mode, and clicked a pixel on the screen to successfully update the backdrop background color.

## Summary by Sourcery

Unify the color palette UI across the main and backdrop toolbars and add canvas eyedropper support for backdrop colors.

New Features:
- Add right-click eyedropper interaction on backdrop solid, gradient start/end, and colorizer controls to sample colors directly from the canvas.

Enhancements:
- Introduce a reusable ColorPaletteGrid component to standardize palette rendering and active color highlighting for both horizontal and vertical toolbars.
- Increase backdrop palette swatch sizes and add active border styling to align with the main toolbar color slots.
- Extend canvas color picking logic to optionally update backdrop solid or gradient colors instead of only the primary annotation color.