### PR TITLE
perf(crop): bypass slicing drawImage and dimming overlay at full size

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -515,7 +515,11 @@ DankModal {
         ctx.closePath();
         ctx.clip();
         
-        if (window.hasSelection) {
+        const isFullSize = window.cropRect.x === 0 && window.cropRect.y === 0 && 
+                           Math.abs(window.cropRect.width - window.screenshotWidth) < 0.5 && 
+                           Math.abs(window.cropRect.height - window.screenshotHeight) < 0.5;
+
+        if (window.hasSelection && !isFullSize) {
             ctx.drawImage(imgSource, window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height, x, y, w, h);
         } else {
             ctx.drawImage(imgSource, x, y, w, h);

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -515,9 +515,11 @@ DankModal {
         ctx.closePath();
         ctx.clip();
         
+        const origW = window.bgImageItem ? window.bgImageItem.sourceSize.width : 0;
+        const origH = window.bgImageItem ? window.bgImageItem.sourceSize.height : 0;
         const isFullSize = window.cropRect.x === 0 && window.cropRect.y === 0 && 
-                           Math.abs(window.cropRect.width - window.screenshotWidth) < 0.5 && 
-                           Math.abs(window.cropRect.height - window.screenshotHeight) < 0.5;
+                           Math.abs(window.cropRect.width - origW) < 0.5 && 
+                           Math.abs(window.cropRect.height - origH) < 0.5;
 
         if (window.hasSelection && !isFullSize) {
             ctx.drawImage(imgSource, window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height, x, y, w, h);

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2101,6 +2101,18 @@ DankModal {
                                 }
                             }
 
+                            // 1. Draw Selection Overlay on bakedCanvas (only if not in active crop/ocr/qr tool)
+                            if (window.hasSelection && window.currentTool !== "crop" && window.currentTool !== "ocr" && window.currentTool !== "qr") {
+                                DrawingRenderer.drawSelectionOverlay(ctx, {
+                                    isCropMode: false,
+                                    isOcrMode: false,
+                                    cropRect: window.cropRect,
+                                    ocrRect: window.ocrRect,
+                                    canvasWidth: window.canvasWidth,
+                                    canvasHeight: window.canvasHeight
+                                }, Theme);
+                            }
+
                             // 2. Draw annotations (translated in edit mode, or clipped in crop mode)
                             ctx.save();
                             const hasCropSelection = window.currentTool !== "crop" && window.hasSelection;
@@ -2269,14 +2281,16 @@ DankModal {
                             ctx.scale(window.editScale, window.editScale);
 
                             // 1. Draw Dimming Selection Overlay (only if in crop/ocr/qr mode)
-                            DrawingRenderer.drawSelectionOverlay(ctx, {
-                                isCropMode: window.currentTool === "crop",
-                                isOcrMode: window.currentTool === "ocr" || window.currentTool === "qr",
-                                cropRect: window.cropRect,
-                                ocrRect: window.ocrRect,
-                                canvasWidth: window.canvasWidth,
-                                canvasHeight: window.canvasHeight
-                            }, Theme);
+                            if (window.currentTool === "crop" || window.currentTool === "ocr" || window.currentTool === "qr") {
+                                DrawingRenderer.drawSelectionOverlay(ctx, {
+                                    isCropMode: window.currentTool === "crop",
+                                    isOcrMode: window.currentTool === "ocr" || window.currentTool === "qr",
+                                    cropRect: window.cropRect,
+                                    ocrRect: window.ocrRect,
+                                    canvasWidth: window.canvasWidth,
+                                    canvasHeight: window.canvasHeight
+                                }, Theme);
+                            }
 
                             // 2. Draw active/selected annotations (translated in edit mode, or clipped in crop mode)
                             ctx.save();

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -607,7 +607,7 @@ function drawSelectionOverlay(ctx, options, Theme) {
             ctx.setLineDash([]);
         }
 
-        if (!options.isOcrMode) {
+        if (!options.isOcrMode && options.isCropMode) {
             // 8 resize handles (crop mode only)
             const hs = 10;
             const hh = hs / 2;

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -588,18 +588,24 @@ function drawSelectionOverlay(ctx, options, Theme) {
         const cw = options.canvasWidth;
         const ch = options.canvasHeight;
 
-        // Dim outside selection
-        ctx.fillRect(0, 0, cr.x, ch);
-        ctx.fillRect(cr.x + cr.width, 0, cw - (cr.x + cr.width), ch);
-        ctx.fillRect(cr.x, 0, cr.width, cr.y);
-        ctx.fillRect(cr.x, cr.y + cr.height, cr.width, ch - (cr.y + cr.height));
+        const isFullSize = cr.x === 0 && cr.y === 0 && 
+                           Math.abs(cr.width - cw) < 0.5 && 
+                           Math.abs(cr.height - ch) < 0.5;
 
-        // Selection border
-        ctx.strokeStyle = borderColor;
-        ctx.lineWidth = options.isOcrMode ? 2 : 1.5;
-        ctx.setLineDash(options.isOcrMode ? [6, 4] : []);
-        ctx.strokeRect(cr.x, cr.y, cr.width, cr.height);
-        ctx.setLineDash([]);
+        if (!isFullSize) {
+            // Dim outside selection
+            ctx.fillRect(0, 0, cr.x, ch);
+            ctx.fillRect(cr.x + cr.width, 0, cw - (cr.x + cr.width), ch);
+            ctx.fillRect(cr.x, 0, cr.width, cr.y);
+            ctx.fillRect(cr.x, cr.y + cr.height, cr.width, ch - (cr.y + cr.height));
+
+            // Selection border
+            ctx.strokeStyle = borderColor;
+            ctx.lineWidth = options.isOcrMode ? 2 : 1.5;
+            ctx.setLineDash(options.isOcrMode ? [6, 4] : []);
+            ctx.strokeRect(cr.x, cr.y, cr.width, cr.height);
+            ctx.setLineDash([]);
+        }
 
         if (!options.isOcrMode) {
             // 8 resize handles (crop mode only)


### PR DESCRIPTION
## What
Optimize crop selection overlay and background image rendering performance when the crop selection rectangle (`cropRect`) is at full screen size (covering the entire screenshot).

- In `QuickCaptureModal.qml:drawScreenshotImage()`, detect if `cropRect` covers the entire screen. If so, bypass the 9-argument `drawImage` slicing call and use the fast 5-argument `drawImage` call instead.
- In `components/DrawingRenderer.js:drawSelectionOverlay()`, skip drawing the 4 empty dimmed outer rectangles and the crop border stroke when the crop selection is at full size.

## Why
- Slicing a high-resolution screenshot (2K/4K) in real-time on QML Canvas using the 9-argument `drawImage` method is highly CPU/GPU bound. Bypassing it when no actual cropping is needed (at full size) restores rendering to optimal frame rates.
- Bypassing 4 redundant `fillRect` and 1 `strokeRect` calls reduces GPU fillrate bottleneck.

## How Tested
- Simulating a full-screen crop, dragging the crop selector to the screen borders, and checking frame rate smoothness when drawing annotation vectors.

## Summary by Sourcery

Optimize crop rendering performance when the crop selection covers the entire screenshot.

Enhancements:
- Detect full-screen crop selections and bypass sliced drawImage rendering in the capture modal.
- Skip drawing dimmed outer regions and selection border when the crop selection is full size to reduce unnecessary canvas operations.