### PR TITLE
refactor(draw): centralize duplicate drawStroke functions to window level

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -895,6 +895,7 @@ DankModal {
     property var bgImageItem: null
     property var boardContainerItem: null
     property var exportCanvasItem: null
+    property var offscreenSamplerItem: null
 
     onSelectedStrokeChanged: window.requestPaintAll()
     onEffectiveBackdropModeChanged: window.requestPaintAll()
@@ -918,7 +919,7 @@ DankModal {
             roundRect: window.roundRect,
             roundHighlighter: window.roundHighlighter,
             bgImageItem: window.bgImageItem,
-            offscreenSampler: offscreenSampler,
+            offscreenSampler: window.offscreenSamplerItem,
             canvasWidth: window.canvasWidth,
             canvasHeight: window.canvasHeight,
             canvasMinX: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.x : 0,
@@ -3599,6 +3600,9 @@ DankModal {
                         var ctx = getContext("2d");
                         ctx.clearRect(0, 0, width, height);
                         ctx.drawImage(bgImage, 0, 0, width, height);
+                    }
+                    Component.onCompleted: {
+                        window.offscreenSamplerItem = offscreenSampler;
                     }
                 }
             }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -913,6 +913,19 @@ DankModal {
         if (window.bakedCanvas) window.bakedCanvas.requestPaint();
     }
 
+    function drawStroke(ctx, stroke) {
+        DrawingRenderer.drawStroke(ctx, stroke, Helpers, Qt, Theme, {
+            roundRect: window.roundRect,
+            roundHighlighter: window.roundHighlighter,
+            bgImageItem: window.bgImageItem,
+            offscreenSampler: offscreenSampler,
+            canvasWidth: window.canvasWidth,
+            canvasHeight: window.canvasHeight,
+            canvasMinX: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.x : 0,
+            canvasMinY: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.y : 0,
+        });
+    }
+
     // Radial Menu Presets & History
     property var radialPresets: []
     property var presetHistory: []
@@ -2228,19 +2241,6 @@ DankModal {
 
                             ctx.restore();
                         }
-
-                        function drawStroke(ctx, stroke) {
-                            DrawingRenderer.drawStroke(ctx, stroke, Helpers, Qt, Theme, {
-                                roundRect: window.roundRect,
-                                roundHighlighter: window.roundHighlighter,
-                                bgImageItem: window.bgImageItem,
-                                offscreenSampler: offscreenSampler,
-                                canvasWidth: window.canvasWidth,
-                                canvasHeight: window.canvasHeight,
-                                canvasMinX: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.x : 0,
-                                canvasMinY: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.y : 0,
-                            });
-                        }
                     }
 
                     Canvas {
@@ -2459,19 +2459,6 @@ DankModal {
 
                             ctx.restore();
                             ctx.restore();
-                        }
-
-                        function drawStroke(ctx, stroke) {
-                            DrawingRenderer.drawStroke(ctx, stroke, Helpers, Qt, Theme, {
-                                roundRect: window.roundRect,
-                                roundHighlighter: window.roundHighlighter,
-                                bgImageItem: window.bgImageItem,
-                                offscreenSampler: offscreenSampler,
-                                canvasWidth: window.canvasWidth,
-                                canvasHeight: window.canvasHeight,
-                                canvasMinX: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.x : 0,
-                                canvasMinY: (window.currentTool !== "crop" && window.hasSelection) ? window.cropRect.y : 0,
-                            });
                         }
 
                         // Mouse Drawing & Action Capture
@@ -3264,11 +3251,11 @@ DankModal {
                             // 1.4 Draw Pixelate BEFORE spotlight layer in export
                             for (let i = 0; i < window.strokes.length; i++) {
                                 if (window.strokes[i].tool === "pixelate") {
-                                    window.activeCanvas.drawStroke(ctx, window.strokes[i]);
+                                    window.drawStroke(ctx, window.strokes[i]);
                                 }
                             }
                             if (window.currentStroke && window.currentStroke.tool === "pixelate") {
-                                window.activeCanvas.drawStroke(ctx, window.currentStroke);
+                                window.drawStroke(ctx, window.currentStroke);
                             }
 
                             const isDrawingSpotlight = window.currentStroke && window.currentStroke.tool === "spotlight";
@@ -3352,17 +3339,15 @@ DankModal {
                             }
 
                             // 2. Overlay the annotations at full resolution
-                            if (window.activeCanvas) {
-                                // Draw all completed strokes (except pixelate and spotlight)
-                                for (var i = 0; i < window.strokes.length; i++) {
-                                    if (window.strokes[i].tool !== "pixelate" && window.strokes[i].tool !== "spotlight") {
-                                        window.activeCanvas.drawStroke(ctx, window.strokes[i]);
-                                    }
+                            // Draw all completed strokes (except pixelate and spotlight)
+                            for (var i = 0; i < window.strokes.length; i++) {
+                                if (window.strokes[i].tool !== "pixelate" && window.strokes[i].tool !== "spotlight") {
+                                    window.drawStroke(ctx, window.strokes[i]);
                                 }
-                                // Draw current dragging stroke if any
-                                if (window.currentStroke && window.currentStroke.tool !== "pixelate" && window.currentStroke.tool !== "spotlight") {
-                                    window.activeCanvas.drawStroke(ctx, window.currentStroke);
-                                }
+                            }
+                            // Draw current dragging stroke if any
+                            if (window.currentStroke && window.currentStroke.tool !== "pixelate" && window.currentStroke.tool !== "spotlight") {
+                                window.drawStroke(ctx, window.currentStroke);
                             }
                             ctx.restore();
                         }

--- a/components/MagnifierLoupe.qml
+++ b/components/MagnifierLoupe.qml
@@ -93,10 +93,10 @@ Rectangle {
                     const cropY = window.hasSelection ? window.cropRect.y : 0;
                     ctx.translate(-cropX, -cropY);
                     for (var i = 0; i < window.strokes.length; i++) {
-                        drawingCanvas.drawStroke(ctx, window.strokes[i]);
+                        window.drawStroke(ctx, window.strokes[i]);
                     }
                     if (window.currentStroke) {
-                        drawingCanvas.drawStroke(ctx, window.currentStroke);
+                        window.drawStroke(ctx, window.currentStroke);
                     }
                     ctx.restore();
                 }
@@ -110,10 +110,10 @@ Rectangle {
                 }
                 if (window.showAnnotations) {
                     for (var i = 0; i < window.strokes.length; i++) {
-                        drawingCanvas.drawStroke(ctx, window.strokes[i]);
+                        window.drawStroke(ctx, window.strokes[i]);
                     }
                     if (window.currentStroke) {
-                        drawingCanvas.drawStroke(ctx, window.currentStroke);
+                        window.drawStroke(ctx, window.currentStroke);
                     }
                 }
             }


### PR DESCRIPTION
### What
This pull request refactors the `drawStroke` method in `QuickCaptureModal.qml`. The duplicate definitions of `drawStroke` in both `bakedCanvas` and `drawingCanvas` have been removed, and unified into a single window-level `drawStroke` function on the parent `DankModal`.

### Why
Centralizing `drawStroke` reduces code duplication, simplifies maintenance, and removes the fragile dependency where `exportCanvas` and `MagnifierLoupe` had to access the method indirectly via `window.activeCanvas` or `drawingCanvas`.

### How tested
1. Checked for QML syntax errors using `qmllint`.
2. Verified that drawing, exporting, and the magnifier loupe function properly.