### PR TITLE
refactor(compositor): remove redundant compositor check and propagate CLI stderr errors

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -47,6 +47,14 @@ PluginComponent {
 
     function triggerCapture(mode) {
         root.restoringFromFloat = false;
+        
+        // Strictly validate mode against allowlist to prevent command injection
+        const allowedModes = ["region", "window", "full", "output", ""];
+        if (mode && !allowedModes.includes(mode)) {
+            console.warn("Invalid screenshot mode rejected: " + mode);
+            return;
+        }
+
         root.activeIpcMode = mode || "";
         root.startCaptureAfterDelay();
     }
@@ -70,7 +78,7 @@ PluginComponent {
         // This lets us detect ESC cancellation when `dms screenshot region`
         // incorrectly returns exit code 0 without writing a new file.
         Proc.runCommand("pre-capture-cleanup", ["rm", "-f", "/tmp/dms_capture_bg.png"], () => {
-            const cmdStr = root.screenshotArgs().map(arg => '"' + arg.replace(/"/g, '\\"') + '"').join(" ") + " 2>&1";
+            const cmdStr = root.screenshotArgs().map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
             Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
                 if (exitCode === 0) {
                     // Verify the file was actually written before opening the editor.
@@ -87,7 +95,7 @@ PluginComponent {
                     root.isCapturing = false;
                     root.activeIpcMode = "";
                     if (typeof ToastService !== "undefined" && ToastService) {
-                        const errorMsg = (stdout && stdout.trim()) ? stdout.trim() : "Screenshot failed (mode: " + failMode + ").";
+                        const errorMsg = (stdout && stdout.trim()) ? stdout.trim() : I18n.tr("Screenshot failed (mode: %1).").arg(failMode);
                         ToastService.showError(errorMsg);
                     }
                 }

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -47,24 +47,8 @@ PluginComponent {
 
     function triggerCapture(mode) {
         root.restoringFromFloat = false;
-        const targetMode = mode ? mode : root.captureMode;
-        
-        if (targetMode === "window") {
-            const checkCmd = "if [ -n \"$HYPRLAND_INSTANCE_SIGNATURE\" ] || pgrep -x dwl >/dev/null; then echo \"SUPPORTED\"; else echo \"UNSUPPORTED\"; fi";
-            Proc.runCommand("check-compositor", ["sh", "-c", checkCmd], (stdout, exitCode) => {
-                if (!stdout || stdout.trim() !== "SUPPORTED") {
-                    if (typeof ToastService !== "undefined" && ToastService) {
-                        ToastService.showError(I18n.tr("Window capture mode is only supported on Hyprland or DWL."));
-                    }
-                    return;
-                }
-                root.activeIpcMode = mode || "";
-                root.startCaptureAfterDelay();
-            });
-        } else {
-            root.activeIpcMode = mode || "";
-            root.startCaptureAfterDelay();
-        }
+        root.activeIpcMode = mode || "";
+        root.startCaptureAfterDelay();
     }
 
     function closeControlCenter() {
@@ -86,36 +70,25 @@ PluginComponent {
         // This lets us detect ESC cancellation when `dms screenshot region`
         // incorrectly returns exit code 0 without writing a new file.
         Proc.runCommand("pre-capture-cleanup", ["rm", "-f", "/tmp/dms_capture_bg.png"], () => {
-            Proc.runCommand("screenshot-trigger", root.screenshotArgs(), (stdout, exitCode) => {
+            const cmdStr = root.screenshotArgs().map(arg => '"' + arg.replace(/"/g, '\\"') + '"').join(" ") + " 2>&1";
+            Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
                 if (exitCode === 0) {
                     // Verify the file was actually written before opening the editor.
                     // If the user pressed ESC, dms may return 0 but write no file.
                     Proc.runCommand("verify-capture", ["test", "-f", "/tmp/dms_capture_bg.png"], (_, fileExists) => {
+                        root.isCapturing = false;
+                        root.activeIpcMode = "";
                         if (fileExists === 0) {
-                            root.isCapturing = false;
-                            root.activeIpcMode = "";
-                            root.resolvedDmsPath = "dms"; // reset to default path on success
                             root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
-                        } else {
-                            // File not written — user cancelled with ESC. Reset silently.
-                            root.isCapturing = false;
-                            root.activeIpcMode = "";
-                            root.resolvedDmsPath = "dms";
                         }
                     });
                 } else {
-                    if (root.resolvedDmsPath === "dms") {
-                        root.resolvedDmsPath = "/usr/local/bin/dms";
-                        root.startActualCapture();
-                    } else if (root.resolvedDmsPath === "/usr/local/bin/dms") {
-                        root.resolvedDmsPath = "/usr/bin/dms";
-                        root.startActualCapture();
-                    } else {
-                        root.isCapturing = false;
-                        root.activeIpcMode = "";
-                        root.resolvedDmsPath = "dms"; // reset to default path for next attempts
-                        if (typeof ToastService !== "undefined" && ToastService)
-                            ToastService.showError("Screenshot failed (mode: " + root.screenshotMode() + ").");
+                    const failMode = root.screenshotMode();
+                    root.isCapturing = false;
+                    root.activeIpcMode = "";
+                    if (typeof ToastService !== "undefined" && ToastService) {
+                        const errorMsg = (stdout && stdout.trim()) ? stdout.trim() : "Screenshot failed (mode: " + failMode + ").";
+                        ToastService.showError(errorMsg);
                     }
                 }
             }, 0, 60000);
@@ -346,6 +319,21 @@ PluginComponent {
             newInstances[pluginId] = root;
             pluginService.pluginInstances = newInstances;
         }
+
+        // Resolve dms path once at startup
+        Proc.runCommand("check-dms-local", ["test", "-x", "/usr/local/bin/dms"], (_, exitCode) => {
+            if (exitCode === 0) {
+                root.resolvedDmsPath = "/usr/local/bin/dms";
+            } else {
+                Proc.runCommand("check-dms-usr", ["test", "-x", "/usr/bin/dms"], (_, exitCodeUsr) => {
+                    if (exitCodeUsr === 0) {
+                        root.resolvedDmsPath = "/usr/bin/dms";
+                    } else {
+                        root.resolvedDmsPath = "dms";
+                    }
+                });
+            }
+        });
     }
 
     Component.onDestruction: {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -16,7 +16,6 @@ PluginComponent {
     property bool isCapturing: false
     readonly property string captureMode: (pluginData.captureMode || "region")
     property string activeIpcMode: ""
-    property string resolvedDmsPath: "dms"
     property bool restoringFromFloat: false
     property bool isDownloading: false
     // Exposed so the widget surface can read annotation state without accessing internal modal id
@@ -31,7 +30,7 @@ PluginComponent {
         const mode = root.activeIpcMode !== "" ? root.activeIpcMode : root.captureMode;
         const format = "png";
         const cursorVal = pluginData.includeCursor ? "on" : "off";
-        const args = [root.resolvedDmsPath, "screenshot", mode, "--no-clipboard", "--dir", "/tmp", "--filename", "dms_capture_bg.png", "--format", format, "--cursor", cursorVal, "--no-notify"];
+        const args = ["dms", "screenshot", mode, "--no-clipboard", "--dir", "/tmp", "--filename", "dms_capture_bg.png", "--format", format, "--cursor", cursorVal, "--no-notify"];
 
         if (mode === "region" && pluginData.skipConfirm !== false) {
             args.push("--no-confirm");
@@ -327,21 +326,6 @@ PluginComponent {
             newInstances[pluginId] = root;
             pluginService.pluginInstances = newInstances;
         }
-
-        // Resolve dms path once at startup
-        Proc.runCommand("check-dms-local", ["test", "-x", "/usr/local/bin/dms"], (_, exitCode) => {
-            if (exitCode === 0) {
-                root.resolvedDmsPath = "/usr/local/bin/dms";
-            } else {
-                Proc.runCommand("check-dms-usr", ["test", "-x", "/usr/bin/dms"], (_, exitCodeUsr) => {
-                    if (exitCodeUsr === 0) {
-                        root.resolvedDmsPath = "/usr/bin/dms";
-                    } else {
-                        root.resolvedDmsPath = "dms";
-                    }
-                });
-            }
-        });
     }
 
     Component.onDestruction: {


### PR DESCRIPTION
### What
This PR refactors the screenshot triggering pipeline to remove a redundant compositor check and correctly propagate runtime CLI errors to the user.

### Why
1. Previously, the plugin manually checked if it was running on Hyprland or DWL before triggering a window capture. However, the upstream `dms screenshot` CLI already does this validation natively.
2. The retry logic in path resolution was overwriting `stdout`, losing the actual runtime error message (such as compositor mismatch).
3. The standard CLI errors printed to `stderr` were dropped since `Proc.runCommand` only reads `stdout` by default.

### How Tested
1. Executed `dms ipc call quickCapture screenshot window` on a non-supported compositor.
2. Verified that the capture is immediately aborted and the Toast displays the exact error message `"Error: window capture requires Hyprland or Mango"`.

## Summary by Sourcery

Refine the quick capture screenshot pipeline to rely on the dms CLI for compositor validation and surface CLI error output to users while simplifying path resolution.

Bug Fixes:
- Ensure stderr output from the dms screenshot CLI is captured and shown to users when a capture fails.
- Prevent loss of the original CLI error message during screenshot retries by removing path-based retry logic.

Enhancements:
- Remove the redundant compositor pre-check in the capture trigger and delegate compositor validation to the dms CLI.
- Simplify screenshot failure handling by resetting capture state consistently and displaying either the CLI error message or a generic failure message.
- Resolve the dms binary path once at startup instead of retrying multiple paths on each failure.