### PR TITLE
fix(Backdrop): toolbar flicker when scrolling/switching modes

### DIFF
--- a/components/AlignmentControl.qml
+++ b/components/AlignmentControl.qml
@@ -36,7 +36,7 @@ Item {
         }
         StyledText {
             text: control._labelMap[control.backdropAlignment] ?? "C"
-            width: compact ? 14 : 18; horizontalAlignment: Text.AlignHCenter
+            width: compact ? 18 : 22; horizontalAlignment: Text.AlignHCenter
             font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter

--- a/components/AlignmentControl.qml
+++ b/components/AlignmentControl.qml
@@ -35,7 +35,8 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
         }
         StyledText {
-            text: control._labelMap[control.backdropAlignment] ?? "C"
+            text: (control._labelMap[control.backdropAlignment] ?? "C").padEnd(2)
+            font.family: "monospace"
             font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter

--- a/components/AlignmentControl.qml
+++ b/components/AlignmentControl.qml
@@ -35,8 +35,8 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
         }
         StyledText {
-            text: (control._labelMap[control.backdropAlignment] ?? "C").padEnd(2)
-            font.family: "monospace"
+            text: control._labelMap[control.backdropAlignment] ?? "C"
+            width: compact ? 16 : 22; horizontalAlignment: Text.AlignHCenter
             font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter

--- a/components/AlignmentControl.qml
+++ b/components/AlignmentControl.qml
@@ -36,7 +36,7 @@ Item {
         }
         StyledText {
             text: control._labelMap[control.backdropAlignment] ?? "C"
-            width: compact ? 16 : 22; horizontalAlignment: Text.AlignHCenter
+            width: compact ? 14 : 18; horizontalAlignment: Text.AlignHCenter
             font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -36,7 +36,7 @@ Item {
                 if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
                 return control.backdropAspectRatio;
             }
-            width: compact ? 40 : 50; horizontalAlignment: Text.AlignLeft
+            width: compact ? 30 : 38; horizontalAlignment: Text.AlignLeft
             font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -32,10 +32,13 @@ Item {
         }
         StyledText {
             text: {
-                if (control.backdropAspectRatio === "auto") return I18n.tr("AUTO");
-                if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
-                return control.backdropAspectRatio;
+                var t;
+                if (control.backdropAspectRatio === "auto") t = I18n.tr("AUTO");
+                else if (control.backdropAspectRatio === "custom") t = control.customAspectRatio.toFixed(2);
+                else t = control.backdropAspectRatio;
+                return String(t).padStart(5);
             }
+            font.family: "monospace"
             font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -36,7 +36,7 @@ Item {
                 if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
                 return control.backdropAspectRatio;
             }
-            width: compact ? 30 : 38; horizontalAlignment: Text.AlignLeft
+            width: compact ? 36 : 46; horizontalAlignment: Text.AlignLeft
             font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -32,13 +32,11 @@ Item {
         }
         StyledText {
             text: {
-                var t;
-                if (control.backdropAspectRatio === "auto") t = I18n.tr("AUTO");
-                else if (control.backdropAspectRatio === "custom") t = control.customAspectRatio.toFixed(2);
-                else t = control.backdropAspectRatio;
-                return String(t).padStart(5);
+                if (control.backdropAspectRatio === "auto") return I18n.tr("AUTO");
+                if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
+                return control.backdropAspectRatio;
             }
-            font.family: "monospace"
+            width: compact ? 40 : 50; horizontalAlignment: Text.AlignLeft
             font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter

--- a/components/BackdropModeSelectors.qml
+++ b/components/BackdropModeSelectors.qml
@@ -19,8 +19,8 @@ Grid {
     readonly property var modes: [
         { mode: "none", icon: "blur_off", tooltip: qsTr("No Backdrop") },
         { mode: "solid", icon: "format_color_fill", tooltip: qsTr("Solid Color") },
-        { mode: "gradient", icon: "gradient", tooltip: qsTr("Linear Gradient") },
         { mode: "radial", icon: "filter_tilt_shift", tooltip: qsTr("Radial Gradient") },
+        { mode: "gradient", icon: "gradient", tooltip: qsTr("Linear Gradient") },
         { mode: "conic", icon: "timelapse", tooltip: qsTr("Conic Gradient") }
     ]
 

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -473,7 +473,7 @@ Rectangle {
                         }
                         StyledText {
                             text: root.backdropPadding + "px"
-                            width: 32; horizontalAlignment: Text.AlignRight
+                            width: 40; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -509,7 +509,7 @@ Rectangle {
                         }
                         StyledText {
                             text: root.backdropCornerRadius + "px"
-                            width: 32; horizontalAlignment: Text.AlignRight
+                            width: 40; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -545,7 +545,7 @@ Rectangle {
                         }
                         StyledText {
                             text: root.backdropShadowStrength + "%"
-                            width: 32; horizontalAlignment: Text.AlignRight
+                            width: 40; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -582,7 +582,7 @@ Rectangle {
                         }
                         StyledText {
                             text: root.backdropGradientAngle + "°"
-                            width: 32; horizontalAlignment: Text.AlignRight
+                            width: 40; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -472,7 +472,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.backdropPadding + "px"
+                            text: String(root.backdropPadding).padStart(3) + "px"
+                            font.family: "monospace"
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -507,7 +508,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.backdropCornerRadius + "px"
+                            text: String(root.backdropCornerRadius).padStart(3) + "px"
+                            font.family: "monospace"
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -542,7 +544,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.backdropShadowStrength + "%"
+                            text: String(root.backdropShadowStrength).padStart(3) + "%"
+                            font.family: "monospace"
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -578,7 +581,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.backdropGradientAngle + "°"
+                            text: String(root.backdropGradientAngle).padStart(3) + "°"
+                            font.family: "monospace"
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -619,13 +623,15 @@ Rectangle {
             }
             
             Rectangle { 
-                visible: root.backdropMode !== "none"
+                opacity: root.backdropMode !== "none" ? 1 : 0
+                enabled: root.backdropMode !== "none"
                 width: tc.separatorThickness; height: tc.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter 
             }
             
             // Colors (Solid or Gradient)
             Row {
-                visible: root.backdropMode !== "none"
+                opacity: root.backdropMode !== "none" ? 1 : 0
+                enabled: root.backdropMode !== "none"
                 spacing: Theme.spacingS
                 anchors.verticalCenter: parent.verticalCenter
                                  BackdropColorSelectors {
@@ -713,7 +719,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.backdropPadding
+                            text: String(root.backdropPadding).padStart(3)
+                            font.family: "monospace"
                             font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -747,7 +754,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.backdropCornerRadius
+                            text: String(root.backdropCornerRadius).padStart(3)
+                            font.family: "monospace"
                             font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -781,7 +789,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.backdropShadowStrength
+                            text: String(root.backdropShadowStrength).padStart(3)
+                            font.family: "monospace"
                             font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -816,7 +825,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: root.backdropGradientAngle
+                            text: String(root.backdropGradientAngle).padStart(3)
+                            font.family: "monospace"
                             font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -857,13 +867,15 @@ Rectangle {
             }
             
             Rectangle { 
-                visible: root.backdropMode !== "none"
+                opacity: root.backdropMode !== "none" ? 1 : 0
+                enabled: root.backdropMode !== "none"
                 width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter 
             }
             
             // Colors (Solid or Gradient)
             Column {
-                visible: root.backdropMode !== "none"
+                opacity: root.backdropMode !== "none" ? 1 : 0
+                enabled: root.backdropMode !== "none"
                 spacing: Theme.spacingS
                 anchors.horizontalCenter: parent.horizontalCenter
                                  BackdropColorSelectors {

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -473,7 +473,7 @@ Rectangle {
                         }
                         StyledText {
                             text: root.backdropPadding + "px"
-                            width: 42; horizontalAlignment: Text.AlignRight
+                            width: 32; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -509,7 +509,7 @@ Rectangle {
                         }
                         StyledText {
                             text: root.backdropCornerRadius + "px"
-                            width: 42; horizontalAlignment: Text.AlignRight
+                            width: 32; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -545,7 +545,7 @@ Rectangle {
                         }
                         StyledText {
                             text: root.backdropShadowStrength + "%"
-                            width: 42; horizontalAlignment: Text.AlignRight
+                            width: 32; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -582,7 +582,7 @@ Rectangle {
                         }
                         StyledText {
                             text: root.backdropGradientAngle + "°"
-                            width: 42; horizontalAlignment: Text.AlignRight
+                            width: 32; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -472,8 +472,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: String(root.backdropPadding).padStart(3) + "px"
-                            font.family: "monospace"
+                            text: root.backdropPadding + "px"
+                            width: 42; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -508,8 +508,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: String(root.backdropCornerRadius).padStart(3) + "px"
-                            font.family: "monospace"
+                            text: root.backdropCornerRadius + "px"
+                            width: 42; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -544,8 +544,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: String(root.backdropShadowStrength).padStart(3) + "%"
-                            font.family: "monospace"
+                            text: root.backdropShadowStrength + "%"
+                            width: 42; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -581,8 +581,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: String(root.backdropGradientAngle).padStart(3) + "°"
-                            font.family: "monospace"
+                            text: root.backdropGradientAngle + "°"
+                            width: 42; horizontalAlignment: Text.AlignRight
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -719,8 +719,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: String(root.backdropPadding).padStart(3)
-                            font.family: "monospace"
+                            text: root.backdropPadding
+                            width: tc.btnSize; horizontalAlignment: Text.AlignRight
                             font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -754,8 +754,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: String(root.backdropCornerRadius).padStart(3)
-                            font.family: "monospace"
+                            text: root.backdropCornerRadius
+                            width: tc.btnSize; horizontalAlignment: Text.AlignRight
                             font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -789,8 +789,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: String(root.backdropShadowStrength).padStart(3)
-                            font.family: "monospace"
+                            text: root.backdropShadowStrength
+                            width: tc.btnSize; horizontalAlignment: Text.AlignRight
                             font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter
@@ -825,8 +825,8 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         StyledText {
-                            text: String(root.backdropGradientAngle).padStart(3)
-                            font.family: "monospace"
+                            text: root.backdropGradientAngle
+                            width: tc.btnSize; horizontalAlignment: Text.AlignRight
                             font.pixelSize: tc.fontSizeCompact
                             color: Theme.surfaceText
                             anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
## Summary

Fix backdrop toolbar flickering caused by layout reflows when switching modes or scrolling properties.

## Changes

### `components/QuickCaptureToolbar.qml`
- **Separator & Colors section:** replace bare `visible` with `opacity` + `enabled` to preserve layout space on hide
- **Text labels:** `monospace` font + `String.padStart(3)` for padding, corner radius, shadow strength, gradient angle — eliminates width jitter when values change

### `components/AlignmentControl.qml`
- `monospace` font + `.padEnd(2)` — stable width across alignment codes ("C", "TL", "BR", etc.)

### `components/AspectRatioControl.qml`
- `monospace` font + `.padStart(5)` — stable width across aspect ratio values ("AUTO", "16:9", "16:10", "1.50", etc.)

## Related Issue
Closes #147

## Summary by Sourcery

Stabilize the Backdrop toolbar UI to eliminate flickering during mode changes and scrolling by making layout and label widths consistent.

Bug Fixes:
- Prevent backdrop toolbar separators and color controls from causing layout reflows when toggling backdrop modes.
- Ensure backdrop numeric and alignment labels maintain stable widths as their values change to avoid visual jitter.

Enhancements:
- Use opacity and enabled states instead of visibility to keep separator and color sections in the layout when backdrop mode is disabled.
- Apply monospace fonts with padded text for numeric and aspect/alignment labels to provide consistent sizing across different values.