### PR TITLE
fix(Text): multi-line text bbox, hit test, and dialog styling

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1383,6 +1383,12 @@ DankModal {
             return;
         }
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            if (event.modifiers & Qt.ShiftModifier) {
+                window.currentTypingText += "\n";
+                if (window.activeCanvas) window.activeCanvas.requestPaint();
+                event.accepted = true;
+                return;
+            }
             window.commitTypingText();
             event.accepted = true;
             return;
@@ -2426,16 +2432,23 @@ DankModal {
                                     ctx.textAlign = "left";
                                     ctx.textBaseline = "middle";
 
+                                    const previewLines = String(window.currentTypingText + "|").split("\n");
+                                    const lineH = window.textFontSize * 1.35;
+
                                     if (window.textBackground) {
-                                        const textMetrics = ctx.measureText(window.currentTypingText + "|");
-                                        const textWidth = textMetrics.width;
+                                        let maxW = 0;
+                                        for (let li = 0; li < previewLines.length; li++) {
+                                            const m = ctx.measureText(previewLines[li]);
+                                            if (m.width > maxW) maxW = m.width;
+                                        }
                                         const h = window.textFontSize;
                                         const padX = h * 0.3;
                                         const padY = h * 0.15;
+                                        const totalH = previewLines.length * lineH - (lineH - h);
                                         const rx = window.typingCoords.x - padX;
                                         const ry = window.typingCoords.y - padY;
-                                        const rw = textWidth + padX * 2;
-                                        const rh = h + padY * 2;
+                                        const rw = maxW + padX * 2;
+                                        const rh = totalH + padY * 2;
                                         const radius = window.textCornerRadius;
 
                                         ctx.fillStyle = Helpers.getContrastingColor(window.currentColor.toString(), Qt);
@@ -2460,16 +2473,20 @@ DankModal {
                                         ctx.fillStyle = window.currentColor;
                                     }
 
-                                    ctx.fillText(window.currentTypingText + "|", window.typingCoords.x, window.typingCoords.y + window.textFontSize / 2);
+                                    for (let li = 0; li < previewLines.length; li++) {
+                                        ctx.fillText(previewLines[li], window.typingCoords.x, window.typingCoords.y + li * lineH + window.textFontSize / 2);
+                                    }
 
                                     if (window.textUnderline) {
-                                        const textWidth = ctx.measureText(window.currentTypingText + "|").width;
                                         ctx.strokeStyle = window.currentColor;
                                         ctx.lineWidth = Math.max(1.5, Math.round(window.textFontSize * 0.08));
-                                        ctx.beginPath();
-                                        ctx.moveTo(window.typingCoords.x, window.typingCoords.y + window.textFontSize * 1.05);
-                                        ctx.lineTo(window.typingCoords.x + textWidth, window.typingCoords.y + window.textFontSize * 1.05);
-                                        ctx.stroke();
+                                        for (let li = 0; li < previewLines.length; li++) {
+                                            const textWidth = ctx.measureText(previewLines[li]).width;
+                                            ctx.beginPath();
+                                            ctx.moveTo(window.typingCoords.x, window.typingCoords.y + li * lineH + window.textFontSize * 1.05);
+                                            ctx.lineTo(window.typingCoords.x + textWidth, window.typingCoords.y + li * lineH + window.textFontSize * 1.05);
+                                            ctx.stroke();
+                                        }
                                     }
                                 }
                             }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -517,16 +517,23 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         ctx.textAlign = "left";
         ctx.textBaseline = "middle";
 
+        const lines = String(stroke.text).split("\n");
+        const lineHeight = stroke.width * 1.35;
+
         if (stroke.hasBackground) {
-            const textMetrics = ctx.measureText(stroke.text);
-            const textWidth = textMetrics.width;
+            let maxWidth = 0;
+            for (let li = 0; li < lines.length; li++) {
+                const m = ctx.measureText(lines[li]);
+                if (m.width > maxWidth) maxWidth = m.width;
+            }
             const h = stroke.width;
             const padX = h * 0.3;
-            const padY = h * 0.15; // Further reduced vertical padding
+            const padY = h * 0.15;
+            const totalH = lines.length * lineHeight - (lineHeight - h);
             const rx = pt.x - padX;
             const ry = pt.y - padY;
-            const rw = textWidth + padX * 2;
-            const rh = h + padY * 2; // Symmetric height
+            const rw = maxWidth + padX * 2;
+            const rh = totalH + padY * 2;
             const radius = stroke.cornerRadius || 0;
 
             ctx.fillStyle = Helpers.getContrastingColor(stroke.color, Qt);
@@ -548,20 +555,23 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 ctx.fillRect(rx, ry, rw, rh);
             }
             
-            // Re-set fill color for text
             ctx.fillStyle = stroke.color;
         }
 
-        ctx.fillText(stroke.text, pt.x, pt.y + stroke.width / 2);
+        for (let li = 0; li < lines.length; li++) {
+            ctx.fillText(lines[li], pt.x, pt.y + li * lineHeight + stroke.width / 2);
+        }
 
         if (stroke.isUnderline) {
-            const textWidth = ctx.measureText(stroke.text).width;
             ctx.strokeStyle = stroke.color;
             ctx.lineWidth = Math.max(1.5, Math.round(stroke.width * 0.08));
-            ctx.beginPath();
-            ctx.moveTo(pt.x, pt.y + stroke.width * 1.1);
-            ctx.lineTo(pt.x + textWidth, pt.y + stroke.width * 1.1);
-            ctx.stroke();
+            for (let li = 0; li < lines.length; li++) {
+                const textWidth = ctx.measureText(lines[li]).width;
+                ctx.beginPath();
+                ctx.moveTo(pt.x, pt.y + li * lineHeight + stroke.width * 1.1);
+                ctx.lineTo(pt.x + textWidth, pt.y + li * lineHeight + stroke.width * 1.1);
+                ctx.stroke();
+            }
         }
     }
 }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -517,7 +517,7 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         ctx.textAlign = "left";
         ctx.textBaseline = "middle";
 
-        const lines = String(stroke.text).split("\n");
+        const lines = (stroke.text || "").split("\n");
         const lineHeight = stroke.width * 1.35;
 
         if (stroke.hasBackground) {

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -382,50 +382,53 @@ function extractDominantColors(imgData, Qt) {
  */
 function estimateTextWidth(text, fontSize, isBold, isMonospace) {
     if (!text) return 0;
-    let charWidthRatio = isMonospace ? 0.6 : 0.52;
-    if (isBold) charWidthRatio += 0.05;
+    const lines = String(text).split("\n");
+    let maxWidth = 0;
+    for (let li = 0; li < lines.length; li++) {
+        const line = lines[li];
+        if (!line) continue;
+        let charWidthRatio = isMonospace ? 0.6 : 0.52;
+        if (isBold) charWidthRatio += 0.05;
 
-    let estWidth = 0;
-    for (let c = 0; c < text.length; c++) {
-        const charCode = text.charCodeAt(c);
-        if (charCode > 255) {
-            // Treat known CJK and related ranges as wide; fall back to proportional width
-            const isCJKOrWideScript =
-                    // CJK Unified Ideographs
-                    (charCode >= 0x3400 && charCode <= 0x4DBF) ||
-                    (charCode >= 0x4E00 && charCode <= 0x9FFF) ||
-                    (charCode >= 0xF900 && charCode <= 0xFAFF) ||
-                    // Hiragana
-                    (charCode >= 0x3040 && charCode <= 0x309F) ||
-                    // Katakana
-                    (charCode >= 0x30A0 && charCode <= 0x30FF) ||
-                    // Hangul syllables
-                    (charCode >= 0xAC00 && charCode <= 0xD7AF);
+        let estWidth = 0;
+        for (let c = 0; c < line.length; c++) {
+            const charCode = line.charCodeAt(c);
+            if (charCode > 255) {
+                const isCJKOrWideScript =
+                        (charCode >= 0x3400 && charCode <= 0x4DBF) ||
+                        (charCode >= 0x4E00 && charCode <= 0x9FFF) ||
+                        (charCode >= 0xF900 && charCode <= 0xFAFF) ||
+                        (charCode >= 0x3040 && charCode <= 0x309F) ||
+                        (charCode >= 0x30A0 && charCode <= 0x30FF) ||
+                        (charCode >= 0xAC00 && charCode <= 0xD7AF);
 
-            if (isCJKOrWideScript) {
-                estWidth += fontSize * 0.9;
-            } else {
-                // Non-ASCII but not CJK (e.g. accented Latin/Vietnamese diacritics): proportional width
+                if (isCJKOrWideScript) {
+                    estWidth += fontSize * 0.9;
+                } else {
+                    estWidth += fontSize * charWidthRatio;
+                }
+            } else if (isMonospace) {
                 estWidth += fontSize * charWidthRatio;
-            }
-        } else if (isMonospace) {
-            estWidth += fontSize * charWidthRatio;
-        } else {
-            const char = text.charAt(c);
-            if ("iIlldt1|()[]{}".indexOf(char) !== -1) {
-                estWidth += fontSize * 0.28;
-            } else if ("mwMW".indexOf(char) !== -1) {
-                estWidth += fontSize * 0.8;
-            } else if (char >= "A" && char <= "Z") {
-                estWidth += fontSize * 0.65;
             } else {
-                estWidth += fontSize * charWidthRatio;
+                const ch = line.charAt(c);
+                if ("iIlldt1|()[]{}".indexOf(ch) !== -1) {
+                    estWidth += fontSize * 0.28;
+                } else if ("mwMW".indexOf(ch) !== -1) {
+                    estWidth += fontSize * 0.8;
+                } else if (ch >= "A" && ch <= "Z") {
+                    estWidth += fontSize * 0.65;
+                } else {
+                    estWidth += fontSize * charWidthRatio;
+                }
             }
         }
+
+        const maxW = fontSize * line.length * (isMonospace ? 1.2 : 1.6);
+        estWidth = Math.min(estWidth, maxW);
+        if (estWidth > maxWidth) maxWidth = estWidth;
     }
 
-    const maxW = fontSize * text.length * (isMonospace ? 1.2 : 1.6);
-    return Math.min(estWidth, maxW);
+    return maxWidth;
 }
 
 /**
@@ -446,11 +449,15 @@ function getStrokeBBox(stroke, estimateTextWidthFn) {
         const p0 = pts[0];
         const fontSize = stroke.width;
         const txt = stroke.text || "";
+        const lines = String(txt).split("\n");
+        const numLines = lines.length || 1;
+        const lineHeight = fontSize * 1.35;
+
         let textW = Constants.minTextWidth;
         if (estimateTextWidthFn) {
             textW = Math.max(Constants.minTextWidth, estimateTextWidthFn(txt, fontSize, stroke.isBold === true, stroke.isMonospace === true));
         }
-        let textH = fontSize;
+        let textH = fontSize + (numLines - 1) * lineHeight;
         let textX = p0.x;
         let textY = p0.y;
 
@@ -603,9 +610,12 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
             const p0 = stroke.points[0];
             const fontSize = stroke.width;
             const txt = stroke.text || "";
+            const lines = String(txt).split("\n");
+            const numLines = lines.length || 1;
+            const lineHeight = fontSize * 1.35;
 
             let textW = Math.max(Constants.minTextWidth, estimateTextWidthFn(txt, fontSize, stroke.isBold === true, stroke.isMonospace === true));
-            let textH = fontSize;
+            let textH = fontSize + (numLines - 1) * lineHeight;
             let textY = p0.y;
             let textX = p0.x;
 

--- a/components/TextInputDialog.qml
+++ b/components/TextInputDialog.qml
@@ -8,8 +8,8 @@ import "../dms-common"
 
 Popup {
     id: textInputDialog
-    width: 320
-    height: 160
+    width: 420
+    height: Math.min(Math.max(textInputField.implicitHeight + 100, 200), 400)
     padding: 0
     modal: false
     focus: true
@@ -59,15 +59,39 @@ Popup {
                 color: Theme.surfaceText
             }
 
-            DankTextField {
-                id: textInputField
+            ScrollView {
+                id: textScrollView
                 width: parent.width
-                placeholderText: I18n.tr("Type note...")
-                focus: true
-                onAccepted: {
-                    window.currentTypingText = textInputField.text;
-                    textInputDialog.close();
-                    window.commitTypingText();
+                height: Math.min(textInputField.implicitHeight, 240)
+                clip: true
+
+                TextArea {
+                    id: textInputField
+                    width: textScrollView.width
+                    placeholderText: I18n.tr("Type note...")
+                    wrapMode: TextEdit.Wrap
+                    focus: true
+                    font.pixelSize: Theme.fontSizeNormal
+                    color: Theme.surfaceText
+                    selectionColor: Theme.withAlpha(Theme.primary, 0.3)
+                    selectedTextColor: Theme.surfaceText
+                    background: Rectangle {
+                        color: Theme.surfaceContainerHigh
+                        radius: Theme.cornerRadiusSmall
+                    }
+                    topPadding: Theme.spacingS
+                    leftPadding: Theme.spacingS
+                    rightPadding: Theme.spacingS
+                    bottomPadding: Theme.spacingS
+
+                    Keys.onPressed: (event) => {
+                        if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter) && !(event.modifiers & Qt.ShiftModifier)) {
+                            window.currentTypingText = textInputField.text;
+                            textInputDialog.close();
+                            window.commitTypingText();
+                            event.accepted = true;
+                        }
+                    }
                 }
             }
 

--- a/components/TextInputDialog.qml
+++ b/components/TextInputDialog.qml
@@ -62,7 +62,7 @@ Popup {
             Rectangle {
                 id: inputBackground
                 width: parent.width
-                height: Math.max(textInputField.implicitHeight + textInputField.topPadding + textInputField.bottomPadding, 72)
+                height: Math.max(textInputField.implicitHeight, 72)
                 radius: Theme.cornerRadiusSmall
                 color: textInputField.activeFocus ? Theme.surfaceContainerHighest : Theme.surfaceContainerHigh
                 border.color: textInputField.activeFocus ? Theme.primary : Theme.outlineMedium

--- a/components/TextInputDialog.qml
+++ b/components/TextInputDialog.qml
@@ -9,7 +9,7 @@ import "../dms-common"
 Popup {
     id: textInputDialog
     width: 420
-    height: Math.min(Math.max(textInputField.implicitHeight + 100, 200), 400)
+    height: Math.min(Math.max(inputBackground.height + 120, 200), 400)
     padding: 0
     modal: false
     focus: true
@@ -59,26 +59,28 @@ Popup {
                 color: Theme.surfaceText
             }
 
-            ScrollView {
-                id: textScrollView
+            Rectangle {
+                id: inputBackground
                 width: parent.width
-                height: Math.min(textInputField.implicitHeight, 240)
-                clip: true
+                height: Math.max(textInputField.implicitHeight + textInputField.topPadding + textInputField.bottomPadding, 72)
+                radius: Theme.cornerRadiusSmall
+                color: textInputField.activeFocus ? Theme.surfaceContainerHighest : Theme.surfaceContainerHigh
+                border.color: textInputField.activeFocus ? Theme.primary : Theme.outlineMedium
+                border.width: textInputField.activeFocus ? 2 : 1
 
                 TextArea {
                     id: textInputField
-                    width: textScrollView.width
+                    anchors.fill: parent
+                    anchors.margins: 1
                     placeholderText: I18n.tr("Type note...")
                     wrapMode: TextEdit.Wrap
                     focus: true
                     font.pixelSize: Theme.fontSizeNormal
+                    font.family: Theme.fontFamily
                     color: Theme.surfaceText
-                    selectionColor: Theme.withAlpha(Theme.primary, 0.3)
-                    selectedTextColor: Theme.surfaceText
-                    background: Rectangle {
-                        color: Theme.surfaceContainerHigh
-                        radius: Theme.cornerRadiusSmall
-                    }
+                    selectionColor: Theme.primaryContainer
+                    selectedTextColor: Theme.primary
+                    background: null
                     topPadding: Theme.spacingS
                     leftPadding: Theme.spacingS
                     rightPadding: Theme.spacingS


### PR DESCRIPTION
## Summary
- **TextInputDialog.qml**: Now matches Dank component styling — focus-highlighted border, `Theme.primaryContainer` selection colors, minimum 3-line visible height (72px)
- **Helpers.js:getStrokeBBox()**: Text bounding box now spans all lines (`fontSize + (numLines-1) * lineHeight` where `lineHeight = fontSize * 1.35`), matching DrawingRenderer rendering
- **Helpers.js:findStrokeAt()**: Hit detection area covers all lines (same multi-line height fix)
- **Helpers.js:estimateTextWidth()**: Now returns max width across all lines (split on `\n`, per-line max)

## Summary by Sourcery

Support multi-line text notes with proper bounding boxes, hit testing, and preview rendering, and restyle the text input dialog to behave like a multi-line note editor.

New Features:
- Allow entering and previewing multi-line text notes with Shift+Enter in quick capture and the text input dialog.

Bug Fixes:
- Fix text bounding boxes and hit-testing so multi-line text strokes cover all lines instead of a single-line height.

Enhancements:
- Improve text width estimation to consider the widest line in multi-line text and clamp extreme widths.
- Render text stroke backgrounds, text, and underlines line-by-line for multi-line content in both the canvas renderer and typing preview.
- Restyle the text input dialog as a resizable, themed multi-line text area with updated focus and selection colors.