### PR TITLE
feat(select): add 8-point vector resizing handles for shapes and 2-point handles for lines

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1190,6 +1190,11 @@ DankModal {
         return Helpers.findStrokeAt(mx, my, window.strokes, window.estimateTextWidth);
     }
 
+    function getSelectedStrokeHandleAt(mx, my) {
+        if (!window.selectedStroke) return "none";
+        return Helpers.getStrokeHandleAt(mx, my, window.selectedStroke, window.estimateTextWidth);
+    }
+
     function exportAndExecute(callback) {
         if (window.isTyping) {
             window.commitTypingText();
@@ -2418,6 +2423,11 @@ DankModal {
                                 // Draw selected stroke
                                 if (selectedStroke && selectedStroke.tool !== "spotlight" && selectedStroke.tool !== "pixelate") {
                                     drawStroke(ctx, selectedStroke);
+                                }
+
+                                // Draw selection resize handles in select mode
+                                if (selectedStroke && window.currentTool === "select") {
+                                    DrawingRenderer.drawSelectionHandles(ctx, selectedStroke, Theme);
                                 }
 
                                 // Draw temporary live typing text

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -27,3 +27,6 @@ const stampTextFontSizeMultiplier = 1.2;
 const stampTextOffsetMultiplier = 0.1;
 const textPaddingMultiplierX = 0.3;
 const textPaddingMultiplierY = 0.15;
+
+// Selection resize handles
+const selectionHandleSize = 8;

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -54,26 +54,81 @@ MouseArea {
 
         if (window.currentTool === "select") {
             if (window.selectedStroke) {
-                const dx = absPt.x - window.pressCoords.x;
-                const dy = absPt.y - window.pressCoords.y;
-                if (window.selectedStroke.tool === "callout" && window.calloutDestDragging && window.originalPoints.length === 4) {
-                    const newPoints = [...window.selectedStroke.points];
-                    newPoints[2] = Qt.point(window.originalPoints[2].x + dx, window.originalPoints[2].y + dy);
-                    newPoints[3] = Qt.point(window.originalPoints[3].x + dx, window.originalPoints[3].y + dy);
-                    window.selectedStroke.points = newPoints;
-                } else {
-                    const newPoints = [];
-                    for (let i = 0; i < window.originalPoints.length; i++) {
-                        newPoints.push(Qt.point(window.originalPoints[i].x + dx, window.originalPoints[i].y + dy));
+                const sh = window.getSelectedStrokeHandleAt(absPt.x, absPt.y);
+                hoveredHandle = sh !== "none" ? sh : "none";
+
+                if (window.activeHandle === "none" && window.originalPoints.length > 0) {
+                    const dx = absPt.x - window.pressCoords.x;
+                    const dy = absPt.y - window.pressCoords.y;
+                    if (window.selectedStroke.tool === "callout" && window.calloutDestDragging && window.originalPoints.length === 4) {
+                        const newPoints = [...window.selectedStroke.points];
+                        newPoints[2] = Qt.point(window.originalPoints[2].x + dx, window.originalPoints[2].y + dy);
+                        newPoints[3] = Qt.point(window.originalPoints[3].x + dx, window.originalPoints[3].y + dy);
+                        window.selectedStroke.points = newPoints;
+                    } else {
+                        const newPoints = [];
+                        for (let i = 0; i < window.originalPoints.length; i++) {
+                            newPoints.push(Qt.point(window.originalPoints[i].x + dx, window.originalPoints[i].y + dy));
+                        }
+                        window.selectedStroke.points = newPoints;
                     }
-                    window.selectedStroke.points = newPoints;
+                    if (window.selectedStroke.tool === "redact") {
+                        window.selectedStroke.cachedCleanColor = undefined;
+                    }
+                } else if (window.activeHandle !== "none" && window.originalPoints.length > 0) {
+                    const dx = absPt.x - window.pressCoords.x;
+                    const dy = absPt.y - window.pressCoords.y;
+                    const orig = window.originalPoints;
+                    const tool = window.selectedStroke.tool;
+
+                    if (tool === "rect" || tool === "ellipse" || tool === "redact" ||
+                        tool === "pixelate" || tool === "spotlight") {
+                        const p0 = orig[0];
+                        const p1 = orig[orig.length - 1];
+                        let x1 = Math.min(p0.x, p1.x);
+                        let y1 = Math.min(p0.y, p1.y);
+                        let x2 = Math.max(p0.x, p1.x);
+                        let y2 = Math.max(p0.y, p1.y);
+                        const minSize = 10;
+
+                        switch (window.activeHandle) {
+                            case "tl": x1 = Math.min(x1 + dx, x2 - minSize); y1 = Math.min(y1 + dy, y2 - minSize); break;
+                            case "tr": x2 = Math.max(x2 + dx, x1 + minSize); y1 = Math.min(y1 + dy, y2 - minSize); break;
+                            case "bl": x1 = Math.min(x1 + dx, x2 - minSize); y2 = Math.max(y2 + dy, y1 + minSize); break;
+                            case "br": x2 = Math.max(x2 + dx, x1 + minSize); y2 = Math.max(y2 + dy, y1 + minSize); break;
+                            case "tc": y1 = Math.min(y1 + dy, y2 - minSize); break;
+                            case "bc": y2 = Math.max(y2 + dy, y1 + minSize); break;
+                            case "lc": x1 = Math.min(x1 + dx, x2 - minSize); break;
+                            case "rc": x2 = Math.max(x2 + dx, x1 + minSize); break;
+                        }
+
+                        const wasFlippedX = p0.x > p1.x;
+                        const wasFlippedY = p0.y > p1.y;
+                        const newP0 = Qt.point(wasFlippedX ? x2 : x1, wasFlippedY ? y2 : y1);
+                        const newP1 = Qt.point(wasFlippedX ? x1 : x2, wasFlippedY ? y1 : y2);
+
+                        const newPoints = [...window.selectedStroke.points];
+                        newPoints[0] = newP0;
+                        newPoints[newPoints.length - 1] = newP1;
+                        window.selectedStroke.points = newPoints;
+
+                        if (tool === "redact") {
+                            window.selectedStroke.cachedCleanColor = undefined;
+                        }
+                    } else if (tool === "line" || tool === "arrow") {
+                        const newPoints = [...window.selectedStroke.points];
+                        if (window.activeHandle === "start") {
+                            newPoints[0] = Qt.point(orig[0].x + dx, orig[0].y + dy);
+                        } else if (window.activeHandle === "end") {
+                            newPoints[newPoints.length - 1] = Qt.point(orig[orig.length - 1].x + dx, orig[orig.length - 1].y + dy);
+                        }
+                        window.selectedStroke.points = newPoints;
+                    }
                 }
-                 if (window.selectedStroke.tool === "redact") {
-                     window.selectedStroke.cachedCleanColor = undefined;
-                 }
-                 drawingCanvas.requestPaint();
+                drawingCanvas.requestPaint();
             } else {
                 hoveredStrokeIdx = window.findStrokeAt(absPt.x, absPt.y);
+                hoveredHandle = "none";
             }
             return;
         }
@@ -225,6 +280,7 @@ MouseArea {
         if (h === "tr" || h === "bl") return Qt.SizeBDiagCursor;
         if (h === "tc" || h === "bc") return Qt.SplitVCursor;
         if (h === "lc" || h === "rc") return Qt.SplitHCursor;
+        if (h === "start" || h === "end") return Qt.SizeAllCursor;
         if (window.currentTool === "colorpicker") {
             return Qt.CrossCursor;
         }
@@ -278,8 +334,11 @@ MouseArea {
             const strokeIdx = window.findStrokeAt(absPt.x, absPt.y);
             if (strokeIdx !== -1) {
                 const list = [...window.strokes];
-                list.splice(strokeIdx, 1);
+                const removed = list.splice(strokeIdx, 1);
                 window.strokes = list;
+                if (window.selectedStroke === removed[0]) {
+                    window.selectedStroke = null;
+                }
                 drawingCanvas.requestPaint();
             }
             return;
@@ -287,7 +346,41 @@ MouseArea {
 
         const absPt = getAbsolutePoint(mouse.x, mouse.y);
         if (window.currentTool === "select") {
+            // Check if clicking on a resize handle
+            if (window.selectedStroke) {
+                const sh = window.getSelectedStrokeHandleAt(absPt.x, absPt.y);
+                if (sh !== "none") {
+                    window.activeHandle = sh;
+                    window.pressCoords = absPt;
+                    const orig = [];
+                    for (let p of window.selectedStroke.points) {
+                        orig.push(Qt.point(p.x, p.y));
+                    }
+                    window.originalPoints = orig;
+                    drawingCanvas.requestPaint();
+                    return;
+                }
+            }
+
             const strokeIdx = window.findStrokeAt(absPt.x, absPt.y);
+            if (strokeIdx === -1) {
+                // Clicked empty space — deselect
+                if (window.selectedStroke) {
+                    window.strokeWidth = window.preGrabStrokeWidth;
+                    window.textFontSize = window.preGrabTextFontSize;
+                    window.pixelateIntensity = window.preGrabPixelateIntensity;
+                    window.spotlightIntensity = window.preGrabSpotlightIntensity;
+                    window.calloutZoom = window.preGrabCalloutZoom;
+                    window.currentColor = window.preGrabColor;
+                    window.activeRedactMode = window.preGrabRedactMode;
+                    window.calloutLinkLines = window.preGrabCalloutLinkLines;
+                }
+                window.selectedStroke = null;
+                window.originalPoints = [];
+                drawingCanvas.requestPaint();
+                return;
+            }
+
             if (strokeIdx !== -1) {
                 const stroke = window.strokes[strokeIdx];
                 
@@ -483,15 +576,7 @@ MouseArea {
 
     onReleased: (mouse) => {
         if (window.currentTool === "select") {
-             window.selectedStroke = null;
-             window.strokeWidth = window.preGrabStrokeWidth;
-             window.textFontSize = window.preGrabTextFontSize;
-             window.pixelateIntensity = window.preGrabPixelateIntensity;
-             window.spotlightIntensity = window.preGrabSpotlightIntensity;
-             window.calloutZoom = window.preGrabCalloutZoom;
-             window.currentColor = window.preGrabColor;
-             window.activeRedactMode = window.preGrabRedactMode;
-             window.calloutLinkLines = window.preGrabCalloutLinkLines;
+             window.activeHandle = "none";
              window.calloutDestDragging = false;
              window.originalPoints = [];
              drawingCanvas.requestPaint();

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -54,8 +54,7 @@ MouseArea {
 
         if (window.currentTool === "select") {
             if (window.selectedStroke) {
-                const sh = window.getSelectedStrokeHandleAt(absPt.x, absPt.y);
-                hoveredHandle = sh !== "none" ? sh : "none";
+                hoveredHandle = window.getSelectedStrokeHandleAt(absPt.x, absPt.y);
 
                 if (window.activeHandle === "none" && window.originalPoints.length > 0) {
                     const dx = absPt.x - window.pressCoords.x;
@@ -337,6 +336,14 @@ MouseArea {
                 const removed = list.splice(strokeIdx, 1);
                 window.strokes = list;
                 if (window.selectedStroke === removed[0]) {
+                    window.strokeWidth = window.preGrabStrokeWidth;
+                    window.textFontSize = window.preGrabTextFontSize;
+                    window.pixelateIntensity = window.preGrabPixelateIntensity;
+                    window.spotlightIntensity = window.preGrabSpotlightIntensity;
+                    window.calloutZoom = window.preGrabCalloutZoom;
+                    window.currentColor = window.preGrabColor;
+                    window.activeRedactMode = window.preGrabRedactMode;
+                    window.calloutLinkLines = window.preGrabCalloutLinkLines;
                     window.selectedStroke = null;
                 }
                 drawingCanvas.requestPaint();
@@ -377,6 +384,8 @@ MouseArea {
                 }
                 window.selectedStroke = null;
                 window.originalPoints = [];
+                window.activeHandle = "none";
+                hoveredHandle = "none";
                 drawingCanvas.requestPaint();
                 return;
             }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -577,6 +577,68 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
 }
 
 /**
+ * Draws resize handles for a selected stroke in select mode.
+ * 8-point handles for shapes, 2-point handles for lines.
+ * @param {object} ctx - The Canvas 2D context.
+ * @param {object} stroke - The selected stroke data object.
+ * @param {object} Theme - The Theme object.
+ */
+function drawSelectionHandles(ctx, stroke, Theme) {
+    if (!stroke || !stroke.points || stroke.points.length === 0) return;
+
+    const hs = Constants.selectionHandleSize;
+    const hh = hs / 2;
+
+    if (stroke.tool === "rect" || stroke.tool === "ellipse" || stroke.tool === "redact" ||
+        stroke.tool === "pixelate" || stroke.tool === "spotlight") {
+        if (stroke.points.length < 2) return;
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[stroke.points.length - 1];
+        const x1 = Math.min(p0.x, p1.x);
+        const y1 = Math.min(p0.y, p1.y);
+        const x2 = Math.max(p0.x, p1.x);
+        const y2 = Math.max(p0.y, p1.y);
+        const cx = (x1 + x2) / 2;
+        const cy = (y1 + y2) / 2;
+
+        ctx.save();
+        ctx.strokeStyle = Theme.primary;
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 4]);
+        ctx.strokeRect(x1, y1, x2 - x1, y2 - y1);
+        ctx.restore();
+
+        ctx.fillStyle = "#ffffff";
+        ctx.strokeStyle = Theme.primary;
+        ctx.lineWidth = 1.5;
+        const handlePoints = [
+            {x: x1, y: y1}, {x: x2, y: y1}, {x: x1, y: y2}, {x: x2, y: y2},
+            {x: cx, y: y1}, {x: cx, y: y2}, {x: x1, y: cy}, {x: x2, y: cy}
+        ];
+        for (let p of handlePoints) {
+            ctx.fillRect(p.x - hh, p.y - hh, hs, hs);
+            ctx.strokeRect(p.x - hh, p.y - hh, hs, hs);
+        }
+        return;
+    }
+
+    if (stroke.tool === "line" || stroke.tool === "arrow") {
+        if (stroke.points.length < 2) return;
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[stroke.points.length - 1];
+
+        ctx.fillStyle = "#ffffff";
+        ctx.strokeStyle = Theme.primary;
+        ctx.lineWidth = 1.5;
+        ctx.fillRect(p0.x - hh, p0.y - hh, hs, hs);
+        ctx.strokeRect(p0.x - hh, p0.y - hh, hs, hs);
+        ctx.fillRect(p1.x - hh, p1.y - hh, hs, hs);
+        ctx.strokeRect(p1.x - hh, p1.y - hh, hs, hs);
+        return;
+    }
+}
+
+/**
  * Draws the selection (crop) overlay with dimming and handles.
  * @param {object} ctx - The Canvas 2D context.
  * @param {object} options - Selection options (cropRect, canvasWidth, canvasHeight, isCropMode)

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -646,6 +646,51 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
 }
 
 /**
+ * Checks if a point (mx, my) is hovering over a resize handle of the given stroke.
+ * Returns the handle identifier or "none".
+ * Shapes: tl, tr, bl, br, tc, bc, lc, rc
+ * Lines: start, end
+ */
+function getStrokeHandleAt(mx, my, stroke, estimateTextWidthFn) {
+    if (!stroke || !stroke.points || stroke.points.length === 0) return "none";
+    const threshold = Constants.selectionHandleSize + 4;
+
+    if (stroke.tool === "rect" || stroke.tool === "ellipse" || stroke.tool === "redact" ||
+        stroke.tool === "pixelate" || stroke.tool === "spotlight") {
+        if (stroke.points.length < 2) return "none";
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[stroke.points.length - 1];
+        const x1 = Math.min(p0.x, p1.x);
+        const y1 = Math.min(p0.y, p1.y);
+        const x2 = Math.max(p0.x, p1.x);
+        const y2 = Math.max(p0.y, p1.y);
+        const cx = (x1 + x2) / 2;
+        const cy = (y1 + y2) / 2;
+
+        if (Math.abs(mx - x1) <= threshold && Math.abs(my - y1) <= threshold) return "tl";
+        if (Math.abs(mx - x2) <= threshold && Math.abs(my - y1) <= threshold) return "tr";
+        if (Math.abs(mx - x1) <= threshold && Math.abs(my - y2) <= threshold) return "bl";
+        if (Math.abs(mx - x2) <= threshold && Math.abs(my - y2) <= threshold) return "br";
+        if (Math.abs(mx - cx) <= threshold && Math.abs(my - y1) <= threshold) return "tc";
+        if (Math.abs(mx - cx) <= threshold && Math.abs(my - y2) <= threshold) return "bc";
+        if (Math.abs(mx - x1) <= threshold && Math.abs(my - cy) <= threshold) return "lc";
+        if (Math.abs(mx - x2) <= threshold && Math.abs(my - cy) <= threshold) return "rc";
+        return "none";
+    }
+
+    if (stroke.tool === "line" || stroke.tool === "arrow") {
+        if (stroke.points.length < 2) return "none";
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[stroke.points.length - 1];
+        if (Math.abs(mx - p0.x) <= threshold && Math.abs(my - p0.y) <= threshold) return "start";
+        if (Math.abs(mx - p1.x) <= threshold && Math.abs(my - p1.y) <= threshold) return "end";
+        return "none";
+    }
+
+    return "none";
+}
+
+/**
  * Smooths a polyline using a multi-pass weighted moving average.
  * Each pass replaces every interior point with:
  *   0.25 * prev + 0.5 * current + 0.25 * next


### PR DESCRIPTION
## Summary
- Implements visual resizing handles for selected vector annotations in Select Mode
- Shapes (rect, ellipse, redact, pixelate, spotlight): 8-point handles (4 corners + 4 edges)
- Lines (line, arrow): 2-point handles (start + end)
- Handles: white fill, primary-color border, 8x8px
- Cursor changes on handle hover for each direction
- Selection persists after release — click empty space to deselect
- Middle-click to delete also clears selection ref

## Closes
Closes #135

## Summary by Sourcery

Add resize handles and improved selection behavior for vector annotations in select mode.

New Features:
- Display 8-point resize handles for rectangular shapes and 2-point handles for line and arrow strokes when selected.
- Enable direct resizing of shapes from corners and edges and lines from start/end points via drag handles.

Enhancements:
- Keep strokes selected after drag operations and allow deselection by clicking on empty space.
- Update cursors when hovering over selection handles, including move cursors for line endpoints.
- Ensure middle-click deletion also clears any active selection reference.
- Visually indicate selected shapes with a dashed primary-colored bounding box around resize handles.