### PR TITLE
feat(select): add resizing handles for highlighter, stamp, and callout

### DIFF
--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -122,7 +122,7 @@ MouseArea {
                             newPoints[newPoints.length - 1] = Qt.point(orig[orig.length - 1].x + dx, orig[orig.length - 1].y + dy);
                         }
                         window.selectedStroke.points = newPoints;
-                    } else if (tool === "callout" && window.activeHandle.indexOf("src_") === 0) {
+                    } else if (tool === "callout" && window.activeHandle && window.activeHandle.indexOf("src_") === 0 && orig.length === 4) {
                         const p0 = orig[0];
                         const p1 = orig[1];
                         let x1 = Math.min(p0.x, p1.x);
@@ -320,12 +320,12 @@ MouseArea {
 
     cursorShape: {
         const h = (window.activeHandle !== "none" && window.activeHandle !== "new") ? window.activeHandle : hoveredHandle;
-        const hs = h.length > 4 ? h.slice(-3) : h;
+        const hs = (h && h.length > 4) ? h.slice(-3) : h;
         if (h === "tl" || h === "br" || hs === "_tl" || hs === "_br") return Qt.SizeFDiagCursor;
         if (h === "tr" || h === "bl" || hs === "_tr" || hs === "_bl") return Qt.SizeBDiagCursor;
         if (h === "tc" || h === "bc" || hs === "_tc" || hs === "_bc") return Qt.SplitVCursor;
         if (h === "lc" || h === "rc" || hs === "_lc" || hs === "_rc") return Qt.SplitHCursor;
-        if (h === "start" || h === "end") return Qt.SizeAllCursor;
+        if (h === "start" || h === "end" || h === "stamp" || h === "anchor") return Qt.SizeAllCursor;
         if (window.currentTool === "colorpicker") {
             return Qt.CrossCursor;
         }

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -114,12 +114,57 @@ MouseArea {
                         if (tool === "redact") {
                             window.selectedStroke.cachedCleanColor = undefined;
                         }
-                    } else if (tool === "line" || tool === "arrow") {
+                    } else if (tool === "line" || tool === "arrow" || tool === "highlighter") {
                         const newPoints = [...window.selectedStroke.points];
                         if (window.activeHandle === "start") {
                             newPoints[0] = Qt.point(orig[0].x + dx, orig[0].y + dy);
                         } else if (window.activeHandle === "end") {
                             newPoints[newPoints.length - 1] = Qt.point(orig[orig.length - 1].x + dx, orig[orig.length - 1].y + dy);
+                        }
+                        window.selectedStroke.points = newPoints;
+                    } else if (tool === "callout" && window.activeHandle.indexOf("src_") === 0) {
+                        const p0 = orig[0];
+                        const p1 = orig[1];
+                        let x1 = Math.min(p0.x, p1.x);
+                        let y1 = Math.min(p0.y, p1.y);
+                        let x2 = Math.max(p0.x, p1.x);
+                        let y2 = Math.max(p0.y, p1.y);
+                        const minSize = 10;
+                        const h = window.activeHandle.slice(4);
+
+                        switch (h) {
+                            case "tl": x1 = Math.min(x1 + dx, x2 - minSize); y1 = Math.min(y1 + dy, y2 - minSize); break;
+                            case "tr": x2 = Math.max(x2 + dx, x1 + minSize); y1 = Math.min(y1 + dy, y2 - minSize); break;
+                            case "bl": x1 = Math.min(x1 + dx, x2 - minSize); y2 = Math.max(y2 + dy, y1 + minSize); break;
+                            case "br": x2 = Math.max(x2 + dx, x1 + minSize); y2 = Math.max(y2 + dy, y1 + minSize); break;
+                            case "tc": y1 = Math.min(y1 + dy, y2 - minSize); break;
+                            case "bc": y2 = Math.max(y2 + dy, y1 + minSize); break;
+                            case "lc": x1 = Math.min(x1 + dx, x2 - minSize); break;
+                            case "rc": x2 = Math.max(x2 + dx, x1 + minSize); break;
+                        }
+
+                        const wasFlippedX = p0.x > p1.x;
+                        const wasFlippedY = p0.y > p1.y;
+                        const newP0 = Qt.point(wasFlippedX ? x2 : x1, wasFlippedY ? y2 : y1);
+                        const newP1 = Qt.point(wasFlippedX ? x1 : x2, wasFlippedY ? y1 : y2);
+
+                        const newPoints = [...window.selectedStroke.points];
+                        newPoints[0] = newP0;
+                        newPoints[1] = newP1;
+
+                        const newSW = Math.abs(newP1.x - newP0.x);
+                        const newSH = Math.abs(newP1.y - newP0.y);
+                        const zoom = window.selectedStroke.width / 100.0;
+                        newPoints[3] = Qt.point(newPoints[2].x + newSW * zoom, newPoints[2].y + newSH * zoom);
+                        window.selectedStroke.points = newPoints;
+                    } else if (tool === "stamp") {
+                        const newPoints = [...window.selectedStroke.points];
+                        const hasLeader = window.selectedStroke.hasLeaderLine && window.selectedStroke.points.length >= 2;
+                        if (window.activeHandle === "anchor" && hasLeader) {
+                            newPoints[0] = Qt.point(orig[0].x + dx, orig[0].y + dy);
+                        } else if (window.activeHandle === "stamp") {
+                            const idx = hasLeader ? 1 : 0;
+                            newPoints[idx] = Qt.point(orig[idx].x + dx, orig[idx].y + dy);
                         }
                         window.selectedStroke.points = newPoints;
                     }
@@ -275,10 +320,11 @@ MouseArea {
 
     cursorShape: {
         const h = (window.activeHandle !== "none" && window.activeHandle !== "new") ? window.activeHandle : hoveredHandle;
-        if (h === "tl" || h === "br") return Qt.SizeFDiagCursor;
-        if (h === "tr" || h === "bl") return Qt.SizeBDiagCursor;
-        if (h === "tc" || h === "bc") return Qt.SplitVCursor;
-        if (h === "lc" || h === "rc") return Qt.SplitHCursor;
+        const hs = h.length > 4 ? h.slice(-3) : h;
+        if (h === "tl" || h === "br" || hs === "_tl" || hs === "_br") return Qt.SizeFDiagCursor;
+        if (h === "tr" || h === "bl" || hs === "_tr" || hs === "_bl") return Qt.SizeBDiagCursor;
+        if (h === "tc" || h === "bc" || hs === "_tc" || hs === "_bc") return Qt.SplitVCursor;
+        if (h === "lc" || h === "rc" || hs === "_lc" || hs === "_rc") return Qt.SplitHCursor;
         if (h === "start" || h === "end") return Qt.SizeAllCursor;
         if (window.currentTool === "colorpicker") {
             return Qt.CrossCursor;

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -622,7 +622,7 @@ function drawSelectionHandles(ctx, stroke, Theme) {
         return;
     }
 
-    if (stroke.tool === "line" || stroke.tool === "arrow") {
+    if (stroke.tool === "line" || stroke.tool === "arrow" || stroke.tool === "highlighter") {
         if (stroke.points.length < 2) return;
         const p0 = stroke.points[0];
         const p1 = stroke.points[stroke.points.length - 1];
@@ -634,6 +634,61 @@ function drawSelectionHandles(ctx, stroke, Theme) {
         ctx.strokeRect(p0.x - hh, p0.y - hh, hs, hs);
         ctx.fillRect(p1.x - hh, p1.y - hh, hs, hs);
         ctx.strokeRect(p1.x - hh, p1.y - hh, hs, hs);
+        return;
+    }
+
+    if (stroke.tool === "stamp") {
+        const hasLeader = stroke.hasLeaderLine && stroke.points.length >= 2;
+        const stampPt = hasLeader ? stroke.points[1] : stroke.points[0];
+
+        ctx.fillStyle = "#ffffff";
+        ctx.strokeStyle = Theme.primary;
+        ctx.lineWidth = 1.5;
+
+        if (hasLeader) {
+            const anchorPt = stroke.points[0];
+            ctx.fillRect(anchorPt.x - hh, anchorPt.y - hh, hs, hs);
+            ctx.strokeRect(anchorPt.x - hh, anchorPt.y - hh, hs, hs);
+        }
+
+        ctx.fillRect(stampPt.x - hh, stampPt.y - hh, hs, hs);
+        ctx.strokeRect(stampPt.x - hh, stampPt.y - hh, hs, hs);
+        return;
+    }
+
+    if (stroke.tool === "callout" && stroke.points.length === 4) {
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[1];
+        const x1 = Math.min(p0.x, p1.x);
+        const y1 = Math.min(p0.y, p1.y);
+        const x2 = Math.max(p0.x, p1.x);
+        const y2 = Math.max(p0.y, p1.y);
+        const cx = (x1 + x2) / 2;
+        const cy = (y1 + y2) / 2;
+        const sw = x2 - x1;
+        const sh = y2 - y1;
+        if (sw <= 0 || sh <= 0) return;
+
+        ctx.save();
+        ctx.strokeStyle = Theme.primary;
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 4]);
+        ctx.strokeRect(x1, y1, sw, sh);
+        ctx.restore();
+
+        ctx.fillStyle = "#ffffff";
+        ctx.strokeStyle = Theme.primary;
+        ctx.lineWidth = 1.5;
+        const handlePoints = [
+            {x: x1, y: y1}, {x: x2, y: y1},
+            {x: x1, y: y2}, {x: x2, y: y2},
+            {x: cx, y: y1}, {x: cx, y: y2},
+            {x: x1, y: cy}, {x: x2, y: cy}
+        ];
+        for (let p of handlePoints) {
+            ctx.fillRect(p.x - hh, p.y - hh, hs, hs);
+            ctx.strokeRect(p.x - hh, p.y - hh, hs, hs);
+        }
         return;
     }
 }

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -678,12 +678,47 @@ function getStrokeHandleAt(mx, my, stroke, estimateTextWidthFn) {
         return "none";
     }
 
-    if (stroke.tool === "line" || stroke.tool === "arrow") {
+    if (stroke.tool === "line" || stroke.tool === "arrow" || stroke.tool === "highlighter") {
         if (stroke.points.length < 2) return "none";
         const p0 = stroke.points[0];
         const p1 = stroke.points[stroke.points.length - 1];
         if (Math.abs(mx - p0.x) <= threshold && Math.abs(my - p0.y) <= threshold) return "start";
         if (Math.abs(mx - p1.x) <= threshold && Math.abs(my - p1.y) <= threshold) return "end";
+        return "none";
+    }
+
+    if (stroke.tool === "stamp") {
+        const hasLeader = stroke.hasLeaderLine && stroke.points.length >= 2;
+        const stampPt = hasLeader ? stroke.points[1] : stroke.points[0];
+        const stampRadius = stroke.width * Constants.stampRadiusMultiplier + Constants.stampSelectThresholdOffset;
+        const dx = mx - stampPt.x;
+        const dy = my - stampPt.y;
+        if (dx * dx + dy * dy <= stampRadius * stampRadius) return "stamp";
+        if (hasLeader) {
+            const anchorPt = stroke.points[0];
+            if (Math.abs(mx - anchorPt.x) <= threshold && Math.abs(my - anchorPt.y) <= threshold) return "anchor";
+        }
+        return "none";
+    }
+
+    if (stroke.tool === "callout" && stroke.points.length === 4) {
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[1];
+        const x1 = Math.min(p0.x, p1.x);
+        const y1 = Math.min(p0.y, p1.y);
+        const x2 = Math.max(p0.x, p1.x);
+        const y2 = Math.max(p0.y, p1.y);
+        const cx = (x1 + x2) / 2;
+        const cy = (y1 + y2) / 2;
+
+        if (Math.abs(mx - x1) <= threshold && Math.abs(my - y1) <= threshold) return "src_tl";
+        if (Math.abs(mx - x2) <= threshold && Math.abs(my - y1) <= threshold) return "src_tr";
+        if (Math.abs(mx - x1) <= threshold && Math.abs(my - y2) <= threshold) return "src_bl";
+        if (Math.abs(mx - x2) <= threshold && Math.abs(my - y2) <= threshold) return "src_br";
+        if (Math.abs(mx - cx) <= threshold && Math.abs(my - y1) <= threshold) return "src_tc";
+        if (Math.abs(mx - cx) <= threshold && Math.abs(my - y2) <= threshold) return "src_bc";
+        if (Math.abs(mx - x1) <= threshold && Math.abs(my - cy) <= threshold) return "src_lc";
+        if (Math.abs(mx - x2) <= threshold && Math.abs(my - cy) <= threshold) return "src_rc";
         return "none";
     }
 


### PR DESCRIPTION
## Summary
- **Highlighter**: 2-point endpoint handles (reuses line/arrow logic)
- **Stamp**: 1 handle at stamp circle (hits anywhere on circle radius), 2 handles if has leader line
- **Callout**: 8 handles for source rect — dest rect auto-proportions on resize
- **Text**: deferred to follow-up

## Related
Refs #156

## Summary by Sourcery

Add selection resizing handles and interaction logic for highlighter, stamp, and callout drawing tools.

New Features:
- Enable endpoint selection handles and drag-to-resize behavior for highlighter strokes using existing line/arrow mechanics.
- Add stamp selection handles for both the stamp circle and optional leader line anchor, supporting repositioning via drag.
- Introduce callout source-rectangle selection handles that allow resizing the source area while auto-adjusting the destination rectangle based on zoom.

Enhancements:
- Update cursor shapes to reflect the appropriate resize direction when hovering or dragging callout source handles, including prefixed handle identifiers.