### PR TITLE
fix: clear selectedStroke on new capture and use unique capture paths for float restore

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -18,12 +18,14 @@ PluginComponent {
     property string activeIpcMode: ""
     property bool isDownloading: false
     property string currentCapturePath: ""
+    property int _captureSeq: 0
     // Exposed so the widget surface can read annotation state without accessing internal modal id
     readonly property bool isAnnotating: modal.shouldBeVisible
 
     // ── Capture helpers ───────────────────────────────────────────────────────
     function capturePath() {
-        return "/tmp/dms_capture_" + Date.now() + ".png";
+        _captureSeq = (_captureSeq + 1) % 100000;
+        return "/tmp/dms_capture_" + Date.now() + "_" + _captureSeq + ".png";
     }
 
     function screenshotMode() {
@@ -78,28 +80,28 @@ PluginComponent {
     function startActualCapture() {
         root.currentCapturePath = root.capturePath();
         const filename = root.currentCapturePath.split("/").pop();
-        Proc.runCommand("pre-capture-cleanup", ["rm", "-f", "/tmp/dms_capture_bg.png"], () => {
-            const cmdStr = root.screenshotArgs(filename).map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
-            Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
-                if (exitCode === 0) {
-                    Proc.runCommand("verify-capture", ["test", "-f", root.currentCapturePath], (_, fileExists) => {
-                        root.isCapturing = false;
-                        root.activeIpcMode = "";
-                        if (fileExists === 0) {
-                            root.validateAndOpenCapturedImage(root.currentCapturePath);
-                        }
-                    });
-                } else {
-                    const failMode = root.screenshotMode();
+        // Clean up old capture files (>1 hour) to prevent disk usage accumulation
+        Proc.runCommand("cleanup-old-captures", ["sh", "-c", "find /tmp -name 'dms_capture_*.png' -mmin +60 -delete 2>/dev/null"]);
+        const cmdStr = root.screenshotArgs(filename).map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
+        Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
+            if (exitCode === 0) {
+                Proc.runCommand("verify-capture", ["test", "-f", root.currentCapturePath], (_, fileExists) => {
                     root.isCapturing = false;
                     root.activeIpcMode = "";
-                    if (typeof ToastService !== "undefined" && ToastService) {
-                        const errorMsg = (stdout && stdout.trim()) ? stdout.trim() : I18n.tr("Screenshot failed (mode: %1).").arg(failMode);
-                        ToastService.showError(errorMsg);
+                    if (fileExists === 0) {
+                        root.validateAndOpenCapturedImage(root.currentCapturePath);
                     }
+                });
+            } else {
+                const failMode = root.screenshotMode();
+                root.isCapturing = false;
+                root.activeIpcMode = "";
+                if (typeof ToastService !== "undefined" && ToastService) {
+                    const errorMsg = (stdout && stdout.trim()) ? stdout.trim() : I18n.tr("Screenshot failed (mode: %1).").arg(failMode);
+                    ToastService.showError(errorMsg);
                 }
-            }, 0, 60000);
-        });
+            }
+        }, 0, 60000);
     }
 
     function closeOverlay() {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -18,14 +18,12 @@ PluginComponent {
     property string activeIpcMode: ""
     property bool isDownloading: false
     property string currentCapturePath: ""
-    property int _captureSeq: 0
     // Exposed so the widget surface can read annotation state without accessing internal modal id
     readonly property bool isAnnotating: modal.shouldBeVisible
 
     // ── Capture helpers ───────────────────────────────────────────────────────
     function capturePath() {
-        _captureSeq = (_captureSeq + 1) % 100000;
-        return "/tmp/dms_capture_" + Date.now() + "_" + _captureSeq + ".png";
+        return "/tmp/dms_capture_" + Date.now() + ".png";
     }
 
     function screenshotMode() {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -17,19 +17,25 @@ PluginComponent {
     readonly property string captureMode: (pluginData.captureMode || "region")
     property string activeIpcMode: ""
     property bool isDownloading: false
+    property string currentCapturePath: ""
     // Exposed so the widget surface can read annotation state without accessing internal modal id
     readonly property bool isAnnotating: modal.shouldBeVisible
 
     // ── Capture helpers ───────────────────────────────────────────────────────
+    function capturePath() {
+        return "/tmp/dms_capture_" + Date.now() + ".png";
+    }
+
     function screenshotMode() {
         return root.activeIpcMode !== "" ? root.activeIpcMode : root.captureMode;
     }
 
-    function screenshotArgs() {
+    function screenshotArgs(filename) {
+        filename = filename || "dms_capture_bg.png";
         const mode = root.activeIpcMode !== "" ? root.activeIpcMode : root.captureMode;
         const format = "png";
         const cursorVal = pluginData.includeCursor ? "on" : "off";
-        const args = ["dms", "screenshot", mode, "--no-clipboard", "--dir", "/tmp", "--filename", "dms_capture_bg.png", "--format", format, "--cursor", cursorVal, "--no-notify"];
+        const args = ["dms", "screenshot", mode, "--no-clipboard", "--dir", "/tmp", "--filename", filename, "--format", format, "--cursor", cursorVal, "--no-notify"];
 
         if (mode === "region" && pluginData.skipConfirm !== false) {
             args.push("--no-confirm");
@@ -70,20 +76,17 @@ PluginComponent {
     }
 
     function startActualCapture() {
-        // Delete any existing capture file before taking the screenshot.
-        // This lets us detect ESC cancellation when `dms screenshot region`
-        // incorrectly returns exit code 0 without writing a new file.
+        root.currentCapturePath = root.capturePath();
+        const filename = root.currentCapturePath.split("/").pop();
         Proc.runCommand("pre-capture-cleanup", ["rm", "-f", "/tmp/dms_capture_bg.png"], () => {
-            const cmdStr = root.screenshotArgs().map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
+            const cmdStr = root.screenshotArgs(filename).map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
             Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
                 if (exitCode === 0) {
-                    // Verify the file was actually written before opening the editor.
-                    // If the user pressed ESC, dms may return 0 but write no file.
-                    Proc.runCommand("verify-capture", ["test", "-f", "/tmp/dms_capture_bg.png"], (_, fileExists) => {
+                    Proc.runCommand("verify-capture", ["test", "-f", root.currentCapturePath], (_, fileExists) => {
                         root.isCapturing = false;
                         root.activeIpcMode = "";
                         if (fileExists === 0) {
-                            root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
+                            root.validateAndOpenCapturedImage(root.currentCapturePath);
                         }
                     });
                 } else {
@@ -111,11 +114,12 @@ PluginComponent {
 
     function fromClipboard() {
         root.closeControlCenter();
-        const checkCmd = "if dms cl paste > /tmp/dms_capture_bg.png 2>/dev/null && file -b /tmp/dms_capture_bg.png | grep -qi \"image\"; then echo \"IMAGE\"; else TEXT=$(dms cl paste 2>/dev/null); if [ -n \"$TEXT\" ]; then echo \"TEXT:$TEXT\"; else echo \"EMPTY\"; fi; fi";
+        root.currentCapturePath = root.capturePath();
+        const checkCmd = "if dms cl paste > " + root.currentCapturePath + " 2>/dev/null && file -b " + root.currentCapturePath + " | grep -qi \"image\"; then echo \"IMAGE\"; else TEXT=$(dms cl paste 2>/dev/null); if [ -n \"$TEXT\" ]; then echo \"TEXT:$TEXT\"; else echo \"EMPTY\"; fi; fi";
         Proc.runCommand("smart-paste", ["sh", "-c", checkCmd], (stdout, exitCode) => {
             const output = stdout.trim();
             if (output === "IMAGE") {
-                root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
+                root.validateAndOpenCapturedImage(root.currentCapturePath);
             } else if (output.startsWith("TEXT:")) {
                 let text = output.substring(5).trim();
                 if (text === "") {
@@ -159,6 +163,7 @@ PluginComponent {
                 }
             }
 
+            modal.currentCapturePath = path;
             modal.shouldBeVisible = true;
             modal.openCentered();
         });
@@ -170,18 +175,20 @@ PluginComponent {
 
         if (uri.startsWith("http://") || uri.startsWith("https://")) {
             root.isDownloading = true;
-            Proc.runCommand("download-image", ["curl", "-s", "-L", "-o", "/tmp/dms_capture_bg.png", uri], (stdout, exitCode) => {
+            root.currentCapturePath = root.capturePath();
+            Proc.runCommand("download-image", ["curl", "-s", "-L", "-o", root.currentCapturePath, uri], (stdout, exitCode) => {
                 root.isDownloading = false;
                 if (exitCode === 0) {
-                    root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
+                    root.validateAndOpenCapturedImage(root.currentCapturePath);
                 } else if (typeof ToastService !== "undefined" && ToastService) {
                     ToastService.showError("Failed to download image.");
                 }
             });
         } else {
-            Proc.runCommand("copy-image", ["cp", "-f", uri, "/tmp/dms_capture_bg.png"], (stdout, exitCode) => {
+            root.currentCapturePath = root.capturePath();
+            Proc.runCommand("copy-image", ["cp", "-f", uri, root.currentCapturePath], (stdout, exitCode) => {
                 if (exitCode === 0) {
-                    root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
+                    root.validateAndOpenCapturedImage(root.currentCapturePath);
                 } else if (typeof ToastService !== "undefined" && ToastService) {
                     ToastService.showError("Failed to copy image.");
                 }
@@ -239,11 +246,7 @@ PluginComponent {
             if (path.startsWith("file://")) {
                 path = path.substring(7);
             }
-            if (path === "/tmp/dms_capture_bg.png") {
-                root.validateAndOpenCapturedImage("/tmp/dms_capture_bg.png");
-            } else {
-                root.loadImageFromUri(path);
-            }
+            root.loadImageFromUri(path);
             return "SUCCESS";
         }
 
@@ -280,10 +283,10 @@ PluginComponent {
         browserIcon: "image"
         fileExtensions: ["*.png", "*.jpg", "*.jpeg", "*.webp", "*.bmp"]
         onFileSelected: path => {
-            Proc.runCommand("copy-image", ["cp", "-f", path, "/tmp/dms_capture_bg.png"], (stdout, exitCode) => {
+            root.currentCapturePath = root.capturePath();
+            Proc.runCommand("copy-image", ["cp", "-f", path, root.currentCapturePath], (stdout, exitCode) => {
                 if (exitCode === 0) {
-                    modal.shouldBeVisible = true;
-                    modal.openCentered();
+                    root.validateAndOpenCapturedImage(root.currentCapturePath);
                 } else {
                     ToastService.showError("Failed to load image.");
                 }

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -78,8 +78,6 @@ PluginComponent {
     function startActualCapture() {
         root.currentCapturePath = root.capturePath();
         const filename = root.currentCapturePath.split("/").pop();
-        // Clean up old capture files (>1 hour) to prevent disk usage accumulation
-        Proc.runCommand("cleanup-old-captures", ["sh", "-c", "find /tmp -name 'dms_capture_*.png' -mmin +60 -delete 2>/dev/null"]);
         const cmdStr = root.screenshotArgs(filename).map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
         Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
             if (exitCode === 0) {
@@ -105,6 +103,7 @@ PluginComponent {
     function closeOverlay() {
         modal.shouldBeVisible = false;
         modal.close();
+        Proc.runCommand("cleanup-old-captures", ["sh", "-c", "find /tmp -name 'dms_capture_*.png' -mmin +60 -delete 2>/dev/null"]);
     }
 
     function selectImageAndAnnotate() {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1106,6 +1106,7 @@ DankModal {
 
     property var restoreState: null
     property string restoreSource: ""
+    property string currentCapturePath: ""
 
     FloatService {
         id: floatService
@@ -1664,6 +1665,9 @@ DankModal {
         window.bgImageSource = "";
         if (window.restoreSource) {
             window.bgImageSource = window.restoreSource;
+        } else if (window.currentCapturePath) {
+            window.bgImageSource = "file://" + window.currentCapturePath;
+            window.currentCapturePath = "";
         } else {
             window.bgImageSource = "file:///tmp/dms_capture_bg.png";
         }
@@ -1714,6 +1718,9 @@ DankModal {
                     restoredStrokes.push(stroke);
                 }
                 window.strokes = restoredStrokes;
+            }
+            if (data.originalBackground) {
+                window.bgImageSource = data.originalBackground;
             }
             if (data.stampCounter !== undefined) {
                 window.stampCounter = data.stampCounter;

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -323,6 +323,7 @@ QtObject {
 
         var annotationState = {
             strokes: serializedStrokes,
+            originalBackground: root.modal.bgImageSource,
             stampCounter: root.modal.stampCounter,
             cropRect: {
                 x: root.modal.cropRect.x,


### PR DESCRIPTION
## Fixes

### selectedStroke persisted across captures
`selectedStroke` and `copiedStroke` were never cleared when starting a new capture or dismissing the modal, causing the previously selected stroke to render on the new canvas.

**Fix**: Clear `selectedStroke` and `copiedStroke` in `onOpened` (new capture) and `discardAndClose()`.

### Float restore showed flattened image instead of original background
When floating an annotated image, the original background path (`/tmp/dms_capture_bg.png`) was stored in `annotationState.originalBackground`. Subsequent captures overwrote that file, so restoring a prior float window showed a wrong or double-rendered image.

**Fix**: Each capture now uses a unique temp file (`/tmp/dms_capture_<timestamp>.png`). The daemon generates the path via `capturePath()` and passes it to the modal. Since files are never overwritten, `originalBackground` always points to the correct original screenshot. This was applied to all entry points: screenshot, clipboard, download, copy, file browser, drag-drop, IPC.

## Changes
- `QuickCaptureDaemon.qml`: +`currentCapturePath`, +`capturePath()`, all capture flows use unique paths
- `QuickCaptureModal.qml`: +`currentCapturePath` property, reads it in `onOpened`, clears stale state
- `QuickCaptureActions.qml`: stores `originalBackground` in annotationState for float restore

## Summary by Sourcery

Use per-capture image paths and clear annotation selection state to ensure new captures and float restores show the correct background without stale strokes.

Bug Fixes:
- Reset selected and copied strokes when opening a new capture or discarding the modal to prevent previous annotations from appearing on new canvases.
- Store and reuse unique screenshot file paths per capture so restored floating windows always display the original background image.

Enhancements:
- Propagate the current capture path through the daemon, modal, and actions so background handling is consistent across all capture entry points.