### PR TITLE
feat(ipc): add float action support to quickCapture IPC commands

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -19,7 +19,6 @@ PluginComponent {
     property string activeIpcMode: ""
     property bool isDownloading: false
     property string currentCapturePath: ""
-    property string captureAction: "edit" // "edit" | "float"
     // Exposed so the widget surface can read annotation state without accessing internal modal id
     readonly property bool isAnnotating: modal.shouldBeVisible
 
@@ -52,7 +51,10 @@ PluginComponent {
     }
 
     function triggerCapture(mode) {
-        // Strictly validate mode against allowlist to prevent command injection
+        root.triggerCaptureWithAction(mode, "edit");
+    }
+
+    function triggerCaptureWithAction(mode, action) {
         const allowedModes = ["region", "window", "full", "output", ""];
         if (mode && !allowedModes.includes(mode)) {
             console.warn("Invalid screenshot mode rejected: " + mode);
@@ -60,6 +62,7 @@ PluginComponent {
         }
 
         root.activeIpcMode = mode || "";
+        captureDelayTimer.captureAction = action || "edit";
         root.startCaptureAfterDelay();
     }
 
@@ -78,6 +81,7 @@ PluginComponent {
     }
 
     function startActualCapture() {
+        const action = captureDelayTimer.captureAction || "edit";
         root.currentCapturePath = root.capturePath();
         const filename = root.currentCapturePath.split("/").pop();
         const cmdStr = root.screenshotArgs(filename).map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
@@ -87,16 +91,13 @@ PluginComponent {
                     root.isCapturing = false;
                     root.activeIpcMode = "";
                     if (fileExists === 0) {
-                        root.validateAndOpenCapturedImage(root.currentCapturePath);
-                    } else {
-                        root.captureAction = "edit";
+                        root.validateAndOpenCapturedImage(root.currentCapturePath, action);
                     }
                 });
             } else {
                 const failMode = root.screenshotMode();
                 root.isCapturing = false;
                 root.activeIpcMode = "";
-                root.captureAction = "edit";
                 if (typeof ToastService !== "undefined" && ToastService) {
                     const errorMsg = (stdout && stdout.trim()) ? stdout.trim() : I18n.tr("Screenshot failed (mode: %1).").arg(failMode);
                     ToastService.showError(errorMsg);
@@ -112,25 +113,34 @@ PluginComponent {
     }
 
     function selectImageAndAnnotate() {
+        root.selectImageAndAnnotateWithAction("edit");
+    }
+
+    function selectImageAndAnnotateWithAction(action) {
         root.closeControlCenter();
+        fileBrowserModal.captureAction = action || "edit";
         fileBrowserModal.open();
     }
 
     function fromClipboard() {
+        root.fromClipboardWithAction("edit");
+    }
+
+    function fromClipboardWithAction(action) {
         root.closeControlCenter();
         root.currentCapturePath = root.capturePath();
         const checkCmd = "if dms cl paste > " + root.currentCapturePath + " 2>/dev/null && file -b " + root.currentCapturePath + " | grep -qi \"image\"; then echo \"IMAGE\"; else TEXT=$(dms cl paste 2>/dev/null); if [ -n \"$TEXT\" ]; then echo \"TEXT:$TEXT\"; else echo \"EMPTY\"; fi; fi";
         Proc.runCommand("smart-paste", ["sh", "-c", checkCmd], (stdout, exitCode) => {
             const output = stdout.trim();
             if (output === "IMAGE") {
-                root.validateAndOpenCapturedImage(root.currentCapturePath);
+                root.validateAndOpenCapturedImage(root.currentCapturePath, action);
             } else if (output.startsWith("TEXT:")) {
                 let text = output.substring(5).trim();
                 if (text === "") {
                     if (typeof ToastService !== "undefined" && ToastService)
                         ToastService.showError("Clipboard text is not a valid URL or path.");
                 } else {
-                    root.loadImageFromUri(text);
+                    root.loadImageFromUriWithAction(text, action);
                 }
             } else {
                 if (typeof ToastService !== "undefined" && ToastService)
@@ -146,13 +156,10 @@ PluginComponent {
     }
 
     function openImageAsFloat(path) {
-        const action = root.captureAction;
-        root.captureAction = "edit";
-        if (action !== "float") return;
         floatServiceItem.spawnWindow("file://" + path, pluginData, null, [path]);
     }
 
-    function validateAndOpenCapturedImage(path) {
+    function validateAndOpenCapturedImage(path, action) {
         Proc.runCommand("validate-image", ["file", "-b", path], function(stdout, exitCode) {
             const output = stdout.toLowerCase();
             if (exitCode !== 0 || output.includes("empty") || !output.includes("image")) {
@@ -180,7 +187,7 @@ PluginComponent {
                 }
             }
 
-            if (root.captureAction === "float") {
+            if (action === "float") {
                 root.openImageAsFloat(path);
             } else {
                 root.openImageForEdit(path);
@@ -189,6 +196,10 @@ PluginComponent {
     }
 
     function loadImageFromUri(uri) {
+        root.loadImageFromUriWithAction(uri, "edit");
+    }
+
+    function loadImageFromUriWithAction(uri, action) {
         if (uri.startsWith("file://"))
             uri = uri.substring(7);
 
@@ -198,7 +209,7 @@ PluginComponent {
             Proc.runCommand("download-image", ["curl", "-s", "-L", "-o", root.currentCapturePath, uri], (stdout, exitCode) => {
                 root.isDownloading = false;
                 if (exitCode === 0) {
-                    root.validateAndOpenCapturedImage(root.currentCapturePath);
+                    root.validateAndOpenCapturedImage(root.currentCapturePath, action);
                 } else if (typeof ToastService !== "undefined" && ToastService) {
                     ToastService.showError("Failed to download image.");
                 }
@@ -207,7 +218,7 @@ PluginComponent {
             root.currentCapturePath = root.capturePath();
             Proc.runCommand("copy-image", ["cp", "-f", uri, root.currentCapturePath], (stdout, exitCode) => {
                 if (exitCode === 0) {
-                    root.validateAndOpenCapturedImage(root.currentCapturePath);
+                    root.validateAndOpenCapturedImage(root.currentCapturePath, action);
                 } else if (typeof ToastService !== "undefined" && ToastService) {
                     ToastService.showError("Failed to copy image.");
                 }
@@ -243,29 +254,25 @@ PluginComponent {
     // ── IPC handlers ─────────────────────────────────────────────────────────
     IpcHandler {
         function screenshot(mode: string, action: string) : string {
-            root.captureAction = action || "edit";
-            root.triggerCapture(mode === "default" ? "" : mode);
+            root.triggerCaptureWithAction(mode === "default" ? "" : mode, action || "edit");
             return "SUCCESS";
         }
 
         function selectFile(action: string) : string {
-            root.captureAction = action || "edit";
-            root.selectImageAndAnnotate();
+            root.selectImageAndAnnotateWithAction(action || "edit");
             return "SUCCESS";
         }
 
         function fromClipboard(action: string) : string {
-            root.captureAction = action || "edit";
-            root.fromClipboard();
+            root.fromClipboardWithAction(action || "edit");
             return "SUCCESS";
         }
 
         function openImage(path: string, action: string) : string {
-            root.captureAction = action || "edit";
             if (path.startsWith("file://")) {
                 path = path.substring(7);
             }
-            root.loadImageFromUri(path);
+            root.loadImageFromUriWithAction(path, action || "edit");
             return "SUCCESS";
         }
 
@@ -282,6 +289,7 @@ PluginComponent {
     // ── Capture delay timer ───────────────────────────────────────────────────
     Timer {
         id: captureDelayTimer
+        property string captureAction: "edit"
 
         interval: Math.max(50, Theme.popoutAnimationDuration + 50)
         repeat: false
@@ -304,14 +312,16 @@ PluginComponent {
     // ── File browser ──────────────────────────────────────────────────────────
     FileBrowserModal {
         id: fileBrowserModal
+        property string captureAction: "edit"
         browserTitle: I18n.tr("Select Image to Annotate")
         browserIcon: "image"
         fileExtensions: ["*.png", "*.jpg", "*.jpeg", "*.webp", "*.bmp"]
         onFileSelected: path => {
+            const action = fileBrowserModal.captureAction;
             root.currentCapturePath = root.capturePath();
             Proc.runCommand("copy-image", ["cp", "-f", path, root.currentCapturePath], (stdout, exitCode) => {
                 if (exitCode === 0) {
-                    root.validateAndOpenCapturedImage(root.currentCapturePath);
+                    root.validateAndOpenCapturedImage(root.currentCapturePath, action);
                 } else {
                     ToastService.showError("Failed to load image.");
                 }

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -50,10 +50,6 @@ PluginComponent {
         return args;
     }
 
-    function triggerCapture(mode) {
-        root.triggerCaptureWithAction(mode, "edit");
-    }
-
     function triggerCaptureWithAction(mode, action) {
         const allowedModes = ["region", "window", "full", "output", ""];
         if (mode && !allowedModes.includes(mode)) {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -1,4 +1,5 @@
 import "./dms-common"
+import "./components"
 import QtQuick
 import QtQuick.Controls
 import Quickshell
@@ -18,6 +19,7 @@ PluginComponent {
     property string activeIpcMode: ""
     property bool isDownloading: false
     property string currentCapturePath: ""
+    property string captureAction: "edit" // "edit" | "float"
     // Exposed so the widget surface can read annotation state without accessing internal modal id
     readonly property bool isAnnotating: modal.shouldBeVisible
 
@@ -86,12 +88,15 @@ PluginComponent {
                     root.activeIpcMode = "";
                     if (fileExists === 0) {
                         root.validateAndOpenCapturedImage(root.currentCapturePath);
+                    } else {
+                        root.captureAction = "edit";
                     }
                 });
             } else {
                 const failMode = root.screenshotMode();
                 root.isCapturing = false;
                 root.activeIpcMode = "";
+                root.captureAction = "edit";
                 if (typeof ToastService !== "undefined" && ToastService) {
                     const errorMsg = (stdout && stdout.trim()) ? stdout.trim() : I18n.tr("Screenshot failed (mode: %1).").arg(failMode);
                     ToastService.showError(errorMsg);
@@ -134,6 +139,19 @@ PluginComponent {
         });
     }
 
+    function openImageForEdit(path) {
+        modal.currentCapturePath = path;
+        modal.shouldBeVisible = true;
+        modal.openCentered();
+    }
+
+    function openImageAsFloat(path) {
+        const action = root.captureAction;
+        root.captureAction = "edit";
+        if (action !== "float") return;
+        floatServiceItem.spawnWindow("file://" + path, pluginData, null, [path]);
+    }
+
     function validateAndOpenCapturedImage(path) {
         Proc.runCommand("validate-image", ["file", "-b", path], function(stdout, exitCode) {
             const output = stdout.toLowerCase();
@@ -162,9 +180,11 @@ PluginComponent {
                 }
             }
 
-            modal.currentCapturePath = path;
-            modal.shouldBeVisible = true;
-            modal.openCentered();
+            if (root.captureAction === "float") {
+                root.openImageAsFloat(path);
+            } else {
+                root.openImageForEdit(path);
+            }
         });
     }
 
@@ -222,26 +242,26 @@ PluginComponent {
 
     // ── IPC handlers ─────────────────────────────────────────────────────────
     IpcHandler {
-        function screenshot(mode: string) : string {
-            if (mode === "default") {
-                root.triggerCapture("");
-            } else {
-                root.triggerCapture(mode);
-            }
+        function screenshot(mode: string, action: string) : string {
+            root.captureAction = action || "edit";
+            root.triggerCapture(mode === "default" ? "" : mode);
             return "SUCCESS";
         }
 
-        function selectFile() : string {
+        function selectFile(action: string) : string {
+            root.captureAction = action || "edit";
             root.selectImageAndAnnotate();
             return "SUCCESS";
         }
 
-        function fromClipboard() : string {
+        function fromClipboard(action: string) : string {
+            root.captureAction = action || "edit";
             root.fromClipboard();
             return "SUCCESS";
         }
 
-        function openImage(path: string) : string {
+        function openImage(path: string, action: string) : string {
+            root.captureAction = action || "edit";
             if (path.startsWith("file://")) {
                 path = path.substring(7);
             }
@@ -268,11 +288,17 @@ PluginComponent {
         onTriggered: root.startActualCapture()
     }
 
+    // ── Float service ─────────────────────────────────────────────────────────
+    FloatService {
+        id: floatServiceItem
+    }
+
     // ── Modal ─────────────────────────────────────────────────────────────────
     QuickCaptureModal {
         id: modal
 
         parentWidget: root
+        floatService: floatServiceItem
     }
 
     // ── File browser ──────────────────────────────────────────────────────────

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -108,18 +108,10 @@ PluginComponent {
         Proc.runCommand("cleanup-old-captures", ["sh", "-c", "find /tmp -name 'dms_capture_*.png' -mmin +60 -delete 2>/dev/null"]);
     }
 
-    function selectImageAndAnnotate() {
-        root.selectImageAndAnnotateWithAction("edit");
-    }
-
     function selectImageAndAnnotateWithAction(action) {
         root.closeControlCenter();
         fileBrowserModal.captureAction = action || "edit";
         fileBrowserModal.open();
-    }
-
-    function fromClipboard() {
-        root.fromClipboardWithAction("edit");
     }
 
     function fromClipboardWithAction(action) {
@@ -191,10 +183,6 @@ PluginComponent {
         });
     }
 
-    function loadImageFromUri(uri) {
-        root.loadImageFromUriWithAction(uri, "edit");
-    }
-
     function loadImageFromUriWithAction(uri, action) {
         if (uri.startsWith("file://"))
             uri = uri.substring(7);
@@ -240,7 +228,7 @@ PluginComponent {
             return;
         }
 
-        root.loadImageFromUri(urlStr);
+        root.loadImageFromUriWithAction(urlStr, "edit");
     }
 
     // ── Plugin identity ───────────────────────────────────────────────────────

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -254,17 +254,17 @@ PluginComponent {
     // ── IPC handlers ─────────────────────────────────────────────────────────
     IpcHandler {
         function screenshot(mode: string, action: string) : string {
-            root.triggerCaptureWithAction(mode === "default" ? "" : mode, action || "edit");
+            root.triggerCaptureWithAction(mode === "default" ? "" : mode, action);
             return "SUCCESS";
         }
 
         function selectFile(action: string) : string {
-            root.selectImageAndAnnotateWithAction(action || "edit");
+            root.selectImageAndAnnotateWithAction(action);
             return "SUCCESS";
         }
 
         function fromClipboard(action: string) : string {
-            root.fromClipboardWithAction(action || "edit");
+            root.fromClipboardWithAction(action);
             return "SUCCESS";
         }
 
@@ -272,7 +272,7 @@ PluginComponent {
             if (path.startsWith("file://")) {
                 path = path.substring(7);
             }
-            root.loadImageFromUriWithAction(path, action || "edit");
+            root.loadImageFromUriWithAction(path, action);
             return "SUCCESS";
         }
 

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1107,14 +1107,16 @@ DankModal {
     property var restoreState: null
     property string restoreSource: ""
     property string currentCapturePath: ""
+    property var floatService: null
 
-    FloatService {
-        id: floatService
-        onRestoreRequested: function(imageSource, annotationState) {
-            window.restoreSource = imageSource;
-            window.restoreState = annotationState;
-            window.shouldBeVisible = true;
-            window.openCentered();
+    onFloatServiceChanged: {
+        if (floatService) {
+            floatService.restoreRequested.connect(function(imageSource, annotationState) {
+                window.restoreSource = imageSource;
+                window.restoreState = annotationState;
+                window.shouldBeVisible = true;
+                window.openCentered();
+            });
         }
     }
 
@@ -1123,7 +1125,7 @@ DankModal {
         parentWidget: window.parentWidget
         modal: window
         exportAndExecute: window.exportAndExecute
-        floatService: floatService
+        floatService: window.floatService
         onCloseRequested: window.discardAndClose()
     }
 

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1109,14 +1109,13 @@ DankModal {
     property string currentCapturePath: ""
     property var floatService: null
 
-    onFloatServiceChanged: {
-        if (floatService) {
-            floatService.restoreRequested.connect(function(imageSource, annotationState) {
-                window.restoreSource = imageSource;
-                window.restoreState = annotationState;
-                window.shouldBeVisible = true;
-                window.openCentered();
-            });
+    Connections {
+        target: window.floatService
+        function onRestoreRequested(imageSource, annotationState) {
+            window.restoreSource = imageSource;
+            window.restoreState = annotationState;
+            window.shouldBeVisible = true;
+            window.openCentered();
         }
     }
 

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -116,7 +116,7 @@ PluginComponent {
         if (root.daemon) root.daemon.triggerCaptureWithAction("", "edit");
     }
     pillRightClickAction: function() {
-        if (root.daemon) root.daemon.fromClipboard();
+        if (root.daemon) root.daemon.fromClipboardWithAction("edit");
     }
 
     // ── Control Center integration ────────────────────────────────────────────

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -58,7 +58,7 @@ PluginComponent {
                 cursorShape: Qt.PointingHandCursor
                 onClicked: (mouse) => {
                     if (mouse.button === Qt.MiddleButton) {
-                        if (root.daemon) root.daemon.triggerCapture("full");
+                        if (root.daemon) root.daemon.triggerCaptureWithAction("full", "edit");
                     }
                 }
             }
@@ -104,7 +104,7 @@ PluginComponent {
                 cursorShape: Qt.PointingHandCursor
                 onClicked: (mouse) => {
                     if (mouse.button === Qt.MiddleButton) {
-                        if (root.daemon) root.daemon.triggerCapture("full");
+                        if (root.daemon) root.daemon.triggerCaptureWithAction("full", "edit");
                     }
                 }
             }
@@ -113,7 +113,7 @@ PluginComponent {
 
     // ── Bar Pill interactions ─────────────────────────────────────────────────
     pillClickAction: function() {
-        if (root.daemon) root.daemon.triggerCapture();
+        if (root.daemon) root.daemon.triggerCaptureWithAction("", "edit");
     }
     pillRightClickAction: function() {
         if (root.daemon) root.daemon.fromClipboard();
@@ -125,6 +125,6 @@ PluginComponent {
     ccWidgetSecondaryText: root.isActive ? (daemon.isCapturing ? "Capturing..." : "Annotating") : "Ready"
     ccWidgetIsActive: root.isActive
     onCcWidgetToggled: {
-        if (root.daemon) root.daemon.triggerCapture();
+        if (root.daemon) root.daemon.triggerCaptureWithAction("", "edit");
     }
 }

--- a/docs/ipc-and-settings.md
+++ b/docs/ipc-and-settings.md
@@ -14,28 +14,37 @@ dms ipc call quickCapture <command> [arg]
 
 ### Supported Commands
 
-| Command | Argument | Description |
+All commands accept an `action` parameter (`edit` / `float`) — use `float` to spawn an always-on-top window instead of the editor.
+
+| Command | Arguments | Description |
 | :--- | :--- | :--- |
-| `screenshot` | `default`, `region`, `full`, `all`, `output`, `window`, `last` | Triggers a screenshot capture using the specified mode. |
-| `selectFile` | *(none)* | Opens a file picker dialog to load an image for annotation. |
-| `fromClipboard` | *(none)* | Imports an image directly from the system clipboard. |
-| `openImage` | `absolute_file_path` | Opens a specific local image file in the annotator. |
-| `close` | *(none)* | Immediately closes the annotator interface. |
+| `screenshot` | `mode` (`default`, `region`, `full`, `all`, `output`, `window`, `last`) | Triggers a screenshot. |
+| `selectFile` | *(none)* | Opens file picker. |
+| `fromClipboard` | *(none)* | Imports image from clipboard. |
+| `openImage` | `path` | Opens a local image file. |
+| `close` | *(none)* | Closes the annotator. |
+
+```bash
+dms ipc call quickCapture screenshot region edit    # open editor
+dms ipc call quickCapture screenshot region float   # float directly
+```
 
 ### Integration Examples
 
 #### Hyprland Keybinds (`hyprland.conf`)
 ```ini
-bind = , Print, exec, dms ipc call quickCapture screenshot region
-bind = Shift, Print, exec, dms ipc call quickCapture screenshot full
-bind = Control, Print, exec, dms ipc call quickCapture fromClipboard
+bind = , Print, exec, dms ipc call quickCapture screenshot region edit
+bind = Shift, Print, exec, dms ipc call quickCapture screenshot full edit
+bind = Control, Print, exec, dms ipc call quickCapture fromClipboard edit
+# Float without editor:
+# bind = , Print, exec, dms ipc call quickCapture screenshot region float
 ```
 
 #### Niri Window Manager Config (`config.kdl`)
 ```kdl
 binds {
-    Print { spawn "dms" "ipc" "call" "quickCapture" "screenshot" "region"; }
-    Meta+Print { spawn "dms" "ipc" "call" "quickCapture" "screenshot" "window"; }
+    Print { spawn "dms" "ipc" "call" "quickCapture" "screenshot" "region" "edit"; }
+    Meta+Print { spawn "dms" "ipc" "call" "quickCapture" "screenshot" "window" "edit"; }
 }
 ```
 


### PR DESCRIPTION
## Summary
- IPC commands (`screenshot`, `selectFile`, `fromClipboard`, `openImage`) now accept an `action` parameter (`edit`|`float`)
- `action=float` spawns an always-on-top window instead of opening the annotation editor
- `FloatService` moved from `QuickCaptureModal` to `QuickCaptureDaemon` for shared access
- `captureAction` resets on capture failure to prevent stale state

## Usage
```bash
dms ipc call quickCapture screenshot region edit    # open editor (default)
dms ipc call quickCapture screenshot region float   # float directly
dms ipc call quickCapture selectFile float
dms ipc call quickCapture fromClipboard float
dms ipc call quickCapture openImage /path/img.png float
```

## Breaking Change
Old-style calls without `action` parameter no longer work. All callers must be updated to include `edit` or `float`.

## Summary by Sourcery

Add float action support to quickCapture IPC commands and centralize floating window handling in the daemon.

New Features:
- Allow quickCapture IPC commands to specify an action parameter to either open the editor or spawn a floating window.
- Support spawning an always-on-top floating window directly from screenshots, selected files, clipboard images, or explicit image paths via IPC.

Enhancements:
- Move FloatService from the quick capture modal into the daemon for shared reuse and to drive float-only flows.
- Reset the capture action to the default edit mode after failures or float completion to avoid stale state.
- Simplify and clarify IPC documentation for quickCapture commands and their arguments, including float usage examples.

Documentation:
- Document the new action parameter for quickCapture IPC commands and update integration examples to use explicit edit or float actions.