### PR TITLE
feat: unify bar pill click behavior with mode popup and float pin

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -84,13 +84,22 @@ PluginComponent {
         const cmdStr = root.screenshotArgs(filename).map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
         Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
             if (exitCode === 0) {
+                if (stdout && stdout.trim().toLowerCase().includes("error")) {
+                    root.isCapturing = false;
+                    root.activeIpcMode = "";
+                    if (typeof ToastService !== "undefined" && ToastService) {
+                        ToastService.showError(stdout.trim());
+                    }
+                    return;
+                }
                 Proc.runCommand("verify-capture", ["test", "-f", root.currentCapturePath], (_, fileExists) => {
                     root.isCapturing = false;
                     root.activeIpcMode = "";
                     if (fileExists === 0) {
                         root.validateAndOpenCapturedImage(root.currentCapturePath, action);
                     } else if (typeof ToastService !== "undefined" && ToastService) {
-                        ToastService.showError(I18n.tr("Screenshot failed: no image was saved."));
+                        const errMsg = (stdout && stdout.trim()) ? stdout.trim() : I18n.tr("Screenshot failed: no image was saved.");
+                        ToastService.showError(errMsg);
                     }
                 });
             } else {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -89,6 +89,8 @@ PluginComponent {
                     root.activeIpcMode = "";
                     if (fileExists === 0) {
                         root.validateAndOpenCapturedImage(root.currentCapturePath, action);
+                    } else if (typeof ToastService !== "undefined" && ToastService) {
+                        ToastService.showError(I18n.tr("Screenshot failed: no image was saved."));
                     }
                 });
             } else {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -89,8 +89,6 @@ PluginComponent {
                     root.activeIpcMode = "";
                     if (fileExists === 0) {
                         root.validateAndOpenCapturedImage(root.currentCapturePath, action);
-                    } else if (typeof ToastService !== "undefined" && ToastService) {
-                        ToastService.showError(I18n.tr("Screenshot failed: no image was saved."));
                     }
                 });
             } else {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -84,22 +84,13 @@ PluginComponent {
         const cmdStr = root.screenshotArgs(filename).map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
         Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
             if (exitCode === 0) {
-                if (stdout && stdout.trim().toLowerCase().includes("error")) {
-                    root.isCapturing = false;
-                    root.activeIpcMode = "";
-                    if (typeof ToastService !== "undefined" && ToastService) {
-                        ToastService.showError(stdout.trim());
-                    }
-                    return;
-                }
                 Proc.runCommand("verify-capture", ["test", "-f", root.currentCapturePath], (_, fileExists) => {
                     root.isCapturing = false;
                     root.activeIpcMode = "";
                     if (fileExists === 0) {
                         root.validateAndOpenCapturedImage(root.currentCapturePath, action);
                     } else if (typeof ToastService !== "undefined" && ToastService) {
-                        const errMsg = (stdout && stdout.trim()) ? stdout.trim() : I18n.tr("Screenshot failed: no image was saved.");
-                        ToastService.showError(errMsg);
+                        ToastService.showError(I18n.tr("Screenshot failed: no image was saved."));
                     }
                 });
             } else {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -52,7 +52,7 @@ PluginComponent {
 
     function triggerCaptureWithAction(mode, action) {
         const normalizedMode = mode === "default" ? "" : (mode || "");
-        const allowedModes = ["region", "window", "full", "output", ""];
+        const allowedModes = ["region", "window", "full", "output", "all", "last", ""];
         if (normalizedMode && !allowedModes.includes(normalizedMode)) {
             console.warn("Invalid screenshot mode rejected: " + mode);
             return;

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -16,6 +16,7 @@ PluginComponent {
     // ── State ────────────────────────────────────────────────────────────────
     property bool isCapturing: false
     readonly property string captureMode: (pluginData.captureMode || "region")
+    readonly property var allowedModes: ["region", "window", "full", "output", "all", "last", ""]
     property string activeIpcMode: ""
     property bool isDownloading: false
     property string currentCapturePath: ""
@@ -52,7 +53,7 @@ PluginComponent {
 
     function triggerCaptureWithAction(mode, action) {
         const normalizedMode = mode === "default" ? "" : (mode || "");
-        const allowedModes = ["region", "window", "full", "output", "all", "last", ""];
+        const allowedModes = root.allowedModes;
         if (normalizedMode && !allowedModes.includes(normalizedMode)) {
             console.warn("Invalid screenshot mode rejected: " + mode);
             return;

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -39,9 +39,9 @@ PluginComponent {
 
                 Repeater {
                     model: [
-                        { icon: "screenshot_region", text: I18n.tr("Region"), action: () => root.daemon.triggerCaptureWithAction("region", "edit"), isDefault: true },
-                        { icon: "fullscreen", text: I18n.tr("Full Screen"), action: () => root.daemon.triggerCaptureWithAction("full", "edit"), isDefault: false },
-                        { icon: "crop_square", text: I18n.tr("Active Window"), action: () => root.daemon.triggerCaptureWithAction("window", "edit"), isDefault: false },
+                        { icon: "screenshot_region", text: I18n.tr("Region"), modeKey: "region", isDefault: true },
+                        { icon: "fullscreen", text: I18n.tr("Full Screen"), modeKey: "full", isDefault: false },
+                        { icon: "crop_square", text: I18n.tr("Active Window"), modeKey: "window", isDefault: false },
                     ]
 
                     delegate: menuItemComp
@@ -62,9 +62,9 @@ PluginComponent {
 
                 Repeater {
                     model: [
-                        { icon: "grid_view", text: I18n.tr("All Outputs"), action: () => root.daemon.triggerCaptureWithAction("all", "edit") },
-                        { icon: "display_settings", text: I18n.tr("Specific Output"), action: () => root.daemon.triggerCaptureWithAction("output", "edit") },
-                        { icon: "restart_alt", text: I18n.tr("Last Region"), action: () => root.daemon.triggerCaptureWithAction("last", "edit") },
+                        { icon: "grid_view", text: I18n.tr("All Outputs"), modeKey: "all" },
+                        { icon: "display_settings", text: I18n.tr("Specific Output"), modeKey: "output" },
+                        { icon: "restart_alt", text: I18n.tr("Last Region"), modeKey: "last" },
                     ]
 
                     delegate: menuItemComp
@@ -85,8 +85,8 @@ PluginComponent {
 
                 Repeater {
                     model: [
-                        { icon: "content_paste", text: I18n.tr("From Clipboard"), action: () => root.daemon.fromClipboardWithAction("edit") },
-                        { icon: "folder_open", text: I18n.tr("From File"), action: () => root.daemon.selectImageAndAnnotateWithAction("edit") },
+                        { icon: "content_paste", text: I18n.tr("From Clipboard"), modeKey: "clipboard" },
+                        { icon: "folder_open", text: I18n.tr("From File"), modeKey: "selectFile" },
                     ]
 
                     delegate: menuItemComp
@@ -99,14 +99,19 @@ PluginComponent {
         id: menuItemComp
 
         Rectangle {
+            id: itemRect
             width: parent.width
             height: 36
-            color: mouseArea.containsMouse ? Theme.surfaceContainerHigh : "transparent"
+            color: itemMouse.containsMouse ? Theme.surfaceContainerHigh : "transparent"
             radius: Theme.cornerRadiusSmall
+
+            property bool floatMode: false
 
             Row {
                 anchors.left: parent.left
                 anchors.leftMargin: Theme.spacingM
+                anchors.right: parent.right
+                anchors.rightMargin: Theme.spacingS + 28
                 anchors.verticalCenter: parent.verticalCenter
                 spacing: Theme.spacingS
 
@@ -126,14 +131,46 @@ PluginComponent {
                 }
             }
 
+            DankIcon {
+                id: pinIcon
+                anchors.right: parent.right
+                anchors.rightMargin: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+                name: "push_pin"
+                size: 16
+                opacity: itemMouse.containsMouse || itemRect.floatMode ? 1 : 0
+                color: itemRect.floatMode ? Theme.primary : Theme.surfaceText
+                rotation: itemRect.floatMode ? 45 : 0
+                Behavior on opacity { NumberAnimation { duration: 100 } }
+                Behavior on rotation { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
+            }
+
             MouseArea {
-                id: mouseArea
+                id: itemMouse
                 anchors.fill: parent
+                anchors.rightMargin: 28
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onClicked: {
-                    modelData.action();
+                    const action = itemRect.floatMode ? "float" : "edit";
+                    const mk = modelData.modeKey;
+                    if (mk === "clipboard") root.daemon.fromClipboardWithAction(action);
+                    else if (mk === "selectFile") root.daemon.selectImageAndAnnotateWithAction(action);
+                    else root.daemon.triggerCaptureWithAction(mk, action);
                     root.closePopout();
+                }
+            }
+
+            MouseArea {
+                id: pinArea
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: 28
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    itemRect.floatMode = !itemRect.floatMode;
                 }
             }
         }

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -47,7 +47,18 @@ PluginComponent {
                     delegate: menuItemComp
                 }
 
-                MenuSeparator {}
+                Rectangle {
+                    width: parent.width - Theme.spacingL
+                    height: 6
+                    color: "transparent"
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    Rectangle {
+                        width: parent.width
+                        height: 1
+                        color: Theme.withAlpha(Theme.outline, 0.12)
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
 
                 Repeater {
                     model: [
@@ -59,7 +70,18 @@ PluginComponent {
                     delegate: menuItemComp
                 }
 
-                MenuSeparator {}
+                Rectangle {
+                    width: parent.width - Theme.spacingL
+                    height: 6
+                    color: "transparent"
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    Rectangle {
+                        width: parent.width
+                        height: 1
+                        color: Theme.withAlpha(Theme.outline, 0.12)
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
 
                 Repeater {
                     model: [
@@ -113,23 +135,6 @@ PluginComponent {
                     modelData.action();
                     root.closePopout();
                 }
-            }
-        }
-    }
-
-    Component {
-        id: menuSeparator
-
-        Rectangle {
-            width: parent.width - Theme.spacingL
-            height: 6
-            color: "transparent"
-
-            Rectangle {
-                width: parent.width
-                height: 1
-                color: Theme.withAlpha(Theme.outline, 0.12)
-                anchors.verticalCenter: parent.verticalCenter
             }
         }
     }

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -19,6 +19,121 @@ PluginComponent {
     pluginId: "quickCapture"
     pluginService: PluginService
 
+    // ── Popout (left-click menu) ──────────────────────────────────────────────
+    popoutWidth: 240
+    popoutHeight: 400
+
+    popoutContent: Component {
+        PopoutComponent {
+            width: root.popoutWidth
+            headerText: I18n.tr("Quick Capture")
+            detailsText: I18n.tr("Select capture mode")
+            showCloseButton: true
+            closePopout: () => root.closePopout()
+
+            Column {
+                width: parent.width
+                spacing: 2
+                topPadding: Theme.spacingS
+                bottomPadding: Theme.spacingS
+
+                Repeater {
+                    model: [
+                        { icon: "screenshot_region", text: I18n.tr("Capture Region"), action: () => root.daemon.triggerCaptureWithAction("region", "edit"), isDefault: true },
+                        { icon: "fullscreen", text: I18n.tr("Capture Full Screen"), action: () => root.daemon.triggerCaptureWithAction("full", "edit"), isDefault: false },
+                        { icon: "crop_square", text: I18n.tr("Capture Active Window"), action: () => root.daemon.triggerCaptureWithAction("window", "edit"), isDefault: false },
+                    ]
+
+                    delegate: menuItemComp
+                }
+
+                MenuSeparator {}
+
+                Repeater {
+                    model: [
+                        { icon: "grid_view", text: I18n.tr("Capture All Outputs"), action: () => root.daemon.triggerCaptureWithAction("all", "edit") },
+                        { icon: "display_settings", text: I18n.tr("Capture Specific Output"), action: () => root.daemon.triggerCaptureWithAction("output", "edit") },
+                        { icon: "restart_alt", text: I18n.tr("Capture Last Region"), action: () => root.daemon.triggerCaptureWithAction("last", "edit") },
+                    ]
+
+                    delegate: menuItemComp
+                }
+
+                MenuSeparator {}
+
+                Repeater {
+                    model: [
+                        { icon: "content_paste", text: I18n.tr("Import from Clipboard"), action: () => root.daemon.fromClipboardWithAction("edit") },
+                        { icon: "folder_open", text: I18n.tr("Import from File"), action: () => root.daemon.selectImageAndAnnotateWithAction("edit") },
+                    ]
+
+                    delegate: menuItemComp
+                }
+            }
+        }
+    }
+
+    Component {
+        id: menuItemComp
+
+        Rectangle {
+            width: parent.width
+            height: 36
+            color: mouseArea.containsMouse ? Theme.surfaceContainerHigh : "transparent"
+            radius: Theme.cornerRadiusSmall
+
+            Row {
+                anchors.left: parent.left
+                anchors.leftMargin: Theme.spacingM
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Theme.spacingS
+
+                DankIcon {
+                    name: modelData.icon
+                    size: 18
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: modelData.isDefault ? Theme.primary : Theme.surfaceText
+                }
+
+                StyledText {
+                    text: modelData.text
+                    font.pixelSize: Theme.fontSizeNormal
+                    font.bold: modelData.isDefault === true
+                    color: modelData.isDefault ? Theme.primary : Theme.surfaceText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            MouseArea {
+                id: mouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    modelData.action();
+                    root.closePopout();
+                }
+            }
+        }
+    }
+
+    Component {
+        id: MenuSeparator
+
+        Rectangle {
+            width: parent.width - Theme.spacingL
+            height: 6
+            color: "transparent"
+
+            Rectangle {
+                width: parent.width
+                height: 1
+                color: Theme.withAlpha(Theme.outline, 0.12)
+                anchors.verticalCenter: parent.verticalCenter
+            }
+        }
+    }
+
     // ── Horizontal bar pill ───────────────────────────────────────────────────
     horizontalBarPill: Component {
         Item {
@@ -58,7 +173,7 @@ PluginComponent {
                 cursorShape: Qt.PointingHandCursor
                 onClicked: (mouse) => {
                     if (mouse.button === Qt.MiddleButton) {
-                        if (root.daemon) root.daemon.triggerCaptureWithAction("full", "edit");
+                        if (root.daemon) root.daemon.triggerCaptureWithAction("default", "edit");
                     }
                 }
             }
@@ -104,7 +219,7 @@ PluginComponent {
                 cursorShape: Qt.PointingHandCursor
                 onClicked: (mouse) => {
                     if (mouse.button === Qt.MiddleButton) {
-                        if (root.daemon) root.daemon.triggerCaptureWithAction("full", "edit");
+                        if (root.daemon) root.daemon.triggerCaptureWithAction("default", "edit");
                     }
                 }
             }
@@ -113,7 +228,7 @@ PluginComponent {
 
     // ── Bar Pill interactions ─────────────────────────────────────────────────
     pillClickAction: function() {
-        if (root.daemon) root.daemon.triggerCaptureWithAction("default", "edit");
+        root.triggerPopout();
     }
     pillRightClickAction: function() {
         if (root.daemon) root.daemon.fromClipboardWithAction("edit");

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -232,9 +232,7 @@ PluginComponent {
     }
 
     // ── Bar Pill interactions ─────────────────────────────────────────────────
-    pillClickAction: function() {
-        root.triggerPopout();
-    }
+    // popout auto-opens on left click when pillClickAction is not set and popoutContent is defined
     pillRightClickAction: function() {
         if (root.daemon) root.daemon.fromClipboardWithAction("edit");
     }

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -118,7 +118,7 @@ PluginComponent {
     }
 
     Component {
-        id: MenuSeparator
+        id: menuSeparator
 
         Rectangle {
             width: parent.width - Theme.spacingL

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -39,9 +39,9 @@ PluginComponent {
 
                 Repeater {
                     model: [
-                        { icon: "screenshot_region", text: I18n.tr("Capture Region"), action: () => root.daemon.triggerCaptureWithAction("region", "edit"), isDefault: true },
-                        { icon: "fullscreen", text: I18n.tr("Capture Full Screen"), action: () => root.daemon.triggerCaptureWithAction("full", "edit"), isDefault: false },
-                        { icon: "crop_square", text: I18n.tr("Capture Active Window"), action: () => root.daemon.triggerCaptureWithAction("window", "edit"), isDefault: false },
+                        { icon: "screenshot_region", text: I18n.tr("Region"), action: () => root.daemon.triggerCaptureWithAction("region", "edit"), isDefault: true },
+                        { icon: "fullscreen", text: I18n.tr("Full Screen"), action: () => root.daemon.triggerCaptureWithAction("full", "edit"), isDefault: false },
+                        { icon: "crop_square", text: I18n.tr("Active Window"), action: () => root.daemon.triggerCaptureWithAction("window", "edit"), isDefault: false },
                     ]
 
                     delegate: menuItemComp
@@ -62,9 +62,9 @@ PluginComponent {
 
                 Repeater {
                     model: [
-                        { icon: "grid_view", text: I18n.tr("Capture All Outputs"), action: () => root.daemon.triggerCaptureWithAction("all", "edit") },
-                        { icon: "display_settings", text: I18n.tr("Capture Specific Output"), action: () => root.daemon.triggerCaptureWithAction("output", "edit") },
-                        { icon: "restart_alt", text: I18n.tr("Capture Last Region"), action: () => root.daemon.triggerCaptureWithAction("last", "edit") },
+                        { icon: "grid_view", text: I18n.tr("All Outputs"), action: () => root.daemon.triggerCaptureWithAction("all", "edit") },
+                        { icon: "display_settings", text: I18n.tr("Specific Output"), action: () => root.daemon.triggerCaptureWithAction("output", "edit") },
+                        { icon: "restart_alt", text: I18n.tr("Last Region"), action: () => root.daemon.triggerCaptureWithAction("last", "edit") },
                     ]
 
                     delegate: menuItemComp
@@ -85,8 +85,8 @@ PluginComponent {
 
                 Repeater {
                     model: [
-                        { icon: "content_paste", text: I18n.tr("Import from Clipboard"), action: () => root.daemon.fromClipboardWithAction("edit") },
-                        { icon: "folder_open", text: I18n.tr("Import from File"), action: () => root.daemon.selectImageAndAnnotateWithAction("edit") },
+                        { icon: "content_paste", text: I18n.tr("From Clipboard"), action: () => root.daemon.fromClipboardWithAction("edit") },
+                        { icon: "folder_open", text: I18n.tr("From File"), action: () => root.daemon.selectImageAndAnnotateWithAction("edit") },
                     ]
 
                     delegate: menuItemComp

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -106,6 +106,7 @@ PluginComponent {
             radius: Theme.cornerRadiusSmall
 
             function execMode(action) {
+                if (!root.daemon) return;
                 const mk = modelData.modeKey;
                 if (mk === "clipboard") root.daemon.fromClipboardWithAction(action);
                 else if (mk === "selectFile") root.daemon.selectImageAndAnnotateWithAction(action);

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -102,7 +102,7 @@ PluginComponent {
             id: itemRect
             width: parent.width
             height: 36
-            color: itemMouse.containsMouse ? Theme.surfaceContainerHigh : "transparent"
+            color: itemMouse.containsMouse || pinArea.containsMouse ? Theme.surfaceContainerHigh : "transparent"
             radius: Theme.cornerRadiusSmall
 
             property bool floatMode: false
@@ -138,7 +138,7 @@ PluginComponent {
                 anchors.verticalCenter: parent.verticalCenter
                 name: "push_pin"
                 size: 16
-                opacity: itemMouse.containsMouse || itemRect.floatMode ? 1 : 0
+                opacity: itemMouse.containsMouse || pinArea.containsMouse || itemRect.floatMode ? 1 : 0
                 color: itemRect.floatMode ? Theme.primary : Theme.surfaceText
                 rotation: itemRect.floatMode ? 45 : 0
                 Behavior on opacity { NumberAnimation { duration: 100 } }

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -105,7 +105,13 @@ PluginComponent {
             color: itemMouse.containsMouse || pinArea.containsMouse ? Theme.surfaceContainerHigh : "transparent"
             radius: Theme.cornerRadiusSmall
 
-            property bool floatMode: false
+            function execMode(action) {
+                const mk = modelData.modeKey;
+                if (mk === "clipboard") root.daemon.fromClipboardWithAction(action);
+                else if (mk === "selectFile") root.daemon.selectImageAndAnnotateWithAction(action);
+                else root.daemon.triggerCaptureWithAction(mk, action);
+                root.closePopout();
+            }
 
             Row {
                 anchors.left: parent.left
@@ -138,11 +144,9 @@ PluginComponent {
                 anchors.verticalCenter: parent.verticalCenter
                 name: "push_pin"
                 size: 16
-                opacity: itemMouse.containsMouse || pinArea.containsMouse || itemRect.floatMode ? 1 : 0
-                color: itemRect.floatMode ? Theme.primary : Theme.surfaceText
-                rotation: itemRect.floatMode ? 45 : 0
+                opacity: itemMouse.containsMouse || pinArea.containsMouse ? 1 : 0
+                color: pinArea.containsMouse ? Theme.primary : Theme.surfaceText
                 Behavior on opacity { NumberAnimation { duration: 100 } }
-                Behavior on rotation { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
             }
 
             MouseArea {
@@ -152,12 +156,7 @@ PluginComponent {
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onClicked: {
-                    const action = itemRect.floatMode ? "float" : "edit";
-                    const mk = modelData.modeKey;
-                    if (mk === "clipboard") root.daemon.fromClipboardWithAction(action);
-                    else if (mk === "selectFile") root.daemon.selectImageAndAnnotateWithAction(action);
-                    else root.daemon.triggerCaptureWithAction(mk, action);
-                    root.closePopout();
+                    execMode("edit");
                 }
             }
 
@@ -170,7 +169,7 @@ PluginComponent {
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onClicked: {
-                    itemRect.floatMode = !itemRect.floatMode;
+                    execMode("float");
                 }
             }
         }


### PR DESCRIPTION
Closes https://github.com/hthienloc/dms-quick-capture/issues/134

## Summary

- **Left click** → opens popup menu listing all capture modes instead of directly capturing
- **Right click** → unchanged (import from clipboard)
- **Middle click** → uses default capture mode from settings instead of hardcoded full screen
- **Control Center toggle** → unchanged (uses default mode)

### Popup Menu Design

Three groups separated by dividers:
1. **Region / Full Screen / Active Window** — primary modes, Region highlighted as default
2. **All Outputs / Specific Output / Last Region** — secondary capture modes
3. **From Clipboard / From File** — import actions

### Float Pin

Each menu item has a pin icon (`push_pin`) visible on hover. Clicking the pin executes the action directly as `float` (always-on-top window), while clicking the item body uses `edit` (opens editor).

### Bug Fixes

- Added missing `"all"` and `"last"` modes to allowed modes list in `triggerCaptureWithAction()` — previously these modes were silently rejected

## Summary by Sourcery

Introduce a popout quick-capture mode selector for the bar pill and align its click behavior with other capture entry points.

New Features:
- Add a left-click popout menu listing primary, secondary, and import capture modes with per-item icons and labeling.
- Allow pinning capture modes from the popout to trigger captures directly in floating (always-on-top) mode.

Bug Fixes:
- Ensure "all" and "last" capture modes are accepted by the capture daemon instead of being silently rejected.

Enhancements:
- Change middle-click on the bar pill to use the configured default capture mode instead of always full screen.
- Update bar pill behavior so left-click opens the popout when no explicit click handler is defined, maintaining right-click import from clipboard behavior.