### PR TITLE
feat: double-click text to edit in select mode

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -629,6 +629,7 @@ DankModal {
     property bool isTyping: false
     property point typingCoords: Qt.point(0,0)
     property string currentTypingText: ""
+    property var editingStroke: null
 
     // Helper to decode hex color to RGB
     function hexToRgb(hex) { return Helpers.hexToRgb(hex, Qt); }
@@ -1430,6 +1431,7 @@ DankModal {
 
     function handleTypingKey(event) {
         if (event.key === Qt.Key_Escape) {
+            window.editingStroke = null;
             window.isTyping = false;
             window.currentTypingText = "";
             if (window.activeCanvas) window.activeCanvas.requestPaint();
@@ -3055,7 +3057,37 @@ DankModal {
     function commitTypingText() {
         if (!window.isTyping) return;
         const textStr = window.currentTypingText.trim();
-        if (textStr.length > 0) {
+        if (window.editingStroke) {
+            if (textStr.length > 0) {
+                const s = window.editingStroke;
+                s.text = textStr;
+                s.color = window.currentColor.toString();
+                s.width = window.textFontSize;
+                s.isMonospace = window.textFontFamily === "monospace";
+                s.fontFamily = window.textFontFamily;
+                s.isBold = window.textBold;
+                s.isItalic = window.textItalic;
+                s.isUnderline = window.textUnderline;
+                s.hasBackground = window.textBackground;
+                s.cornerRadius = window.textCornerRadius;
+                s.points = [Qt.point(window.typingCoords.x, window.typingCoords.y)];
+                const idx = window.strokes.indexOf(s);
+                if (idx !== -1) {
+                    const list = [...window.strokes];
+                    list[idx] = s;
+                    window.strokes = list;
+                }
+                if (window.currentTool === "select") {
+                    window.selectedStroke = s;
+                }
+            } else {
+                const list = [...window.strokes];
+                const idx = list.indexOf(window.editingStroke);
+                if (idx !== -1) list.splice(idx, 1);
+                window.strokes = list;
+            }
+            window.editingStroke = null;
+        } else if (textStr.length > 0) {
             window.pushStroke({
                 tool: "text",
                 color: window.currentColor.toString(),

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -3070,7 +3070,7 @@ DankModal {
                 s.isUnderline = window.textUnderline;
                 s.hasBackground = window.textBackground;
                 s.cornerRadius = window.textCornerRadius;
-                s.points = [Qt.point(window.typingCoords.x, window.typingCoords.y)];
+                s.points = [window.typingCoords];
                 const idx = window.strokes.indexOf(s);
                 if (idx !== -1) {
                     const list = [...window.strokes];

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -638,7 +638,7 @@ MouseArea {
         const strokeIdx = window.findStrokeAt(absPt.x, absPt.y);
         if (strokeIdx === -1) return;
         const stroke = window.strokes[strokeIdx];
-        if (stroke.tool !== "text") return;
+        if (stroke.tool !== "text" || !stroke.points || stroke.points.length === 0) return;
 
         window.editingStroke = stroke;
         window.selectedStroke = null;

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -632,6 +632,31 @@ MouseArea {
          drawingCanvas.requestPaint();
     }
 
+    onDoubleClicked: (mouse) => {
+        if (window.currentTool !== "select") return;
+        const absPt = getAbsolutePoint(mouse.x, mouse.y);
+        const strokeIdx = window.findStrokeAt(absPt.x, absPt.y);
+        if (strokeIdx === -1) return;
+        const stroke = window.strokes[strokeIdx];
+        if (stroke.tool !== "text") return;
+
+        window.editingStroke = stroke;
+        window.selectedStroke = null;
+        window.typingCoords = Qt.point(stroke.points[0].x, stroke.points[0].y);
+        window.currentTypingText = stroke.text;
+        window.isTyping = true;
+        window.currentColor = stroke.color;
+        window.textFontSize = stroke.width;
+        window.textBold = stroke.isBold;
+        window.textItalic = stroke.isItalic;
+        window.textUnderline = stroke.isUnderline;
+        window.textBackground = stroke.hasBackground;
+        window.textCornerRadius = stroke.cornerRadius;
+        window.textFontFamily = stroke.fontFamily;
+        textInputDialog.open();
+        if (window.activeCanvas) window.activeCanvas.requestPaint();
+    }
+
     onReleased: (mouse) => {
         if (window.currentTool === "select") {
              window.activeHandle = "none";

--- a/components/TextInputDialog.qml
+++ b/components/TextInputDialog.qml
@@ -90,8 +90,8 @@ Popup {
                     Keys.onPressed: (event) => {
                         if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter) && !(event.modifiers & Qt.ShiftModifier)) {
                             window.currentTypingText = textInputField.text;
-                            textInputDialog.close();
                             window.commitTypingText();
+                            textInputDialog.close();
                             event.accepted = true;
                         }
                     }
@@ -109,8 +109,8 @@ Popup {
                     textColor: Theme.primaryText
                     onClicked: {
                         window.currentTypingText = textInputField.text;
-                        textInputDialog.close();
                         window.commitTypingText();
+                        textInputDialog.close();
                     }
                 }
 

--- a/components/TextInputDialog.qml
+++ b/components/TextInputDialog.qml
@@ -25,7 +25,7 @@ Popup {
 
     onOpened: {
         Qt.callLater(() => {
-            textInputField.text = "";
+            textInputField.text = window.currentTypingText;
             textInputField.forceActiveFocus();
         });
     }
@@ -34,6 +34,7 @@ Popup {
         if (window.isTyping) {
             window.isTyping = false;
             window.currentTypingText = "";
+            window.editingStroke = null;
             if (window.activeCanvas) window.activeCanvas.requestPaint();
             if (modalFocusScope) {
                 modalFocusScope.forceActiveFocus();


### PR DESCRIPTION
### Summary

Double-click an existing text stroke in select mode to edit its content via popup dialog, without switching away from the select tool.

### Changes

- **QuickCaptureModal.qml**: Added `editingStroke` property. Modified `commitTypingText()` to update the stroke in-place (or delete if empty) instead of creating a new one. Escape clears editing state. Re-selects the stroke after commit if still in select mode.

- **DrawMouseArea.qml**: Added `onDoubleClicked` handler — detects text stroke under cursor in select mode, pre-fills typing state, opens popup dialog.

- **TextInputDialog.qml**: Pre-fills text from `window.currentTypingText` when opened. Clears `editingStroke` on dismiss.

Closes #78 (text editing sub-feature)

## Summary by Sourcery

Enable in-place editing of existing text strokes from select mode via a double-click-initiated text dialog.

New Features:
- Allow double-clicking a text stroke in select mode to open a dialog for editing its content and styling in place.

Enhancements:
- Preserve and reapply text stroke selection after edits when remaining in select mode.
- Pre-fill the text input dialog with the current text stroke content and styling when editing.