### PR TITLE
feat: random pixelation mode for irreversible privacy

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -231,10 +231,13 @@ DankModal {
     // Intensity Management
     property int strokeWidth: 8
     property int pixelateIntensity: 8
-    property bool pixelateRandomize: false
+    property bool pixelateRandomize: true
     onPixelateRandomizeChanged: {
         if (selectedStroke && selectedStroke.tool === "pixelate") {
             selectedStroke.randomize = window.pixelateRandomize;
+            if (window.pixelateRandomize && selectedStroke.randomSeed === undefined) {
+                selectedStroke.randomSeed = Math.floor(Math.random() * 2147483647);
+            }
             const idx = window.strokes.indexOf(selectedStroke);
             if (idx !== -1) {
                 const list = [...window.strokes];

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -233,15 +233,15 @@ DankModal {
     property int pixelateIntensity: 8
     property bool pixelateRandomize: true
     onPixelateRandomizeChanged: {
-        if (selectedStroke && selectedStroke.tool === "pixelate") {
-            selectedStroke.randomize = window.pixelateRandomize;
-            if (window.pixelateRandomize && selectedStroke.randomSeed === undefined) {
-                selectedStroke.randomSeed = Math.floor(Math.random() * 2147483647);
+        if (window.selectedStroke && window.selectedStroke.tool === "pixelate") {
+            window.selectedStroke.randomize = window.pixelateRandomize;
+            if (window.pixelateRandomize && window.selectedStroke.randomSeed === undefined) {
+                window.selectedStroke.randomSeed = Math.floor(Math.random() * 2147483647);
             }
-            const idx = window.strokes.indexOf(selectedStroke);
+            const idx = window.strokes.indexOf(window.selectedStroke);
             if (idx !== -1) {
                 const list = [...window.strokes];
-                list[idx] = selectedStroke;
+                list[idx] = window.selectedStroke;
                 window.strokes = list;
             }
             if (window.activeCanvas) window.activeCanvas.requestPaint();

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -231,6 +231,19 @@ DankModal {
     // Intensity Management
     property int strokeWidth: 8
     property int pixelateIntensity: 8
+    property bool pixelateRandomize: false
+    onPixelateRandomizeChanged: {
+        if (selectedStroke && selectedStroke.tool === "pixelate") {
+            selectedStroke.randomize = window.pixelateRandomize;
+            const idx = window.strokes.indexOf(selectedStroke);
+            if (idx !== -1) {
+                const list = [...window.strokes];
+                list[idx] = selectedStroke;
+                window.strokes = list;
+            }
+            if (window.activeCanvas) window.activeCanvas.requestPaint();
+        }
+    }
     property int spotlightIntensity: 50
     property int textFontSize: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textFontSize !== undefined ? window.parentWidget.pluginData.textFontSize : 36
     property int calloutZoom: 150
@@ -2578,8 +2591,9 @@ DankModal {
                             lineOptionsToolbar: lineOptionsToolbar
                             arrowOptionsToolbar: arrowOptionsToolbar
                             redactOptionsToolbar: redactOptionsToolbar
-                            calloutOptionsToolbar: calloutOptionsToolbar
-                        }
+                             calloutOptionsToolbar: calloutOptionsToolbar
+                             pixelateOptionsToolbar: pixelateOptionsToolbar
+                         }
 
                         SizePreviewCard {
                             id: sizePreviewItem
@@ -2899,6 +2913,13 @@ DankModal {
                     toolbarPosition: window.toolbarPosition
                     currentLinkLines: window.calloutLinkLines
                     onLinkLinesSelected: (count) => window.calloutLinkLines = count
+                }
+
+                PixelateOptionsToolbar {
+                    id: pixelateOptionsToolbar
+                    toolbarPosition: window.toolbarPosition
+                    randomizeActive: window.pixelateRandomize
+                    onRandomizeToggled: window.pixelateRandomize = !window.pixelateRandomize
                 }
 
                 MoreToolsMenu {

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -490,6 +490,9 @@ MouseArea {
                 else if (stroke.tool === "pixelate") {
                     window.pixelateIntensity = stroke.width;
                     window.pixelateRandomize = stroke.randomize === true;
+                    if (window.pixelateRandomize && stroke.randomSeed === undefined) {
+                        stroke.randomSeed = Math.floor(Math.random() * 2147483647);
+                    }
                 }
                 else if (stroke.tool === "spotlight") window.spotlightIntensity = stroke.width;
                 else if (stroke.tool === "callout") window.calloutZoom = stroke.width;
@@ -635,7 +638,8 @@ MouseArea {
              arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled",
              redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid",
              calloutLinkLines: window.currentTool === "callout" ? window.calloutLinkLines : 1,
-             randomize: window.currentTool === "pixelate" ? window.pixelateRandomize : false
+             randomize: window.currentTool === "pixelate" ? window.pixelateRandomize : false,
+             randomSeed: window.currentTool === "pixelate" ? Math.floor(Math.random() * 2147483647) : 0
          };
          drawingCanvas.requestPaint();
     }

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -22,6 +22,7 @@ MouseArea {
     required property var arrowOptionsToolbar
     required property var redactOptionsToolbar
     required property var calloutOptionsToolbar
+    required property var pixelateOptionsToolbar
 
     property string activeHandle: "none"
     property string hoveredHandle: "none"
@@ -371,6 +372,9 @@ MouseArea {
                 } else if (window.currentTool === "callout") {
                     calloutOptionsToolbar.open(mapped.x, mapped.y);
                     return;
+                } else if (window.currentTool === "pixelate") {
+                    pixelateOptionsToolbar.open(mapped.x, mapped.y);
+                    return;
                 }
             }
             radialMenu.open(mapped.x, mapped.y);
@@ -483,7 +487,10 @@ MouseArea {
 
                 // Sync internal state with stroke's intensity
                 if (stroke.tool === "text") window.textFontSize = stroke.width;
-                else if (stroke.tool === "pixelate") window.pixelateIntensity = stroke.width;
+                else if (stroke.tool === "pixelate") {
+                    window.pixelateIntensity = stroke.width;
+                    window.pixelateRandomize = stroke.randomize === true;
+                }
                 else if (stroke.tool === "spotlight") window.spotlightIntensity = stroke.width;
                 else if (stroke.tool === "callout") window.calloutZoom = stroke.width;
                 else window.strokeWidth = stroke.width;
@@ -627,7 +634,8 @@ MouseArea {
              arrowLineStyle: window.currentTool === "arrow" ? window.activeArrowLineStyle : "solid",
              arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled",
              redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid",
-             calloutLinkLines: window.currentTool === "callout" ? window.calloutLinkLines : 1
+             calloutLinkLines: window.currentTool === "callout" ? window.calloutLinkLines : 1,
+             randomize: window.currentTool === "pixelate" ? window.pixelateRandomize : false
          };
          drawingCanvas.requestPaint();
     }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -310,8 +310,8 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                                 let h = (x * 374761393 + y * 668265263 + seed) >>> 0;
                                 h = Math.imul(h ^ (h >>> 13), 1274126177) >>> 0;
                                 h = (h ^ (h >>> 16)) >>> 0;
-                                sx = Math.min(x + (h % bw), imgW - 1);
-                                sy = Math.min(y + ((h >>> 8) % bh), imgH - 1);
+                                sx = Math.max(0, Math.min(x + (h % bw), imgW - 1));
+                                sy = Math.max(0, Math.min(y + ((h >>> 8) % bh), imgH - 1));
                             } else {
                                 sampleSize = Math.max(1, Math.round(blockSize / 5));
                                 sx = Math.min(x + Math.floor(bw / 2), rx + rw - 1);

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -296,7 +296,6 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
 
                 if (config.bgImageItem && config.bgImageItem.status === 1 /* Image.Ready */) {
                     const blockSize = Math.max(8, Math.min(36, stroke.width * 3));
-                    const sampleSize = Math.max(1, Math.round(blockSize / 5));
                     const imgW = config.bgImageItem.sourceSize.width;
                     const imgH = config.bgImageItem.sourceSize.height;
                     for (let y = ry; y < ry + rh; y += blockSize) {
@@ -304,10 +303,18 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                             const bw = Math.min(blockSize, rx + rw - x);
                             const bh = Math.min(blockSize, ry + rh - y);
                             if (bw <= 0 || bh <= 0) continue;
-                            let sx = Math.min(x + Math.floor(bw / 2), rx + rw - 1);
-                            let sy = Math.min(y + Math.floor(bh / 2), ry + rh - 1);
-                            sx = Math.max(0, Math.min(sx, Math.max(0, imgW - sampleSize)));
-                            sy = Math.max(0, Math.min(sy, Math.max(0, imgH - sampleSize)));
+                            let sx, sy, sampleSize;
+                            if (stroke.randomize) {
+                                sampleSize = 1;
+                                sx = Math.min(x + Math.floor(Math.random() * bw), imgW - 1);
+                                sy = Math.min(y + Math.floor(Math.random() * bh), imgH - 1);
+                            } else {
+                                sampleSize = Math.max(1, Math.round(blockSize / 5));
+                                sx = Math.min(x + Math.floor(bw / 2), rx + rw - 1);
+                                sy = Math.min(y + Math.floor(bh / 2), ry + rh - 1);
+                                sx = Math.max(0, Math.min(sx, Math.max(0, imgW - sampleSize)));
+                                sy = Math.max(0, Math.min(sy, Math.max(0, imgH - sampleSize)));
+                            }
                             ctx.drawImage(config.bgImageItem, sx, sy, sampleSize, sampleSize, x, y, bw, bh);
                         }
                     }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -306,8 +306,12 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                             let sx, sy, sampleSize;
                             if (stroke.randomize) {
                                 sampleSize = 1;
-                                sx = Math.min(x + Math.floor(Math.random() * bw), imgW - 1);
-                                sy = Math.min(y + Math.floor(Math.random() * bh), imgH - 1);
+                                const seed = stroke.randomSeed !== undefined ? stroke.randomSeed : 0;
+                                let h = (x * 374761393 + y * 668265263 + seed) >>> 0;
+                                h = Math.imul(h ^ (h >>> 13), 1274126177) >>> 0;
+                                h = (h ^ (h >>> 16)) >>> 0;
+                                sx = Math.min(x + (h % bw), imgW - 1);
+                                sy = Math.min(y + ((h >>> 8) % bh), imgH - 1);
                             } else {
                                 sampleSize = Math.max(1, Math.round(blockSize / 5));
                                 sx = Math.min(x + Math.floor(bw / 2), rx + rw - 1);

--- a/components/PixelateOptionsToolbar.qml
+++ b/components/PixelateOptionsToolbar.qml
@@ -88,7 +88,7 @@ Item {
 
                 DankIcon {
                     anchors.centerIn: parent
-                    name: "shuffle"
+                    name: "visibility_lock"
                     size: tc.subToolbarIconSize
                     color: root.randomizeActive ? Theme.primary : Theme.surfaceText
                 }

--- a/components/PixelateOptionsToolbar.qml
+++ b/components/PixelateOptionsToolbar.qml
@@ -1,0 +1,107 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+
+Item {
+    id: root
+    z: 2000
+    anchors.fill: parent
+
+    ToolbarConstants { id: tc }
+
+    property bool visibleState: false
+    visible: opacity > 0
+    opacity: 0
+
+    property real menuX: 0
+    property real menuY: 0
+
+    property bool randomizeActive: false
+    property string toolbarPosition: "top"
+
+    signal randomizeToggled()
+
+    states: [
+        State {
+            name: "visible"
+            when: root.visibleState
+            PropertyChanges { target: root; opacity: 1.0 }
+            PropertyChanges { target: menuContent; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { target: root; property: "opacity"; duration: 120; easing.type: Easing.OutQuad }
+            NumberAnimation { target: menuContent; property: "scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open(x, y) {
+        root.menuX = x;
+        root.menuY = y;
+        root.visibleState = true;
+    }
+
+    function close() {
+        root.visibleState = false;
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: (mouse) => {
+            root.close();
+            mouse.accepted = false;
+        }
+    }
+
+    Rectangle {
+        id: menuContent
+        width: contentRow.implicitWidth + Theme.spacingM * 2
+        height: tc.subToolbarHeight
+        x: Math.max(10, Math.min(root.width - width - 10, root.menuX - width / 2))
+        y: root.toolbarPosition === "bottom"
+            ? Math.max(10, Math.min(root.height - height - 10, root.menuY - height - 20))
+            : Math.max(10, Math.min(root.height - height - 10, root.menuY + 20))
+        scale: 0.95
+
+        color: Theme.surfaceContainer
+        border.color: Theme.withAlpha(Theme.outline, 0.15)
+        border.width: 1
+        radius: Theme.cornerRadius
+
+        Row {
+            id: contentRow
+            anchors.centerIn: parent
+            spacing: Theme.spacingS
+
+            Rectangle {
+                width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
+                radius: Theme.cornerRadius - 2
+                color: root.randomizeActive
+                    ? Theme.withAlpha(Theme.primary, 0.15)
+                    : (modeMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                border.color: root.randomizeActive ? Theme.primary : "transparent"
+                border.width: 1
+
+                DankIcon {
+                    anchors.centerIn: parent
+                    name: "shuffle"
+                    size: tc.subToolbarIconSize
+                    color: root.randomizeActive ? Theme.primary : Theme.surfaceText
+                }
+
+                MouseArea {
+                    id: modeMouse
+                    anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        root.randomizeToggled();
+                        root.close();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds privacy-first random pixelation mode for pixelate tool.

**Changes:**
- Random pixelation mode toggle (privacy mode) — samples 1 random pixel per block instead of averaging, making pixelation irreversible
- Deterministic seeded hash replaces `Math.random()` — ensures repaints don't shuffle pixels on unselected strokes
- `pixelateRandomize` defaults to `on` for privacy by default
- Icon: `visibility_lock` (eye with lock)
- New `PixelateOptionsToolbar.qml` — Shift+right-click on pixelate stroke to toggle

**Bug fix:** non-selected randomized pixelate strokes no longer change pixel pattern when scrolling intensity on another stroke.

## Summary by Sourcery

Add a privacy-focused random pixelation mode for the pixelate tool with a dedicated options toolbar and deterministic rendering behavior.

New Features:
- Introduce a random pixelation mode for the pixelate tool that samples a single random pixel per block for irreversible obfuscation.
- Add a Pixelate options toolbar with a visibility-lock toggle accessible via Shift+right-click on pixelate strokes.

Bug Fixes:
- Ensure randomized pixelate strokes retain a stable pixel pattern when adjusting intensity on other strokes.

Enhancements:
- Use a deterministic seeded randomization scheme for pixelate rendering so non-edited strokes do not visually change on repaint.
- Default pixelate strokes to randomize mode for stronger privacy guarantees.