### PR TITLE
Simplify screenshot validation using dms --json flag

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -35,7 +35,7 @@ PluginComponent {
     function screenshotArgs(filename) {
         const mode = root.activeIpcMode !== "" ? root.activeIpcMode : root.captureMode;
         const cursorVal = pluginData.includeCursor ? "on" : "off";
-        const args = ["dms", "screenshot", mode, "--no-clipboard", "--dir", "/tmp", "--filename", filename, "--format", "png", "--cursor", cursorVal, "--no-notify"];
+        const args = ["dms", "screenshot", mode, "--no-clipboard", "--dir", "/tmp", "--filename", filename, "--format", "png", "--cursor", cursorVal, "--no-notify", "--json"];
 
         if (mode === "region" && pluginData.skipConfirm !== false) {
             args.push("--no-confirm");
@@ -82,18 +82,18 @@ PluginComponent {
         const filename = root.currentCapturePath.split("/").pop();
         const cmdStr = root.screenshotArgs(filename).map(arg => "'" + arg.replace(/'/g, "'\\''") + "'").join(" ") + " 2>&1";
         Proc.runCommand("screenshot-trigger", ["sh", "-c", cmdStr], (stdout, exitCode) => {
-            if (exitCode === 0) {
-                Proc.runCommand("verify-capture", ["test", "-f", root.currentCapturePath], (_, fileExists) => {
-                    root.isCapturing = false;
-                    root.activeIpcMode = "";
-                    if (fileExists === 0) {
-                        root.validateAndOpenCapturedImage(root.currentCapturePath, action);
-                    }
-                });
-            } else {
+            root.isCapturing = false;
+            root.activeIpcMode = "";
+            try {
+                const meta = JSON.parse(stdout.trim());
+                if (meta.status === "success") {
+                    root.currentCapturePath = meta.path;
+                    root.validateAndOpenCapturedImage(meta.path, action, meta.width, meta.height);
+                } else {
+                    throw new Error(meta.message || meta.error || "Screenshot failed");
+                }
+            } catch (e) {
                 const failMode = root.screenshotMode();
-                root.isCapturing = false;
-                root.activeIpcMode = "";
                 if (typeof ToastService !== "undefined" && ToastService) {
                     const errorMsg = (stdout && stdout.trim()) ? stdout.trim() : I18n.tr("Screenshot failed (mode: %1).").arg(failMode);
                     ToastService.showError(errorMsg);
@@ -147,40 +147,22 @@ PluginComponent {
         floatServiceItem.spawnWindow("file://" + path, pluginData, null, [path]);
     }
 
-    function validateAndOpenCapturedImage(path, action) {
-        Proc.runCommand("validate-image", ["file", "-b", path], function(stdout, exitCode) {
-            const output = stdout.toLowerCase();
-            if (exitCode !== 0 || output.includes("empty") || !output.includes("image")) {
+    function validateAndOpenCapturedImage(path, action, width, height) {
+        if (width !== undefined && height !== undefined) {
+            const minSize = pluginData.minImageSize ?? 16;
+            if (width < minSize || height < minSize) {
                 if (typeof ToastService !== "undefined" && ToastService) {
-                    ToastService.showError("Invalid or corrupted image file.");
+                    ToastService.showError("Image is too small (" + width + "x" + height + "). Minimum: " + minSize + "px");
                 }
                 return;
             }
+        }
 
-            let w = 0, h = 0;
-            let re = /(\d+)\s*x\s*(\d+)/g;
-            let match;
-            while ((match = re.exec(stdout)) !== null) {
-                w = parseInt(match[1]);
-                h = parseInt(match[2]);
-            }
-
-            if (w > 0 && h > 0) {
-                const minSize = pluginData.minImageSize ?? 16;
-                if (w < minSize || h < minSize) {
-                    if (typeof ToastService !== "undefined" && ToastService) {
-                        ToastService.showError("Image is too small (" + w + "x" + h + "). Minimum: " + minSize + "px");
-                    }
-                    return;
-                }
-            }
-
-            if (action === "float") {
-                root.openImageAsFloat(path);
-            } else {
-                root.openImageForEdit(path);
-            }
-        });
+        if (action === "float") {
+            root.openImageAsFloat(path);
+        } else {
+            root.openImageForEdit(path);
+        }
     }
 
     function loadImageFromUriWithAction(uri, action) {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -89,8 +89,12 @@ PluginComponent {
                 if (meta.status === "success") {
                     root.currentCapturePath = meta.path;
                     root.validateAndOpenCapturedImage(meta.path, action, meta.width, meta.height);
-                } else {
-                    throw new Error(meta.message || meta.error || "Screenshot failed");
+                } else if (meta.status !== "aborted") {
+                    const failMode = root.screenshotMode();
+                    if (typeof ToastService !== "undefined" && ToastService) {
+                        const errorMsg = meta.message || meta.error || I18n.tr("Screenshot failed (mode: %1).").arg(failMode);
+                        ToastService.showError(errorMsg);
+                    }
                 }
             } catch (e) {
                 const failMode = root.screenshotMode();

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -85,7 +85,12 @@ PluginComponent {
             root.isCapturing = false;
             root.activeIpcMode = "";
             try {
-                const meta = JSON.parse(stdout.trim());
+                const trimmed = stdout.trim();
+                const startIdx = trimmed.indexOf("{");
+                const endIdx = trimmed.lastIndexOf("}");
+                const meta = startIdx !== -1 && endIdx > startIdx
+                    ? JSON.parse(trimmed.substring(startIdx, endIdx + 1))
+                    : JSON.parse(trimmed);
                 if (meta.status === "success") {
                     root.currentCapturePath = meta.path;
                     root.validateAndOpenCapturedImage(meta.path, action, meta.width, meta.height);
@@ -160,8 +165,22 @@ PluginComponent {
                 }
                 return;
             }
+            openAction(path, action);
+        } else {
+            Proc.runCommand("validate-image", ["file", "-b", path], function(stdout, exitCode) {
+                const output = stdout.toLowerCase();
+                if (exitCode !== 0 || output.includes("empty") || !output.includes("image")) {
+                    if (typeof ToastService !== "undefined" && ToastService) {
+                        ToastService.showError("Invalid or corrupted image file.");
+                    }
+                    return;
+                }
+                openAction(path, action);
+            });
         }
+    }
 
+    function openAction(path, action) {
         if (action === "float") {
             root.openImageAsFloat(path);
         } else {

--- a/plugin.json
+++ b/plugin.json
@@ -17,7 +17,7 @@
         "widget": "./QuickCaptureWidget.qml"
     },
     "settings": "./QuickCaptureSettings.qml",
-    "requires_dms": ">=1.5.0",
+    "requires_dms": ">=1.5.1",
     "requires": [],
     "permissions": [
         "settings_read",


### PR DESCRIPTION
Closes #165

Replace 3 sequential Proc.runCommand calls with a single dms screenshot ... --json call that returns structured metadata.

Changes:
- Add --json flag to screenshot args
- Parse JSON output for status, path, width, height
- Remove test -f and file -b validation calls
- validateAndOpenCapturedImage accepts width/height directly
- Silent abort: user pressing Esc shows no error toast
- Bump requires_dms to >=1.5.1

Benefits:
- 3 Proc calls to 1
- Remove file binary dependency
- Structured JSON replaces regex parsing

## Summary by Sourcery

Simplify screenshot capture validation by consuming structured JSON metadata from the dms screenshot command instead of doing separate file existence and image analysis checks.

New Features:
- Support JSON output from the dms screenshot command to obtain structured capture metadata including status, path, width, and height.

Bug Fixes:
- Avoid treating user-initiated screenshot aborts (e.g., pressing Esc) as errors that trigger failure toasts.

Enhancements:
- Reduce multiple process invocations for screenshot validation to a single dms call and drop the dependency on external file-type inspection.
- Update captured image validation to rely on provided width and height and enforce a minimum image size without shelling out to external tools.

Build:
- Bump the minimum required dms version to 1.5.1 in the plugin metadata.