### PR TITLE
refactor: inline trivial wrappers and remove dead code

### DIFF
--- a/CaptureConfig.qml
+++ b/CaptureConfig.qml
@@ -217,8 +217,6 @@ QtObject {
         { key: "R", color: accentColors[6] }
     ]
 
-    function findByKey(items, key) { return Helpers.findByKey(items, key); }
-
     function resolveColor(rawColor) {
         if (!rawColor) return Theme.primary;
         if (typeof rawColor !== "string") {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -113,12 +113,6 @@ PluginComponent {
         }, 0, 60000);
     }
 
-    function closeOverlay() {
-        modal.shouldBeVisible = false;
-        modal.close();
-        Proc.runCommand("cleanup-old-captures", ["sh", "-c", "find /tmp -name 'dms_capture_*.png' -mmin +60 -delete 2>/dev/null"]);
-    }
-
     function selectImageAndAnnotateWithAction(action) {
         root.closeControlCenter();
         fileBrowserModal.captureAction = action || "edit";

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -178,7 +178,7 @@ PluginComponent {
         } else {
             modal.currentCapturePath = path;
             modal.shouldBeVisible = true;
-            modal.openCentered();
+            modal.open();
         }
     }
 

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -647,9 +647,6 @@ DankModal {
     property string currentTypingText: ""
     property var editingStroke: null
 
-    // Helper to decode hex color to RGB
-    function hexToRgb(hex) { return Helpers.hexToRgb(hex, Qt); }
-
     backgroundOpacity: {
         const data = window.parentWidget && window.parentWidget.pluginData;
         if (!data) return 0.6;
@@ -1209,10 +1206,6 @@ DankModal {
         if (Math.abs(mx - x2) <= threshold && my >= y1 && my <= y2) return "rc";
 
         return "none";
-    }
-
-    function isInsideCropRect(mx, my) {
-        return Helpers.isInsideCropRect(mx, my, window.hasSelection, window.cropRect);
     }
 
     function clampCropRect(x, y, w, h) {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -695,10 +695,6 @@ DankModal {
         window.toolbarVisible = window.configShowToolbar;
     }
 
-    function openCentered() {
-        open();
-    }
-
     function rotateScreenshot() {
         const originalW = window.bgImageItem ? window.bgImageItem.sourceSize.width : 1;
         const originalH = window.bgImageItem ? window.bgImageItem.sourceSize.height : 1;
@@ -1179,7 +1175,7 @@ DankModal {
             window.restoreSource = imageSource;
             window.restoreState = annotationState;
             window.shouldBeVisible = true;
-            window.openCentered();
+            window.open();
         }
     }
 
@@ -1244,10 +1240,6 @@ DankModal {
         return config.resolveColor(val);
     }
 
-    function constrainSquarePoint(start, point) {
-        return Helpers.constrainSquarePoint(start, point, Qt);
-    }
-
     function estimateTextWidth(text, fontSize, isBold, isMonospace) {
         return Helpers.estimateTextWidth(text, fontSize, isBold, isMonospace);
     }
@@ -1279,8 +1271,6 @@ DankModal {
         }
         window.exportCanvasItem.requestPaint();
     }
-
-    function shortcutToken(key) { return Helpers.shortcutToken(key, Qt); }
 
     function formatHexColor(color) { return Helpers.formatHexColor(color); }
 
@@ -1441,10 +1431,6 @@ DankModal {
         return window.currentColor;
     }
 
-    function shortcutColor(color) {
-        return color === "primary" ? Theme.primary : color;
-    }
-
     function handleTypingKey(event) {
         if (event.key === Qt.Key_Escape) {
             window.editingStroke = null;
@@ -1479,7 +1465,7 @@ DankModal {
     }
 
     function handleShortcutKey(event) {
-        const token = window.shortcutToken(event.key);
+        const token = Helpers.shortcutToken(event.key, Qt);
         const hasCtrl = event.modifiers & Qt.ControlModifier;
 
         if (event.key === Qt.Key_Escape) {
@@ -1565,13 +1551,13 @@ DankModal {
         }
 
         if (hasCtrl) {
-            const colorShortcut = config.findByKey(config.colorShortcuts, token);
+            const colorShortcut = Helpers.findByKey(config.colorShortcuts, token);
             if (colorShortcut) {
                 let idx = config.colorShortcuts.indexOf(colorShortcut);
                 if (idx !== -1) {
                     window.activeColorSlotIndex = idx;
                 }
-                window.currentColor = window.shortcutColor(colorShortcut.color);
+                window.currentColor = colorShortcut.color === "primary" ? Theme.primary : colorShortcut.color;
                 event.accepted = true;
             }
             return;
@@ -1589,7 +1575,7 @@ DankModal {
             return;
         }
 
-        const toolShortcut = config.findByKey(config.toolShortcuts, token);
+        const toolShortcut = Helpers.findByKey(config.toolShortcuts, token);
         if (toolShortcut) {
             if (toolShortcut.tool === "colorpicker") {
                 if (!window.openColorPickerModal()) {

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -88,12 +88,6 @@ PluginComponent {
                     color: outputMouse.containsMouse ? Theme.surfaceContainerHigh : "transparent"
                     radius: Theme.cornerRadiusSmall
 
-                    function exec(action) {
-                        if (!root.daemon) return;
-                        root.outputExpanded = !root.outputExpanded;
-                        if (root.outputExpanded) root.refreshOutputList();
-                    }
-
                     // ── Tree root branch ────────────────────────
                     Rectangle {
                         x: Theme.spacingM + 8
@@ -122,7 +116,11 @@ PluginComponent {
                         id: outputMouse
                         anchors.fill: parent
                         hoverEnabled: true; cursorShape: Qt.PointingHandCursor
-                        onClicked: outputHeader.exec("edit")
+                        onClicked: {
+                            if (!root.daemon) return;
+                            root.outputExpanded = !root.outputExpanded;
+                            if (root.outputExpanded) root.refreshOutputList();
+                        }
                     }
                 }
 

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -279,7 +279,7 @@ MouseArea {
                      }
                  } else if ((mouse.modifiers & Qt.ShiftModifier) && (window.currentTool === "ellipse" || window.currentTool === "rect" || window.currentTool === "redact" || window.currentTool === "pixelate" || window.currentTool === "spotlight" || window.currentTool === "callout")) {
                      if (window.currentStroke.points[0]) {
-                         finalPt = window.constrainSquarePoint(window.currentStroke.points[0], absPt);
+                         finalPt = Helpers.constrainSquarePoint(window.currentStroke.points[0], absPt, Qt);
                      }
                  }
 

--- a/components/QuickCaptureActions.qml
+++ b/components/QuickCaptureActions.qml
@@ -117,10 +117,6 @@ QtObject {
         }
     }
 
-    function notifyInfo(message, imagePath) {
-        root.sendNotification(message, imagePath);
-    }
-
     function notifyWarning(message) {
         if (typeof ToastService !== "undefined" && ToastService) {
             ToastService.showWarning(message);
@@ -217,7 +213,7 @@ QtObject {
                     if (exitCode === 0) {
                         const notifyPath = targetPath.replace(/^~/, Quickshell.env("HOME"));
                         const iconPath = (notifyPath.toLowerCase().endsWith(".pdf") && originalPng) ? originalPng : notifyPath;
-                        notifyInfo(I18n.tr("Screenshot saved to %1/%2").arg(saveDir).arg(filename), iconPath);
+                        root.sendNotification(I18n.tr("Screenshot saved to %1/%2").arg(saveDir).arg(filename), iconPath);
                         root.closeRequested();
                     } else {
                         notifyError("Failed to save screenshot file.");
@@ -235,7 +231,7 @@ QtObject {
                 const clipSource = originalPng || finalPath;
                 copyFileToClipboard(clipSource, (stdout, exitCode) => {
                     if (exitCode === 0) {
-                        notifyInfo(I18n.tr("Screenshot copied to clipboard."), clipSource);
+                        root.sendNotification(I18n.tr("Screenshot copied to clipboard."), clipSource);
                         root.closeRequested();
                     } else {
                         notifyError("Failed to copy screenshot to clipboard.");
@@ -258,7 +254,7 @@ QtObject {
                             if (saveCode === 0) {
                                 const notifyPath = targetPath.replace(/^~/, Quickshell.env("HOME"));
                                 const iconPath = (notifyPath.toLowerCase().endsWith(".pdf") && originalPng) ? originalPng : notifyPath;
-                                notifyInfo(I18n.tr("Screenshot copied to clipboard and saved to %1").arg(saveDir), iconPath);
+                                root.sendNotification(I18n.tr("Screenshot copied to clipboard and saved to %1").arg(saveDir), iconPath);
                             } else {
                                 notifyWarning("Screenshot copied to clipboard but failed to save file.");
                             }


### PR DESCRIPTION
## Summary
- Inline 7 trivial wrapper functions (openCentered, shortcutColor, shortcutToken, constrainSquarePoint, notifyInfo, findByKey, outputHeader.exec)
- Keep 4 functions that provide meaningful abstraction (screenshotMode, getSelectedStrokeHandleAt, notifyWarning, performDoneAction)
- Remove 3 unused functions (hexToRgb, isInsideCropRect, closeOverlay)

6 files changed, 15 insertions(+), 50 deletions(-)

## Summary by Sourcery

Inline trivial helper wrappers and remove unused helper functions across QuickCapture components to simplify the codebase.

Enhancements:
- Use shared Helpers utilities directly for shortcut handling and geometry constraints instead of local wrapper functions.
- Simplify output header click handling by inlining expansion and refresh logic in the mouse click handler.
- Route informational screenshot notifications directly through the root notification API, reducing indirection.

Chores:
- Remove unused helper functions for hex color conversion, crop-rectangle checks, and overlay closing in QuickCapture QML files.