### PR TITLE
feat: add shape options for redact tool (rect, roundRect, ellipse, freehand)

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -80,6 +80,21 @@ DankModal {
         }
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
+    property string activeRedactShape: "rect" // rect, roundRect, ellipse, freehand
+    onActiveRedactShapeChanged: {
+        if (window.selectedStroke && window.selectedStroke.tool === "redact") {
+            window.selectedStroke.redactShape = window.activeRedactShape;
+            const idx = window.strokes.indexOf(window.selectedStroke);
+            if (idx !== -1) {
+                window.strokes[idx] = window.selectedStroke;
+                window.strokes = [...window.strokes];
+            }
+        }
+        if (window.currentStroke && window.currentStroke.tool === "redact") {
+            window.currentStroke.redactShape = window.activeRedactShape;
+        }
+        if (window.activeCanvas) window.activeCanvas.requestPaint();
+    }
     onActiveLineStyleChanged: {
         if (window.selectedStroke && window.selectedStroke.tool === "line") {
             window.selectedStroke.lineStyle = window.activeLineStyle;
@@ -149,6 +164,7 @@ DankModal {
             window.calloutZoom = window.preGrabCalloutZoom;
             window.currentColor = restoreColor;
             window.activeRedactMode = window.preGrabRedactMode;
+            window.activeRedactShape = window.preGrabRedactShape;
             window.calloutLinkLines = window.preGrabCalloutLinkLines;
             if (window.activeCanvas) window.activeCanvas.requestPaint();
         }
@@ -172,6 +188,7 @@ DankModal {
             window.preGrabCalloutZoom = window.calloutZoom;
             window.preGrabColor = window.currentColor;
             window.preGrabRedactMode = window.activeRedactMode;
+            window.preGrabRedactShape = window.activeRedactShape;
             window.preGrabCalloutLinkLines = window.calloutLinkLines;
             window.selectedStroke = s;
             window.currentColor = s.color;
@@ -186,6 +203,7 @@ DankModal {
                 if (s.arrowHeadStyle) window.activeArrowHeadStyle = s.arrowHeadStyle;
             }
             if (s.tool === "redact" && s.redactMode) window.activeRedactMode = s.redactMode;
+            if (s.tool === "redact" && s.redactShape) window.activeRedactShape = s.redactShape;
             if (s.tool === "callout") window.calloutLinkLines = s.calloutLinkLines !== undefined ? s.calloutLinkLines : 1;
             const reorder = [...window.strokes];
             const idx = reorder.indexOf(s);
@@ -637,6 +655,7 @@ DankModal {
     property int preGrabCalloutZoom: 150
     property color preGrabColor: Theme.primary
     property string preGrabRedactMode: "solid"
+    property string preGrabRedactShape: "rect"
     property int preGrabCalloutLinkLines: 1
     property point pressCoords: Qt.point(0, 0)
     property var originalPoints: []
@@ -1064,10 +1083,12 @@ DankModal {
             window.preGrabStrokeWidth = window.strokeWidth;
             window.preGrabColor = window.currentColor;
             window.preGrabRedactMode = window.activeRedactMode;
+            window.preGrabRedactShape = window.activeRedactShape;
             window.preGrabCalloutLinkLines = window.calloutLinkLines;
             window.strokeWidth = pasted.width;
             window.currentColor = pasted.color;
             if (pasted.tool === "redact" && pasted.redactMode) window.activeRedactMode = pasted.redactMode;
+            if (pasted.tool === "redact" && pasted.redactShape) window.activeRedactShape = pasted.redactShape;
             window.selectedStroke = pasted;
             window.pressCoords = absPt;
             window.originalPoints = newPoints;
@@ -2887,7 +2908,9 @@ DankModal {
                     id: redactOptionsToolbar
                     toolbarPosition: window.toolbarPosition
                     currentMode: window.activeRedactMode
+                    currentShape: window.activeRedactShape
                     onModeSelected: (mode) => window.activeRedactMode = mode
+                    onShapeSelected: (shape) => window.activeRedactShape = shape
                 }
 
                 CalloutOptionsToolbar {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -84,6 +84,10 @@ DankModal {
     onActiveRedactShapeChanged: {
         if (window.selectedStroke && window.selectedStroke.tool === "redact") {
             window.selectedStroke.redactShape = window.activeRedactShape;
+            window.selectedStroke.cachedCleanColor = undefined;
+            if (window.activeRedactShape === "freehand" && !window.selectedStroke.freehandPoints) {
+                window.selectedStroke.freehandPoints = [];
+            }
             const idx = window.strokes.indexOf(window.selectedStroke);
             if (idx !== -1) {
                 window.strokes[idx] = window.selectedStroke;
@@ -92,6 +96,9 @@ DankModal {
         }
         if (window.currentStroke && window.currentStroke.tool === "redact") {
             window.currentStroke.redactShape = window.activeRedactShape;
+            if (window.activeRedactShape === "freehand" && !window.currentStroke.freehandPoints) {
+                window.currentStroke.freehandPoints = [];
+            }
         }
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
@@ -1077,6 +1084,9 @@ DankModal {
             points: newPoints
         };
         StrokeProps.copyStrokeProperties(window.copiedStroke, pasted);
+        if (window.copiedStroke.freehandPoints) {
+            pasted.freehandPoints = window.copiedStroke.freehandPoints.map(p => Qt.point(p.x + dx, p.y + dy));
+        }
         window.pushStroke(pasted);
         
         if (window.currentTool === "select") {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -80,14 +80,11 @@ DankModal {
         }
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
-    property string activeRedactShape: "rect" // rect, roundRect, ellipse, freehand
+    property string activeRedactShape: "rect" // rect, roundRect, ellipse
     onActiveRedactShapeChanged: {
         if (window.selectedStroke && window.selectedStroke.tool === "redact") {
             window.selectedStroke.redactShape = window.activeRedactShape;
             window.selectedStroke.cachedCleanColor = undefined;
-            if (window.activeRedactShape === "freehand" && !window.selectedStroke.freehandPoints) {
-                window.selectedStroke.freehandPoints = [];
-            }
             const idx = window.strokes.indexOf(window.selectedStroke);
             if (idx !== -1) {
                 window.strokes[idx] = window.selectedStroke;
@@ -96,9 +93,6 @@ DankModal {
         }
         if (window.currentStroke && window.currentStroke.tool === "redact") {
             window.currentStroke.redactShape = window.activeRedactShape;
-            if (window.activeRedactShape === "freehand" && !window.currentStroke.freehandPoints) {
-                window.currentStroke.freehandPoints = [];
-            }
         }
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
@@ -1084,9 +1078,6 @@ DankModal {
             points: newPoints
         };
         StrokeProps.copyStrokeProperties(window.copiedStroke, pasted);
-        if (window.copiedStroke.freehandPoints) {
-            pasted.freehandPoints = window.copiedStroke.freehandPoints.map(p => Qt.point(p.x + dx, p.y + dy));
-        }
         window.pushStroke(pasted);
         
         if (window.currentTool === "select") {

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -260,6 +260,7 @@ MouseArea {
                     window.currentStroke.points.push(absPt);
                 }
               } else if (window.currentTool === "redact" && window.activeRedactShape === "freehand") {
+                 if (!window.currentStroke.freehandPoints) window.currentStroke.freehandPoints = [];
                  window.currentStroke.freehandPoints.push(absPt);
                  window.currentStroke.points = [window.currentStroke.points[0], absPt];
               } else if (window.currentTool === "redact") {

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -74,6 +74,13 @@ MouseArea {
                     }
                     if (window.selectedStroke.tool === "redact") {
                         window.selectedStroke.cachedCleanColor = undefined;
+                        if (window.selectedStroke.redactShape === "freehand" && window.selectedStroke.freehandPoints) {
+                            const shifted = [];
+                            for (let i = 0; i < window.selectedStroke.freehandPoints.length; i++) {
+                                shifted.push(Qt.point(window.selectedStroke.freehandPoints[i].x + dx, window.selectedStroke.freehandPoints[i].y + dy));
+                            }
+                            window.selectedStroke.freehandPoints = shifted;
+                        }
                     }
                 } else if (window.activeHandle !== "none" && window.originalPoints.length > 0) {
                     const dx = absPt.x - window.pressCoords.x;

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -259,8 +259,23 @@ MouseArea {
                 } else {
                     window.currentStroke.points.push(absPt);
                 }
-             } else if (window.currentTool === "rect" || window.currentTool === "ellipse" || window.currentTool === "arrow" || window.currentTool === "line"
-                      || window.currentTool === "redact" || window.currentTool === "pixelate" || window.currentTool === "highlighter" || window.currentTool === "spotlight" || window.currentTool === "callout") {
+              } else if (window.currentTool === "redact" && window.activeRedactShape === "freehand") {
+                 window.currentStroke.freehandPoints.push(absPt);
+                 window.currentStroke.points = [window.currentStroke.points[0], absPt];
+              } else if (window.currentTool === "redact") {
+                 let finalPt = absPt;
+                 if ((mouse.modifiers & Qt.ShiftModifier)) {
+                     if (window.currentStroke.points[0]) {
+                         finalPt = Helpers.constrainSquarePoint(window.currentStroke.points[0], absPt, Qt);
+                     }
+                 }
+                 if (window.currentStroke.points.length > 1) {
+                      window.currentStroke.points[window.currentStroke.points.length - 1] = finalPt;
+                  } else {
+                      window.currentStroke.points.push(finalPt);
+                  }
+              } else if (window.currentTool === "rect" || window.currentTool === "ellipse" || window.currentTool === "arrow" || window.currentTool === "line"
+                       || window.currentTool === "pixelate" || window.currentTool === "highlighter" || window.currentTool === "spotlight" || window.currentTool === "callout") {
                   
                  let finalPt = absPt;
                  if ((mouse.modifiers & Qt.ShiftModifier) && (window.currentTool === "line" || window.currentTool === "arrow" || window.currentTool === "highlighter")) {
@@ -396,6 +411,7 @@ MouseArea {
                     window.calloutZoom = window.preGrabCalloutZoom;
                     window.currentColor = window.preGrabColor;
                     window.activeRedactMode = window.preGrabRedactMode;
+                    window.activeRedactShape = window.preGrabRedactShape;
                     window.calloutLinkLines = window.preGrabCalloutLinkLines;
                     window.selectedStroke = null;
                 }
@@ -434,6 +450,7 @@ MouseArea {
                     window.calloutZoom = window.preGrabCalloutZoom;
                     window.currentColor = window.preGrabColor;
                     window.activeRedactMode = window.preGrabRedactMode;
+                    window.activeRedactShape = window.preGrabRedactShape;
                     window.calloutLinkLines = window.preGrabCalloutLinkLines;
                 }
                 window.originalPoints = [];
@@ -455,6 +472,7 @@ MouseArea {
                     window.preGrabCalloutZoom = window.calloutZoom;
                     window.preGrabColor = window.currentColor;
                     window.preGrabRedactMode = window.activeRedactMode;
+                    window.preGrabRedactShape = window.activeRedactShape;
                     window.preGrabCalloutLinkLines = window.calloutLinkLines;
                 }
                 
@@ -469,6 +487,9 @@ MouseArea {
                 }
                 if (stroke.tool === "redact" && stroke.redactMode) {
                     window.activeRedactMode = stroke.redactMode;
+                }
+                if (stroke.tool === "redact" && stroke.redactShape) {
+                    window.activeRedactShape = stroke.redactShape;
                 }
                 if (stroke.tool === "callout") {
                     window.calloutLinkLines = stroke.calloutLinkLines !== undefined ? stroke.calloutLinkLines : 1;
@@ -629,18 +650,20 @@ MouseArea {
         }
 
          window.currentStroke = {
-             tool: window.currentTool,
-             color: window.currentColor.toString(),
-             width: window.activeIntensity,
-             points: [getAbsolutePoint(mouse.x, mouse.y)],
-             lineStyle: window.currentTool === "line" ? window.activeLineStyle : "solid",
-             arrowLineStyle: window.currentTool === "arrow" ? window.activeArrowLineStyle : "solid",
-             arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled",
-             redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid",
-             calloutLinkLines: window.currentTool === "callout" ? window.calloutLinkLines : 1,
-             randomize: window.currentTool === "pixelate" ? window.pixelateRandomize : false,
-             randomSeed: window.currentTool === "pixelate" ? Math.floor(Math.random() * 2147483647) : 0
-         };
+              tool: window.currentTool,
+              color: window.currentColor.toString(),
+              width: window.activeIntensity,
+              points: [getAbsolutePoint(mouse.x, mouse.y)],
+              lineStyle: window.currentTool === "line" ? window.activeLineStyle : "solid",
+              arrowLineStyle: window.currentTool === "arrow" ? window.activeArrowLineStyle : "solid",
+              arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled",
+              redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid",
+              redactShape: window.currentTool === "redact" ? window.activeRedactShape : "rect",
+              freehandPoints: window.currentTool === "redact" && window.activeRedactShape === "freehand" ? [] : undefined,
+              calloutLinkLines: window.currentTool === "callout" ? window.calloutLinkLines : 1,
+              randomize: window.currentTool === "pixelate" ? window.pixelateRandomize : false,
+              randomSeed: window.currentTool === "pixelate" ? Math.floor(Math.random() * 2147483647) : 0
+          };
          drawingCanvas.requestPaint();
     }
 

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -74,13 +74,6 @@ MouseArea {
                     }
                     if (window.selectedStroke.tool === "redact") {
                         window.selectedStroke.cachedCleanColor = undefined;
-                        if (window.selectedStroke.redactShape === "freehand" && window.selectedStroke.freehandPoints) {
-                            const shifted = [];
-                            for (let i = 0; i < window.selectedStroke.freehandPoints.length; i++) {
-                                shifted.push(Qt.point(window.selectedStroke.freehandPoints[i].x + dx, window.selectedStroke.freehandPoints[i].y + dy));
-                            }
-                            window.selectedStroke.freehandPoints = shifted;
-                        }
                     }
                 } else if (window.activeHandle !== "none" && window.originalPoints.length > 0) {
                     const dx = absPt.x - window.pressCoords.x;
@@ -266,11 +259,7 @@ MouseArea {
                 } else {
                     window.currentStroke.points.push(absPt);
                 }
-              } else if (window.currentTool === "redact" && window.activeRedactShape === "freehand") {
-                 if (!window.currentStroke.freehandPoints) window.currentStroke.freehandPoints = [];
-                 window.currentStroke.freehandPoints.push(absPt);
-                 window.currentStroke.points = [window.currentStroke.points[0], absPt];
-              } else if (window.currentTool === "redact") {
+               } else if (window.currentTool === "redact") {
                  let finalPt = absPt;
                  if ((mouse.modifiers & Qt.ShiftModifier)) {
                      if (window.currentStroke.points[0]) {
@@ -667,7 +656,6 @@ MouseArea {
               arrowHeadStyle: window.currentTool === "arrow" ? window.activeArrowHeadStyle : "single-filled",
               redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid",
               redactShape: window.currentTool === "redact" ? window.activeRedactShape : "rect",
-              freehandPoints: window.currentTool === "redact" && window.activeRedactShape === "freehand" ? [] : undefined,
               calloutLinkLines: window.currentTool === "callout" ? window.calloutLinkLines : 1,
               randomize: window.currentTool === "pixelate" ? window.pixelateRandomize : false,
               randomSeed: window.currentTool === "pixelate" ? Math.floor(Math.random() * 2147483647) : 0

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -228,27 +228,50 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         const ry = Math.floor(Math.min(p0.y, p1.y));
         const rw = Math.floor(Math.abs(p1.x - p0.x));
         const rh = Math.floor(Math.abs(p1.y - p0.y));
-        
-        if (rw > 0 && rh > 0) {
-            const radius = config.roundRect ? Math.min(Theme.cornerRadius, Math.min(rw, rh) / 2) : 0;
-            const mode = stroke.redactMode || "solid";
+        const shape = stroke.redactShape || "rect";
+        const mode = stroke.redactMode || "solid";
 
+        const hasArea = shape === "freehand"
+            ? (stroke.freehandPoints && stroke.freehandPoints.length > 1)
+            : (rw > 0 && rh > 0);
+
+        if (hasArea) {
             ctx.save();
-            ctx.beginPath();
-            ctx.moveTo(rx + radius, ry);
-            ctx.lineTo(rx + rw - radius, ry);
-            ctx.arcTo(rx + rw, ry, rx + rw, ry + radius, radius);
-            ctx.lineTo(rx + rw, ry + rh - radius);
-            ctx.arcTo(rx + rw, ry + rh, rx + rw - radius, ry + rh, radius);
-            ctx.lineTo(rx + radius, ry + rh);
-            ctx.arcTo(rx, ry + rh, rx, ry + rh - radius, radius);
-            ctx.lineTo(rx, ry + radius);
-            ctx.arcTo(rx, ry, rx + radius, ry, radius);
-            ctx.closePath();
+
+            if (shape === "freehand" && stroke.freehandPoints) {
+                ctx.beginPath();
+                const pts = stroke.freehandPoints;
+                ctx.moveTo(pts[0].x, pts[0].y);
+                for (let i = 1; i < pts.length; i++) {
+                    ctx.lineTo(pts[i].x, pts[i].y);
+                }
+                ctx.closePath();
+            } else if (shape === "ellipse") {
+                ctx.beginPath();
+                ctx.translate(rx + rw / 2, ry + rh / 2);
+                ctx.scale(rw / 2, rh / 2);
+                ctx.arc(0, 0, 1, 0, 2 * Math.PI);
+                ctx.setTransform(1, 0, 0, 1, 0, 0);
+            } else if (shape === "roundRect") {
+                const radius = Math.min(Theme.cornerRadius, Math.min(rw, rh) / 2);
+                ctx.beginPath();
+                ctx.moveTo(rx + radius, ry);
+                ctx.lineTo(rx + rw - radius, ry);
+                ctx.arcTo(rx + rw, ry, rx + rw, ry + radius, radius);
+                ctx.lineTo(rx + rw, ry + rh - radius);
+                ctx.arcTo(rx + rw, ry + rh, rx + rw - radius, ry + rh, radius);
+                ctx.lineTo(rx + radius, ry + rh);
+                ctx.arcTo(rx, ry + rh, rx, ry + rh - radius, radius);
+                ctx.lineTo(rx, ry + radius);
+                ctx.arcTo(rx, ry, rx + radius, ry, radius);
+                ctx.closePath();
+            } else {
+                ctx.beginPath();
+                ctx.rect(rx, ry, rw, rh);
+            }
 
             if (mode === "clean" && config.offscreenSampler) {
                 if (stroke.isCurrent) {
-                    // Extremely cheap 1x1 pixel read for 60 FPS real-time preview dragging
                     try {
                         const octx = config.offscreenSampler.getContext("2d");
                         const imgData = octx.getImageData(rx, ry, 1, 1);
@@ -257,7 +280,6 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                         ctx.fillStyle = "rgba(128, 128, 128, 0.5)";
                     }
                 } else {
-                    // Compute accurate dominant color exactly once and cache it on the stroke!
                     if (!stroke.cachedCleanColor) {
                         stroke.cachedCleanColor = Helpers.getBoundaryColorOrGradient(ctx, rx, ry, rw, rh, config.offscreenSampler, Qt);
                     }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -626,12 +626,24 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn) {
     if (stroke.tool === "rect" || stroke.tool === "ellipse" || stroke.tool === "redact" ||
         stroke.tool === "pixelate" || stroke.tool === "spotlight") {
         if (stroke.points.length < 2) return;
-        const p0 = stroke.points[0];
-        const p1 = stroke.points[stroke.points.length - 1];
-        const x1 = Math.min(p0.x, p1.x);
-        const y1 = Math.min(p0.y, p1.y);
-        const x2 = Math.max(p0.x, p1.x);
-        const y2 = Math.max(p0.y, p1.y);
+        let x1, y1, x2, y2;
+        if (stroke.tool === "redact" && stroke.redactShape === "freehand" && stroke.freehandPoints && stroke.freehandPoints.length > 0) {
+            x1 = Infinity; x2 = -Infinity; y1 = Infinity; y2 = -Infinity;
+            for (let j = 0; j < stroke.freehandPoints.length; j++) {
+                const p = stroke.freehandPoints[j];
+                if (p.x < x1) x1 = p.x;
+                if (p.x > x2) x2 = p.x;
+                if (p.y < y1) y1 = p.y;
+                if (p.y > y2) y2 = p.y;
+            }
+        } else {
+            const p0 = stroke.points[0];
+            const p1 = stroke.points[stroke.points.length - 1];
+            x1 = Math.min(p0.x, p1.x);
+            y1 = Math.min(p0.y, p1.y);
+            x2 = Math.max(p0.x, p1.x);
+            y2 = Math.max(p0.y, p1.y);
+        }
         const cx = (x1 + x2) / 2;
         const cy = (y1 + y2) / 2;
 

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -247,11 +247,12 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 }
                 ctx.closePath();
             } else if (shape === "ellipse") {
-                ctx.beginPath();
+                ctx.save();
                 ctx.translate(rx + rw / 2, ry + rh / 2);
                 ctx.scale(rw / 2, rh / 2);
+                ctx.beginPath();
                 ctx.arc(0, 0, 1, 0, 2 * Math.PI);
-                ctx.setTransform(1, 0, 0, 1, 0, 0);
+                ctx.restore();
             } else if (shape === "roundRect") {
                 const radius = Math.min(Theme.cornerRadius, Math.min(rw, rh) / 2);
                 ctx.beginPath();

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -231,22 +231,10 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         const shape = stroke.redactShape || "rect";
         const mode = stroke.redactMode || "solid";
 
-        const hasArea = shape === "freehand"
-            ? (stroke.freehandPoints && stroke.freehandPoints.length > 1)
-            : (rw > 0 && rh > 0);
-
-        if (hasArea) {
+        if (rw > 0 && rh > 0) {
             ctx.save();
 
-            if (shape === "freehand" && stroke.freehandPoints) {
-                ctx.beginPath();
-                const pts = stroke.freehandPoints;
-                ctx.moveTo(pts[0].x, pts[0].y);
-                for (let i = 1; i < pts.length; i++) {
-                    ctx.lineTo(pts[i].x, pts[i].y);
-                }
-                ctx.closePath();
-            } else if (shape === "ellipse") {
+            if (shape === "ellipse") {
                 ctx.save();
                 ctx.translate(rx + rw / 2, ry + rh / 2);
                 ctx.scale(rw / 2, rh / 2);
@@ -626,24 +614,12 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn) {
     if (stroke.tool === "rect" || stroke.tool === "ellipse" || stroke.tool === "redact" ||
         stroke.tool === "pixelate" || stroke.tool === "spotlight") {
         if (stroke.points.length < 2) return;
-        let x1, y1, x2, y2;
-        if (stroke.tool === "redact" && stroke.redactShape === "freehand" && stroke.freehandPoints && stroke.freehandPoints.length > 0) {
-            x1 = Infinity; x2 = -Infinity; y1 = Infinity; y2 = -Infinity;
-            for (let j = 0; j < stroke.freehandPoints.length; j++) {
-                const p = stroke.freehandPoints[j];
-                if (p.x < x1) x1 = p.x;
-                if (p.x > x2) x2 = p.x;
-                if (p.y < y1) y1 = p.y;
-                if (p.y > y2) y2 = p.y;
-            }
-        } else {
-            const p0 = stroke.points[0];
-            const p1 = stroke.points[stroke.points.length - 1];
-            x1 = Math.min(p0.x, p1.x);
-            y1 = Math.min(p0.y, p1.y);
-            x2 = Math.max(p0.x, p1.x);
-            y2 = Math.max(p0.y, p1.y);
-        }
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[stroke.points.length - 1];
+        const x1 = Math.min(p0.x, p1.x);
+        const y1 = Math.min(p0.y, p1.y);
+        const x2 = Math.max(p0.x, p1.x);
+        const y2 = Math.max(p0.y, p1.y);
         const cx = (x1 + x2) / 2;
         const cy = (y1 + y2) / 2;
 

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -548,13 +548,25 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 if (dx <= threshold || dy <= threshold) return i;
             }
         } else if (stroke.tool === "redact") {
-            const p0 = stroke.points[0];
-            const p1 = stroke.points[stroke.points.length - 1];
-            const x1 = Math.min(p0.x, p1.x);
-            const x2 = Math.max(p0.x, p1.x);
-            const y1 = Math.min(p0.y, p1.y);
-            const y2 = Math.max(p0.y, p1.y);
             const shape = stroke.redactShape || "rect";
+            let x1, x2, y1, y2;
+            if (shape === "freehand" && stroke.freehandPoints && stroke.freehandPoints.length > 0) {
+                x1 = Infinity; x2 = -Infinity; y1 = Infinity; y2 = -Infinity;
+                for (let j = 0; j < stroke.freehandPoints.length; j++) {
+                    const p = stroke.freehandPoints[j];
+                    if (p.x < x1) x1 = p.x;
+                    if (p.x > x2) x2 = p.x;
+                    if (p.y < y1) y1 = p.y;
+                    if (p.y > y2) y2 = p.y;
+                }
+            } else {
+                const p0 = stroke.points[0];
+                const p1 = stroke.points[stroke.points.length - 1];
+                x1 = Math.min(p0.x, p1.x);
+                x2 = Math.max(p0.x, p1.x);
+                y1 = Math.min(p0.y, p1.y);
+                y2 = Math.max(p0.y, p1.y);
+            }
             if (shape === "ellipse") {
                 const rx = Math.max((x2 - x1) / 2, 1);
                 const ry = Math.max((y2 - y1) / 2, 1);
@@ -562,10 +574,6 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 const cy = y1 + ry;
                 const normalized = Math.pow((mx - cx) / rx, 2) + Math.pow((my - cy) / ry, 2);
                 if (normalized <= 1.1) return i;
-            } else if (shape === "freehand" && stroke.freehandPoints) {
-                if (mx >= x1 - Constants.rectSelectionPadding && mx <= x2 + Constants.rectSelectionPadding && my >= y1 - Constants.rectSelectionPadding && my <= y2 + Constants.rectSelectionPadding) {
-                    return i;
-                }
             } else {
                 if (mx >= x1 - Constants.rectSelectionPadding && mx <= x2 + Constants.rectSelectionPadding && my >= y1 - Constants.rectSelectionPadding && my <= y2 + Constants.rectSelectionPadding) {
                     return i;

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -547,7 +547,31 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 const dy = Math.min(Math.abs(my - y1), Math.abs(my - y2));
                 if (dx <= threshold || dy <= threshold) return i;
             }
-        } else if (stroke.tool === "redact" || stroke.tool === "pixelate" || stroke.tool === "spotlight") {
+        } else if (stroke.tool === "redact") {
+            const p0 = stroke.points[0];
+            const p1 = stroke.points[stroke.points.length - 1];
+            const x1 = Math.min(p0.x, p1.x);
+            const x2 = Math.max(p0.x, p1.x);
+            const y1 = Math.min(p0.y, p1.y);
+            const y2 = Math.max(p0.y, p1.y);
+            const shape = stroke.redactShape || "rect";
+            if (shape === "ellipse") {
+                const rx = Math.max((x2 - x1) / 2, 1);
+                const ry = Math.max((y2 - y1) / 2, 1);
+                const cx = x1 + rx;
+                const cy = y1 + ry;
+                const normalized = Math.pow((mx - cx) / rx, 2) + Math.pow((my - cy) / ry, 2);
+                if (normalized <= 1.1) return i;
+            } else if (shape === "freehand" && stroke.freehandPoints) {
+                if (mx >= x1 - Constants.rectSelectionPadding && mx <= x2 + Constants.rectSelectionPadding && my >= y1 - Constants.rectSelectionPadding && my <= y2 + Constants.rectSelectionPadding) {
+                    return i;
+                }
+            } else {
+                if (mx >= x1 - Constants.rectSelectionPadding && mx <= x2 + Constants.rectSelectionPadding && my >= y1 - Constants.rectSelectionPadding && my <= y2 + Constants.rectSelectionPadding) {
+                    return i;
+                }
+            }
+        } else if (stroke.tool === "pixelate" || stroke.tool === "spotlight") {
             const p0 = stroke.points[0];
             const p1 = stroke.points[stroke.points.length - 1];
             const x1 = Math.min(p0.x, p1.x);

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -548,25 +548,13 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 if (dx <= threshold || dy <= threshold) return i;
             }
         } else if (stroke.tool === "redact") {
+            const p0 = stroke.points[0];
+            const p1 = stroke.points[stroke.points.length - 1];
+            const x1 = Math.min(p0.x, p1.x);
+            const x2 = Math.max(p0.x, p1.x);
+            const y1 = Math.min(p0.y, p1.y);
+            const y2 = Math.max(p0.y, p1.y);
             const shape = stroke.redactShape || "rect";
-            let x1, x2, y1, y2;
-            if (shape === "freehand" && stroke.freehandPoints && stroke.freehandPoints.length > 0) {
-                x1 = Infinity; x2 = -Infinity; y1 = Infinity; y2 = -Infinity;
-                for (let j = 0; j < stroke.freehandPoints.length; j++) {
-                    const p = stroke.freehandPoints[j];
-                    if (p.x < x1) x1 = p.x;
-                    if (p.x > x2) x2 = p.x;
-                    if (p.y < y1) y1 = p.y;
-                    if (p.y > y2) y2 = p.y;
-                }
-            } else {
-                const p0 = stroke.points[0];
-                const p1 = stroke.points[stroke.points.length - 1];
-                x1 = Math.min(p0.x, p1.x);
-                x2 = Math.max(p0.x, p1.x);
-                y1 = Math.min(p0.y, p1.y);
-                y2 = Math.max(p0.y, p1.y);
-            }
             if (shape === "ellipse") {
                 const rx = Math.max((x2 - x1) / 2, 1);
                 const ry = Math.max((y2 - y1) / 2, 1);

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -548,13 +548,25 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 if (dx <= threshold || dy <= threshold) return i;
             }
         } else if (stroke.tool === "redact") {
-            const p0 = stroke.points[0];
-            const p1 = stroke.points[stroke.points.length - 1];
-            const x1 = Math.min(p0.x, p1.x);
-            const x2 = Math.max(p0.x, p1.x);
-            const y1 = Math.min(p0.y, p1.y);
-            const y2 = Math.max(p0.y, p1.y);
             const shape = stroke.redactShape || "rect";
+            let x1, x2, y1, y2;
+            if (shape === "freehand" && stroke.freehandPoints && stroke.freehandPoints.length > 0) {
+                x1 = Infinity; x2 = -Infinity; y1 = Infinity; y2 = -Infinity;
+                for (let j = 0; j < stroke.freehandPoints.length; j++) {
+                    const p = stroke.freehandPoints[j];
+                    if (p.x < x1) x1 = p.x;
+                    if (p.x > x2) x2 = p.x;
+                    if (p.y < y1) y1 = p.y;
+                    if (p.y > y2) y2 = p.y;
+                }
+            } else {
+                const p0 = stroke.points[0];
+                const p1 = stroke.points[stroke.points.length - 1];
+                x1 = Math.min(p0.x, p1.x);
+                x2 = Math.max(p0.x, p1.x);
+                y1 = Math.min(p0.y, p1.y);
+                y2 = Math.max(p0.y, p1.y);
+            }
             if (shape === "ellipse") {
                 const rx = Math.max((x2 - x1) / 2, 1);
                 const ry = Math.max((y2 - y1) / 2, 1);
@@ -690,12 +702,24 @@ function getStrokeHandleAt(mx, my, stroke, estimateTextWidthFn) {
     if (stroke.tool === "rect" || stroke.tool === "ellipse" || stroke.tool === "redact" ||
         stroke.tool === "pixelate" || stroke.tool === "spotlight") {
         if (stroke.points.length < 2) return "none";
-        const p0 = stroke.points[0];
-        const p1 = stroke.points[stroke.points.length - 1];
-        const x1 = Math.min(p0.x, p1.x);
-        const y1 = Math.min(p0.y, p1.y);
-        const x2 = Math.max(p0.x, p1.x);
-        const y2 = Math.max(p0.y, p1.y);
+        let x1, y1, x2, y2;
+        if (stroke.tool === "redact" && stroke.redactShape === "freehand" && stroke.freehandPoints && stroke.freehandPoints.length > 0) {
+            x1 = Infinity; x2 = -Infinity; y1 = Infinity; y2 = -Infinity;
+            for (let j = 0; j < stroke.freehandPoints.length; j++) {
+                const p = stroke.freehandPoints[j];
+                if (p.x < x1) x1 = p.x;
+                if (p.x > x2) x2 = p.x;
+                if (p.y < y1) y1 = p.y;
+                if (p.y > y2) y2 = p.y;
+            }
+        } else {
+            const p0 = stroke.points[0];
+            const p1 = stroke.points[stroke.points.length - 1];
+            x1 = Math.min(p0.x, p1.x);
+            y1 = Math.min(p0.y, p1.y);
+            x2 = Math.max(p0.x, p1.x);
+            y2 = Math.max(p0.y, p1.y);
+        }
         const cx = (x1 + x2) / 2;
         const cy = (y1 + y2) / 2;
 

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -548,25 +548,13 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 if (dx <= threshold || dy <= threshold) return i;
             }
         } else if (stroke.tool === "redact") {
+            const p0 = stroke.points[0];
+            const p1 = stroke.points[stroke.points.length - 1];
+            const x1 = Math.min(p0.x, p1.x);
+            const x2 = Math.max(p0.x, p1.x);
+            const y1 = Math.min(p0.y, p1.y);
+            const y2 = Math.max(p0.y, p1.y);
             const shape = stroke.redactShape || "rect";
-            let x1, x2, y1, y2;
-            if (shape === "freehand" && stroke.freehandPoints && stroke.freehandPoints.length > 0) {
-                x1 = Infinity; x2 = -Infinity; y1 = Infinity; y2 = -Infinity;
-                for (let j = 0; j < stroke.freehandPoints.length; j++) {
-                    const p = stroke.freehandPoints[j];
-                    if (p.x < x1) x1 = p.x;
-                    if (p.x > x2) x2 = p.x;
-                    if (p.y < y1) y1 = p.y;
-                    if (p.y > y2) y2 = p.y;
-                }
-            } else {
-                const p0 = stroke.points[0];
-                const p1 = stroke.points[stroke.points.length - 1];
-                x1 = Math.min(p0.x, p1.x);
-                x2 = Math.max(p0.x, p1.x);
-                y1 = Math.min(p0.y, p1.y);
-                y2 = Math.max(p0.y, p1.y);
-            }
             if (shape === "ellipse") {
                 const rx = Math.max((x2 - x1) / 2, 1);
                 const ry = Math.max((y2 - y1) / 2, 1);
@@ -702,24 +690,12 @@ function getStrokeHandleAt(mx, my, stroke, estimateTextWidthFn) {
     if (stroke.tool === "rect" || stroke.tool === "ellipse" || stroke.tool === "redact" ||
         stroke.tool === "pixelate" || stroke.tool === "spotlight") {
         if (stroke.points.length < 2) return "none";
-        let x1, y1, x2, y2;
-        if (stroke.tool === "redact" && stroke.redactShape === "freehand" && stroke.freehandPoints && stroke.freehandPoints.length > 0) {
-            x1 = Infinity; x2 = -Infinity; y1 = Infinity; y2 = -Infinity;
-            for (let j = 0; j < stroke.freehandPoints.length; j++) {
-                const p = stroke.freehandPoints[j];
-                if (p.x < x1) x1 = p.x;
-                if (p.x > x2) x2 = p.x;
-                if (p.y < y1) y1 = p.y;
-                if (p.y > y2) y2 = p.y;
-            }
-        } else {
-            const p0 = stroke.points[0];
-            const p1 = stroke.points[stroke.points.length - 1];
-            x1 = Math.min(p0.x, p1.x);
-            y1 = Math.min(p0.y, p1.y);
-            x2 = Math.max(p0.x, p1.x);
-            y2 = Math.max(p0.y, p1.y);
-        }
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[stroke.points.length - 1];
+        const x1 = Math.min(p0.x, p1.x);
+        const y1 = Math.min(p0.y, p1.y);
+        const x2 = Math.max(p0.x, p1.x);
+        const y2 = Math.max(p0.y, p1.y);
         const cx = (x1 + x2) / 2;
         const cy = (y1 + y2) / 2;
 

--- a/components/RedactOptionsToolbar.qml
+++ b/components/RedactOptionsToolbar.qml
@@ -124,8 +124,7 @@ Item {
                     model: [
                         { icon: "crop_square", shape: "rect", tooltip: qsTr("Rectangle") },
                         { icon: "rounded_corner", shape: "roundRect", tooltip: qsTr("Rounded Rectangle") },
-                        { icon: "circle", shape: "ellipse", tooltip: qsTr("Ellipse") },
-                        { icon: "gesture", shape: "freehand", tooltip: qsTr("Freehand") }
+                        { icon: "circle", shape: "ellipse", tooltip: qsTr("Ellipse") }
                     ]
 
                     delegate: Rectangle {

--- a/components/RedactOptionsToolbar.qml
+++ b/components/RedactOptionsToolbar.qml
@@ -17,9 +17,11 @@ Item {
     property real menuY: 0
 
     property string currentMode: "solid"
+    property string currentShape: "rect"
     property string toolbarPosition: "top"
 
     signal modeSelected(string mode)
+    signal shapeSelected(string shape)
 
     states: [
         State {
@@ -59,8 +61,8 @@ Item {
 
     Rectangle {
         id: menuContent
-        width: contentRow.implicitWidth + Theme.spacingM * 2
-        height: tc.subToolbarHeight
+        width: Math.max(modeRow.implicitWidth, shapeRow.implicitWidth) + Theme.spacingM * 2
+        height: tc.subToolbarHeight * 2 + Theme.spacingS
         x: Math.max(10, Math.min(root.width - width - 10, root.menuX - width / 2))
         y: root.toolbarPosition === "bottom"
             ? Math.max(10, Math.min(root.height - height - 10, root.menuY - height - 20))
@@ -71,41 +73,84 @@ Item {
         border.color: Theme.withAlpha(Theme.outline, 0.15)
         border.width: 1
         radius: Theme.cornerRadius
-        
-        Row {
-            id: contentRow
+
+        Column {
             anchors.centerIn: parent
             spacing: Theme.spacingS
 
-            // Group: Redact Modes (Solid, Clean)
-            Repeater {
-                model: [
-                    { icon: "square", mode: "solid", tooltip: qsTr("Solid Fill") },
-                    { icon: "auto_fix_high", mode: "clean", tooltip: qsTr("Clean Text Eraser") }
-                ]
+            Row {
+                id: modeRow
+                spacing: Theme.spacingS
 
-                delegate: Rectangle {
-                    width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
-                    radius: Theme.cornerRadius - 2
-                    color: root.currentMode === modelData.mode 
-                        ? Theme.withAlpha(Theme.primary, 0.15) 
-                        : (modeMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
-                    border.color: root.currentMode === modelData.mode ? Theme.primary : "transparent"
-                    border.width: 1
+                Repeater {
+                    model: [
+                        { icon: "square", mode: "solid", tooltip: qsTr("Solid Fill") },
+                        { icon: "auto_fix_high", mode: "clean", tooltip: qsTr("Clean Text Eraser") }
+                    ]
 
-                    DankIcon {
-                        anchors.centerIn: parent
-                        name: modelData.icon
-                        size: tc.subToolbarIconSize
-                        color: root.currentMode === modelData.mode ? Theme.primary : Theme.surfaceText
+                    delegate: Rectangle {
+                        width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
+                        radius: Theme.cornerRadius - 2
+                        color: root.currentMode === modelData.mode
+                            ? Theme.withAlpha(Theme.primary, 0.15)
+                            : (modeMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                        border.color: root.currentMode === modelData.mode ? Theme.primary : "transparent"
+                        border.width: 1
+
+                        DankIcon {
+                            anchors.centerIn: parent
+                            name: modelData.icon
+                            size: tc.subToolbarIconSize
+                            color: root.currentMode === modelData.mode ? Theme.primary : Theme.surfaceText
+                        }
+
+                        MouseArea {
+                            id: modeMouse
+                            anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.modeSelected(modelData.mode);
+                                root.close();
+                            }
+                        }
                     }
+                }
+            }
 
-                    MouseArea {
-                        id: modeMouse
-                        anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            root.modeSelected(modelData.mode);
-                            root.close();
+            Row {
+                id: shapeRow
+                spacing: Theme.spacingS
+
+                Repeater {
+                    model: [
+                        { icon: "crop_square", shape: "rect", tooltip: qsTr("Rectangle") },
+                        { icon: "rounded_corner", shape: "roundRect", tooltip: qsTr("Rounded Rectangle") },
+                        { icon: "circle", shape: "ellipse", tooltip: qsTr("Ellipse") },
+                        { icon: "gesture", shape: "freehand", tooltip: qsTr("Freehand") }
+                    ]
+
+                    delegate: Rectangle {
+                        width: tc.subToolbarBtnSize; height: tc.subToolbarBtnSize
+                        radius: Theme.cornerRadius - 2
+                        color: root.currentShape === modelData.shape
+                            ? Theme.withAlpha(Theme.primary, 0.15)
+                            : (shapeMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                        border.color: root.currentShape === modelData.shape ? Theme.primary : "transparent"
+                        border.width: 1
+
+                        DankIcon {
+                            anchors.centerIn: parent
+                            name: modelData.icon
+                            size: tc.subToolbarIconSize
+                            color: root.currentShape === modelData.shape ? Theme.primary : Theme.surfaceText
+                        }
+
+                        MouseArea {
+                            id: shapeMouse
+                            anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.shapeSelected(modelData.shape);
+                                root.close();
+                            }
                         }
                     }
                 }

--- a/components/StrokeProperties.js
+++ b/components/StrokeProperties.js
@@ -17,7 +17,6 @@ function copyStrokeProperties(source, target) {
     if (source.arrowHeadStyle !== undefined) target.arrowHeadStyle = source.arrowHeadStyle;
     if (source.redactMode !== undefined) target.redactMode = source.redactMode;
     if (source.redactShape !== undefined) target.redactShape = source.redactShape;
-    if (source.freehandPoints !== undefined) target.freehandPoints = source.freehandPoints.slice();
     if (source.hasLeaderLine !== undefined) target.hasLeaderLine = source.hasLeaderLine;
     if (source.calloutLinkLines !== undefined) target.calloutLinkLines = source.calloutLinkLines;
     if (source.id !== undefined) target.id = source.id;

--- a/components/StrokeProperties.js
+++ b/components/StrokeProperties.js
@@ -17,6 +17,7 @@ function copyStrokeProperties(source, target) {
     if (source.arrowHeadStyle !== undefined) target.arrowHeadStyle = source.arrowHeadStyle;
     if (source.redactMode !== undefined) target.redactMode = source.redactMode;
     if (source.redactShape !== undefined) target.redactShape = source.redactShape;
+    if (source.freehandPoints !== undefined) target.freehandPoints = source.freehandPoints.slice();
     if (source.hasLeaderLine !== undefined) target.hasLeaderLine = source.hasLeaderLine;
     if (source.calloutLinkLines !== undefined) target.calloutLinkLines = source.calloutLinkLines;
     if (source.id !== undefined) target.id = source.id;

--- a/components/StrokeProperties.js
+++ b/components/StrokeProperties.js
@@ -16,6 +16,7 @@ function copyStrokeProperties(source, target) {
     if (source.arrowLineStyle !== undefined) target.arrowLineStyle = source.arrowLineStyle;
     if (source.arrowHeadStyle !== undefined) target.arrowHeadStyle = source.arrowHeadStyle;
     if (source.redactMode !== undefined) target.redactMode = source.redactMode;
+    if (source.redactShape !== undefined) target.redactShape = source.redactShape;
     if (source.hasLeaderLine !== undefined) target.hasLeaderLine = source.hasLeaderLine;
     if (source.calloutLinkLines !== undefined) target.calloutLinkLines = source.calloutLinkLines;
     if (source.id !== undefined) target.id = source.id;


### PR DESCRIPTION
Closes #104

## Summary

Adds 4 redact shapes: `rect`, `roundRect`, `ellipse`, `freehand`.

- `rect` — filled rect (no rounding regardless of config)
- `roundRect` — filled rounded rect using `Theme.cornerRadius`
- `ellipse` — filled ellipse
- `freehand` — multi-point filled polygon

## Changes

- **StrokeProperties.js**: `redactShape` added to copy/paste
- **QuickCaptureModal.qml**: `activeRedactShape` state + handler + save/restore
- **DrawMouseArea.qml**: freehand collects all mouse points; non-freehand keeps 2-point rect
- **DrawingRenderer.js**: shape-branching drawing for all 4 shapes
- **Helpers.js**: ellipse uses precise inside-ellipse hit-test; others use bounding box
- **RedactOptionsToolbar.qml**: two-row popup with shape selector

## Summary by Sourcery

Add multiple shape options to the redact drawing tool and wire them through the UI, stroke model, hit-testing, and rendering.

New Features:
- Introduce selectable redact shapes (rectangle, rounded rectangle, ellipse, freehand) in the toolbar and modal state.
- Support freehand redact strokes that track all mouse points and render as filled polygons.
- Enable ellipse-shaped redactions with accurate inside-ellipse hit testing.

Enhancements:
- Persist and propagate the active redact shape across selection, grab, and copy/paste operations.
- Refine redact stroke rendering logic to branch by shape while keeping existing mode behavior.
- Expand the redact options toolbar layout to a two-row menu separating mode and shape selectors.