### PR TITLE
fix: hide shape preview in SizePreviewCard when no stroke selected

### DIFF
--- a/components/SizePreviewCard.qml
+++ b/components/SizePreviewCard.qml
@@ -18,7 +18,7 @@ Rectangle {
     readonly property bool _hasStroke: window.selectedStroke != null
 
     width: _hasStroke ? shapeWidth : 0
-    height: _hasStroke ? width : 0
+    height: width
     radius: _hasStroke ? shapeRadius : 0
     color: "transparent"
     border.color: _hasStroke ? shapeBorderColor : "transparent"
@@ -73,11 +73,12 @@ Rectangle {
     }
 
     StyledText {
+        id: valueLabel
         anchors.top: _hasStroke ? parent.bottom : undefined
         anchors.topMargin: 4 / drawingCanvas.scale
         anchors.horizontalCenter: _hasStroke ? parent.horizontalCenter : undefined
         x: _hasStroke ? 0 : 8 / drawingCanvas.scale
-        y: _hasStroke ? 0 : -height - 4 / drawingCanvas.scale
+        y: _hasStroke ? 0 : -valueLabel.height - 4 / drawingCanvas.scale
         text: {
             if (window.currentTool === "select" && window.selectedStroke && window.selectedStroke.tool === "callout") {
                 if (window.calloutDestDragging) {

--- a/components/SizePreviewCard.qml
+++ b/components/SizePreviewCard.qml
@@ -7,14 +7,25 @@ import "../dms-common"
 
 Rectangle {
     id: sizePreviewItem
-    
+
     required property var window
     required property var drawingCanvas
 
     visible: window.showSizePreview
     x: window.previewX - (width / 2)
     y: window.previewY - (height / 2)
-    width: {
+
+    readonly property bool _hasStroke: window.selectedStroke != null
+
+    width: _hasStroke ? shapeWidth : 0
+    height: _hasStroke ? width : 0
+    radius: _hasStroke ? shapeRadius : 0
+    color: "transparent"
+    border.color: _hasStroke ? shapeBorderColor : "transparent"
+    border.width: _hasStroke ? 1.5 / drawingCanvas.scale : 0
+    z: 20
+
+    readonly property real shapeWidth: {
         let base = window.activeIntensity;
         const tool = window.effectiveTool;
         if (tool === "highlighter") {
@@ -30,27 +41,25 @@ Rectangle {
                 const bw = window.selectedStroke.borderWidth !== undefined ? window.selectedStroke.borderWidth : 2;
                 base = bw * 2;
             } else {
-                base = 40; // Small anchor size for text feedback
+                base = 40;
             }
         }
         return base * window.editScale;
     }
-    height: width
-    radius: {
+    readonly property real shapeRadius: {
         const tool = window.effectiveTool;
-        if (tool === "highlighter") return window.roundHighlighter ? width / 2 : 0;
+        if (tool === "highlighter") return window.roundHighlighter ? shapeWidth / 2 : 0;
         if (tool === "spotlight" || tool === "rect" || tool === "redact") return window.roundRect ? (Theme.cornerRadius * window.editScale) : 0;
         if (tool === "pixelate" || tool === "text") return 0;
         if (tool === "callout") {
             if (window.currentTool === "select" && !window.calloutDestDragging && window.selectedStroke) {
-                return width / 2;
+                return shapeWidth / 2;
             }
             return 0;
         }
-        return width / 2;
+        return shapeWidth / 2;
     }
-    color: "transparent"
-    border.color: {
+    readonly property color shapeBorderColor: {
         if (window.effectiveTool === "callout") {
             if (window.currentTool === "select" && !window.calloutDestDragging && window.selectedStroke) {
                 return Theme.primary;
@@ -62,13 +71,13 @@ Rectangle {
         }
         return Theme.primary;
     }
-    border.width: 1.5 / drawingCanvas.scale
-    z: 20
 
     StyledText {
-        anchors.top: parent.bottom
+        anchors.top: _hasStroke ? parent.bottom : undefined
         anchors.topMargin: 4 / drawingCanvas.scale
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.horizontalCenter: _hasStroke ? parent.horizontalCenter : undefined
+        x: _hasStroke ? 0 : 8 / drawingCanvas.scale
+        y: _hasStroke ? 0 : -height - 4 / drawingCanvas.scale
         text: {
             if (window.currentTool === "select" && window.selectedStroke && window.selectedStroke.tool === "callout") {
                 if (window.calloutDestDragging) {

--- a/components/SizePreviewCard.qml
+++ b/components/SizePreviewCard.qml
@@ -15,14 +15,14 @@ Rectangle {
     x: window.previewX - (width / 2)
     y: window.previewY - (height / 2)
 
-    readonly property bool _hasStroke: window.selectedStroke != null
+    readonly property bool _showShape: window.effectiveTool !== "spotlight"
 
-    width: _hasStroke ? shapeWidth : 0
+    width: _showShape ? shapeWidth : 0
     height: width
-    radius: _hasStroke ? shapeRadius : 0
+    radius: _showShape ? shapeRadius : 0
     color: "transparent"
-    border.color: _hasStroke ? shapeBorderColor : "transparent"
-    border.width: _hasStroke ? 1.5 / drawingCanvas.scale : 0
+    border.color: _showShape ? shapeBorderColor : "transparent"
+    border.width: _showShape ? 1.5 / drawingCanvas.scale : 0
     z: 20
 
     readonly property real shapeWidth: {
@@ -74,11 +74,11 @@ Rectangle {
 
     StyledText {
         id: valueLabel
-        anchors.top: _hasStroke ? parent.bottom : undefined
+        anchors.top: _showShape ? parent.bottom : undefined
         anchors.topMargin: 4 / drawingCanvas.scale
-        anchors.horizontalCenter: _hasStroke ? parent.horizontalCenter : undefined
-        x: _hasStroke ? 0 : 8 / drawingCanvas.scale
-        y: _hasStroke ? 0 : -valueLabel.height - 4 / drawingCanvas.scale
+        anchors.horizontalCenter: _showShape ? parent.horizontalCenter : undefined
+        x: _showShape ? 0 : 8 / drawingCanvas.scale
+        y: _showShape ? 0 : -valueLabel.height - 4 / drawingCanvas.scale
         text: {
             if (window.currentTool === "select" && window.selectedStroke && window.selectedStroke.tool === "callout") {
                 if (window.calloutDestDragging) {


### PR DESCRIPTION
## Summary

When scrolling to adjust tool intensity (stroke width, spotlight opacity, etc.) **without a selected stroke**, the SizePreviewCard previously showed a shape preview (circle/rect) that is misleading — the scroll action has nothing to do with shape geometry.

## Changes

- **SizePreviewCard.qml**: Hide the shape preview (`width: 0`, no border) when `window.selectedStroke` is null
- Keep the **text value label** always visible near the cursor for fine-tuning feedback
- When a stroke IS selected (adjusting its properties), the shape preview + text behave exactly as before

## Why

- Spotlight scroll adjusts opacity (10-95%), not a shape — the shape preview was confusing
- Pen/line/arrow scroll adjusts stroke width — but without a selected stroke, the dummy shape (always 100px for spotlight, etc.) is meaningless
- The text label alone provides clean, focused feedback for precise intensity adjustment

## Summary by Sourcery

Adjust SizePreviewCard behavior so that the shape preview only appears when a stroke is selected, while the text label continues to provide feedback during intensity adjustments.

Bug Fixes:
- Hide shape preview in SizePreviewCard when adjusting intensity with no stroke selected.

Enhancements:
- Keep the numeric intensity label visible and repositioned near the cursor when no stroke is selected.