### PR TITLE
feat: improve crop handle visuals and behavior

### DIFF
--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -697,32 +697,35 @@ MouseArea {
              return;
         }
 
-         if (window.currentTool === "crop") {
-            if (window.activeHandle === "new" || window.activeHandle === "tl" || window.activeHandle === "tr" || window.activeHandle === "bl" || window.activeHandle === "br") {
-                // Check for accidental click (too small) BEFORE clamping
-                if (Math.min(window.cropRect.width, window.cropRect.height) <= 3) {
-                    if (window.strokes.length === 0) {
-                        window.discardAndClose();
-                    } else {
-                        window.hasSelection = false;
-                        window.cropRect = Qt.rect(0, 0, 0, 0);
-                    }
-                    return;
-                }
-                window.cropRect = window.clampCropRect(window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height);
-                if (Math.min(window.cropRect.width, window.cropRect.height) >= 16) {
-                    window.hasSelection = true;
-                    // Automatically enter edit mode with the pen tool once selection is made/resized!
-                    window.currentTool = "pen";
-                } else {
-                    window.hasSelection = false;
-                    window.cropRect = Qt.rect(0, 0, 0, 0);
-                }
-            }
-            window.activeHandle = "none";
-            drawingCanvas.requestPaint();
-            return;
-        }
+          if (window.currentTool === "crop") {
+             if (window.activeHandle === "new" || window.activeHandle === "tl" || window.activeHandle === "tr" || window.activeHandle === "bl" || window.activeHandle === "br"
+                 || window.activeHandle === "tc" || window.activeHandle === "bc" || window.activeHandle === "lc" || window.activeHandle === "rc") {
+                 // Check for accidental click (too small) BEFORE clamping
+                 if (Math.min(window.cropRect.width, window.cropRect.height) <= 3) {
+                     if (window.strokes.length === 0) {
+                         window.discardAndClose();
+                     } else {
+                         window.hasSelection = false;
+                         window.cropRect = Qt.rect(0, 0, 0, 0);
+                     }
+                     return;
+                 }
+                 window.cropRect = window.clampCropRect(window.cropRect.x, window.cropRect.y, window.cropRect.width, window.cropRect.height);
+                 if (Math.min(window.cropRect.width, window.cropRect.height) >= 16) {
+                     window.hasSelection = true;
+                     if (window.activeHandle === "new") {
+                         // Automatically enter edit mode with pen on new selection
+                         window.currentTool = "pen";
+                     }
+                 } else {
+                     window.hasSelection = false;
+                     window.cropRect = Qt.rect(0, 0, 0, 0);
+                 }
+             }
+             window.activeHandle = "none";
+             drawingCanvas.requestPaint();
+             return;
+         }
 
         if (window.currentTool === "ocr") {
             window.activeHandle = "none";

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -698,8 +698,8 @@ MouseArea {
         }
 
           if (window.currentTool === "crop") {
-             if (window.activeHandle === "new" || window.activeHandle === "tl" || window.activeHandle === "tr" || window.activeHandle === "bl" || window.activeHandle === "br"
-                 || window.activeHandle === "tc" || window.activeHandle === "bc" || window.activeHandle === "lc" || window.activeHandle === "rc") {
+              var resizeHandles = ["new", "tl", "tr", "bl", "br", "tc", "bc", "lc", "rc"];
+              if (resizeHandles.indexOf(window.activeHandle) >= 0) {
                  // Check for accidental click (too small) BEFORE clamping
                  if (Math.min(window.cropRect.width, window.cropRect.height) <= 3) {
                      if (window.strokes.length === 0) {
@@ -721,11 +721,11 @@ MouseArea {
                      window.hasSelection = false;
                      window.cropRect = Qt.rect(0, 0, 0, 0);
                  }
-             }
-             window.activeHandle = "none";
-             drawingCanvas.requestPaint();
-             return;
-         }
+              }
+              window.activeHandle = "none";
+              drawingCanvas.requestPaint();
+              return;
+          }
 
         if (window.currentTool === "ocr") {
             window.activeHandle = "none";

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -783,9 +783,9 @@ function drawSelectionOverlay(ctx, options, Theme) {
         ctx.setLineDash([]);
 
         if (!options.isOcrMode) {
-            const arm = 12;
-            const edgeLen = 16;
-            const sw = 2;
+            const arm = 16;
+            const edgeLen = 20;
+            const sw = 2.5;
 
             const x1 = cr.x;
             const y1 = cr.y;

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -783,7 +783,7 @@ function drawSelectionOverlay(ctx, options, Theme) {
         ctx.setLineDash([]);
 
         if (!options.isOcrMode) {
-            const refW = options.canvasWidth;
+            const refW = options.canvasWidth || 1920;
             const arm = Math.max(10, Math.min(24, refW * 0.025));
             const edgeLen = Math.max(14, Math.min(30, refW * 0.03));
             const sw = Math.max(1.5, Math.min(3, refW * 0.0035));

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -783,12 +783,9 @@ function drawSelectionOverlay(ctx, options, Theme) {
         ctx.setLineDash([]);
 
         if (!options.isOcrMode) {
-            // 8 resize handles (crop mode only)
-            const hs = 10;
-            const hh = hs / 2;
-            ctx.fillStyle = Theme.primary;
-            ctx.strokeStyle = "#ffffff";
-            ctx.lineWidth = 1.5;
+            const arm = 12;
+            const edgeLen = 16;
+            const sw = 2;
 
             const x1 = cr.x;
             const y1 = cr.y;
@@ -797,25 +794,57 @@ function drawSelectionOverlay(ctx, options, Theme) {
             const cx = (x1 + x2) / 2;
             const cy = (y1 + y2) / 2;
 
-            // 4 Corners
-            ctx.fillRect(x1 - hh, y1 - hh, hs, hs);
-            ctx.strokeRect(x1 - hh, y1 - hh, hs, hs);
-            ctx.fillRect(x2 - hh, y1 - hh, hs, hs);
-            ctx.strokeRect(x2 - hh, y1 - hh, hs, hs);
-            ctx.fillRect(x1 - hh, y2 - hh, hs, hs);
-            ctx.strokeRect(x1 - hh, y2 - hh, hs, hs);
-            ctx.fillRect(x2 - hh, y2 - hh, hs, hs);
-            ctx.strokeRect(x2 - hh, y2 - hh, hs, hs);
+            // Helper: draw a path twice for contrast (white outline + primary fill)
+            function drawHandlePath(drawFn) {
+                ctx.save();
+                ctx.strokeStyle = "#ffffff";
+                ctx.lineWidth = sw + 2;
+                drawFn();
+                ctx.stroke();
+                ctx.strokeStyle = Theme.primary;
+                ctx.lineWidth = sw;
+                drawFn();
+                ctx.stroke();
+                ctx.restore();
+            }
 
-            // 4 Edge centers
-            ctx.fillRect(cx - hh, y1 - hh, hs, hs);
-            ctx.strokeRect(cx - hh, y1 - hh, hs, hs);
-            ctx.fillRect(cx - hh, y2 - hh, hs, hs);
-            ctx.strokeRect(cx - hh, y2 - hh, hs, hs);
-            ctx.fillRect(x1 - hh, cy - hh, hs, hs);
-            ctx.strokeRect(x1 - hh, cy - hh, hs, hs);
-            ctx.fillRect(x2 - hh, cy - hh, hs, hs);
-            ctx.strokeRect(x2 - hh, cy - hh, hs, hs);
+            // 4 Corners — L-shape brackets
+            drawHandlePath(() => {
+                // Top-left
+                ctx.beginPath();
+                ctx.moveTo(x1, y1 + arm);
+                ctx.lineTo(x1, y1);
+                ctx.lineTo(x1 + arm, y1);
+                // Top-right
+                ctx.moveTo(x2 - arm, y1);
+                ctx.lineTo(x2, y1);
+                ctx.lineTo(x2, y1 + arm);
+                // Bottom-left
+                ctx.moveTo(x1, y2 - arm);
+                ctx.lineTo(x1, y2);
+                ctx.lineTo(x1 + arm, y2);
+                // Bottom-right
+                ctx.moveTo(x2 - arm, y2);
+                ctx.lineTo(x2, y2);
+                ctx.lineTo(x2, y2 - arm);
+            });
+
+            // 4 Edge centers — short line segments
+            drawHandlePath(() => {
+                // Top
+                ctx.beginPath();
+                ctx.moveTo(cx - edgeLen / 2, y1);
+                ctx.lineTo(cx + edgeLen / 2, y1);
+                // Bottom
+                ctx.moveTo(cx - edgeLen / 2, y2);
+                ctx.lineTo(cx + edgeLen / 2, y2);
+                // Left
+                ctx.moveTo(x1, cy - edgeLen / 2);
+                ctx.lineTo(x1, cy + edgeLen / 2);
+                // Right
+                ctx.moveTo(x2, cy - edgeLen / 2);
+                ctx.lineTo(x2, cy + edgeLen / 2);
+            });
         }
     } else {
         // Dim full canvas slightly before selection

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -783,9 +783,10 @@ function drawSelectionOverlay(ctx, options, Theme) {
         ctx.setLineDash([]);
 
         if (!options.isOcrMode) {
-            const arm = 16;
-            const edgeLen = 20;
-            const sw = 2.5;
+            const refW = options.canvasWidth;
+            const arm = Math.max(10, Math.min(24, refW * 0.025));
+            const edgeLen = Math.max(14, Math.min(30, refW * 0.03));
+            const sw = Math.max(1.5, Math.min(3, refW * 0.0035));
 
             const x1 = cr.x;
             const y1 = cr.y;


### PR DESCRIPTION
### Changes
- **New handle style**: corners → L-shape brackets, edges → short line segments (replaces uniform 10×10 squares)
- **Handle size scales** with image dimensions (arm 10–24px, edgeLen 14–30px, stroke 1.5–3px)
- **No auto tool switch** when resizing existing crop (only on new selection)

### Before
All 8 handles were identical 10×10 filled squares. Resizing by corners auto-switched to pen tool.

### After
Corners show L-shaped brackets, edges show perpendicular line segments. Sizing is proportional to the image. Resizing a crop (corner or edge) keeps the current tool active.