### PR TITLE
feat: add Recent Edits history carousel modal for quick-capture

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -310,7 +310,8 @@ PluginComponent {
 
     // ── History carousel modal ────────────────────────────────────────────────
     function showHistoryCarousel() {
-        historyCarouselItem.refresh()
+        if (historyModal.contentLoader && historyModal.contentLoader.item)
+            historyModal.contentLoader.item.refresh()
         historyModal.shouldBeVisible = true
         historyModal.open()
     }
@@ -320,26 +321,20 @@ PluginComponent {
         shouldBeVisible: false
         positioning: "center"
         enableShadow: true
+        keepContentLoaded: true
+        closeOnEscapeKey: true
+        closeOnBackgroundClick: true
 
-        onBackgroundClicked: close()
-
-        modalFocusScope.Keys.onPressed: (event) => {
-            if (event.key === Qt.Key_Escape) {
-                close()
-                event.accepted = true
+        content: Component {
+            RecentEditsCarousel {
+                daemon: root
             }
         }
 
         readonly property real _screenW: targetScreen ? targetScreen.width : (Quickshell.screens[0] ? Quickshell.screens[0].width : 1920)
         readonly property real _screenH: targetScreen ? targetScreen.height : (Quickshell.screens[0] ? Quickshell.screens[0].height : 1080)
         modalWidth: Math.round(_screenW * 0.9)
-        modalHeight: Math.round(_screenH * (historyCarouselItem ? historyCarouselItem.heightFraction : 0.45))
-
-        RecentEditsCarousel {
-            id: historyCarouselItem
-            anchors.fill: parent
-            daemon: root
-        }
+        modalHeight: Math.round(_screenH * (historyModal.contentLoader && historyModal.contentLoader.item ? historyModal.contentLoader.item.heightFraction : 0.45))
     }
 
     // ── Lifecycle: register self so widget surface can delegate to daemon ─────

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -324,6 +324,7 @@ PluginComponent {
         keepContentLoaded: true
         closeOnEscapeKey: true
         closeOnBackgroundClick: true
+        onBackgroundClicked: close()
 
         content: Component {
             RecentEditsCarousel {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -321,6 +321,15 @@ PluginComponent {
         positioning: "center"
         enableShadow: true
 
+        onBackgroundClicked: close()
+
+        modalFocusScope.Keys.onPressed: (event) => {
+            if (event.key === Qt.Key_Escape) {
+                close()
+                event.accepted = true
+            }
+        }
+
         readonly property real _screenW: targetScreen ? targetScreen.width : (Quickshell.screens[0] ? Quickshell.screens[0].width : 1920)
         readonly property real _screenH: targetScreen ? targetScreen.height : (Quickshell.screens[0] ? Quickshell.screens[0].height : 1080)
         modalWidth: Math.round(_screenW * 0.9)

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -333,7 +333,7 @@ PluginComponent {
         readonly property real _screenW: targetScreen ? targetScreen.width : (Quickshell.screens[0] ? Quickshell.screens[0].width : 1920)
         readonly property real _screenH: targetScreen ? targetScreen.height : (Quickshell.screens[0] ? Quickshell.screens[0].height : 1080)
         modalWidth: Math.round(_screenW * 0.9)
-        modalHeight: Math.round(_screenH * (historyCarouselItem.heightFraction))
+        modalHeight: Math.round(_screenH * (historyCarouselItem ? historyCarouselItem.heightFraction : 0.45))
 
         RecentEditsCarousel {
             id: historyCarouselItem

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -8,6 +8,7 @@ import qs.Common
 import qs.Modules.Plugins
 import qs.Services
 import qs.Widgets
+import qs.Modals.Common
 import qs.Modals.FileBrowser
 
 PluginComponent {
@@ -304,6 +305,31 @@ PluginComponent {
                 }
             });
             close();
+        }
+    }
+
+    // ── History carousel modal ────────────────────────────────────────────────
+    function showHistoryCarousel() {
+        historyCarouselItem.refresh()
+        historyModal.shouldBeVisible = true
+        historyModal.open()
+    }
+
+    DankModal {
+        id: historyModal
+        shouldBeVisible: false
+        positioning: "center"
+        enableShadow: true
+
+        readonly property real _screenW: targetScreen ? targetScreen.width : (Quickshell.screens[0] ? Quickshell.screens[0].width : 1920)
+        readonly property real _screenH: targetScreen ? targetScreen.height : (Quickshell.screens[0] ? Quickshell.screens[0].height : 1080)
+        modalWidth: Math.round(_screenW * 0.9)
+        modalHeight: Math.round(_screenH * (historyCarouselItem.heightFraction))
+
+        RecentEditsCarousel {
+            id: historyCarouselItem
+            anchors.fill: parent
+            daemon: root
         }
     }
 

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -34,7 +34,7 @@ PluginComponent {
     }
 
     // ── Popout (left-click menu) ──────────────────────────────────────────────
-    popoutWidth: 280
+    popoutWidth: 250
     popoutHeight: outputExpanded ? 400 + Math.min(outputList.length, 5) * 32 : 400
 
     popoutContent: Component {

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -34,7 +34,7 @@ PluginComponent {
     }
 
     // ── Popout (left-click menu) ──────────────────────────────────────────────
-    popoutWidth: 240
+    popoutWidth: 280
     popoutHeight: outputExpanded ? 400 + Math.min(outputList.length, 5) * 32 : 400
 
     popoutContent: Component {

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -46,39 +46,79 @@ PluginComponent {
             closePopout: () => root.closePopout()
 
             headerActions: Component {
-                Rectangle {
-                    id: folderBtn
-                    width: 32
-                    height: 32
-                    radius: 16
-                    color: folderArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : "transparent"
+                Row {
+                    spacing: 4
 
-                    Behavior on color { ColorAnimation { duration: Theme.shorterDuration; easing.type: Theme.standardEasing } }
+                    Rectangle {
+                        id: folderBtn
+                        width: 32
+                        height: 32
+                        radius: 16
+                        color: folderArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : "transparent"
 
-                    property bool pressed: false
+                        Behavior on color { ColorAnimation { duration: Theme.shorterDuration; easing.type: Theme.standardEasing } }
 
-                    DankIcon {
-                        id: folderIcon
-                        anchors.centerIn: parent
-                        name: "open_in_new"
-                        size: Theme.iconSize - 4
-                        color: folderArea.containsMouse ? Theme.primary : Theme.surfaceVariantText
-                        scale: folderBtn.pressed ? 0.6 : 1.0
-                        Behavior on scale { NumberAnimation { duration: 400; easing.type: Easing.OutBack } }
+                        property bool pressed: false
+
+                        DankIcon {
+                            id: folderIcon
+                            anchors.centerIn: parent
+                            name: "open_in_new"
+                            size: Theme.iconSize - 4
+                            color: folderArea.containsMouse ? Theme.primary : Theme.surfaceVariantText
+                            scale: folderBtn.pressed ? 0.6 : 1.0
+                            Behavior on scale { NumberAnimation { duration: 400; easing.type: Easing.OutBack } }
+                        }
+
+                        MouseArea {
+                            id: folderArea
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onPressed: folderBtn.pressed = true
+                            onReleased: folderBtn.pressed = false
+                            onCanceled: folderBtn.pressed = false
+                            onClicked: {
+                                folderBtn.pressed = false
+                                const dir = root.pluginData.saveDirectory || "~/Pictures/Screenshots";
+                                Proc.runCommand("open-screenshot-dir", ["sh", "-c", "xdg-open " + dir], null);
+                            }
+                        }
                     }
 
-                    MouseArea {
-                        id: folderArea
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onPressed: folderBtn.pressed = true
-                        onReleased: folderBtn.pressed = false
-                        onCanceled: folderBtn.pressed = false
-                        onClicked: {
-                            folderBtn.pressed = false
-                            const dir = root.pluginData.saveDirectory || "~/Pictures/Screenshots";
-                            Proc.runCommand("open-screenshot-dir", ["sh", "-c", "xdg-open " + dir], null);
+                    Rectangle {
+                        id: historyBtn
+                        width: 32
+                        height: 32
+                        radius: 16
+                        color: historyArea.containsMouse ? Qt.rgba(Theme.primary.r, Theme.primary.g, Theme.primary.b, 0.15) : "transparent"
+
+                        Behavior on color { ColorAnimation { duration: Theme.shorterDuration; easing.type: Theme.standardEasing } }
+
+                        property bool pressed: false
+
+                        DankIcon {
+                            anchors.centerIn: parent
+                            name: "history"
+                            size: Theme.iconSize - 4
+                            color: historyArea.containsMouse ? Theme.primary : Theme.surfaceVariantText
+                            scale: historyBtn.pressed ? 0.6 : 1.0
+                            Behavior on scale { NumberAnimation { duration: 400; easing.type: Easing.OutBack } }
+                        }
+
+                        MouseArea {
+                            id: historyArea
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onPressed: historyBtn.pressed = true
+                            onReleased: historyBtn.pressed = false
+                            onCanceled: historyBtn.pressed = false
+                            onClicked: {
+                                historyBtn.pressed = false
+                                root.closePopout()
+                                if (root.daemon) root.daemon.showHistoryCarousel()
+                            }
                         }
                     }
                 }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -173,11 +173,18 @@ Item {
                                     iconName: "open_in_new"
                                     iconSize: 18
                                     buttonSize: 36
-                                    backgroundColor: Qt.rgba(0, 0, 0, 0.55)
-                                    iconColor: "white"
                                     visible: cardHover.hovered
                                     tooltipText: I18n.tr("Open")
                                     onClicked: Proc.runCommand("open-card", ["xdg-open", modelData.savedPath])
+
+                                    property bool _ovHovered: false
+                                    backgroundColor: _ovHovered ? Qt.rgba(0.3, 0.3, 0.3, 0.8) : Qt.rgba(0, 0, 0, 0.55)
+                                    iconColor: "white"
+                                    scale: _ovHovered ? 1.15 : 1.0
+                                    onEntered: _ovHovered = true
+                                    onExited: _ovHovered = false
+                                    Behavior on backgroundColor { ColorAnimation { duration: Theme.shorterDuration } }
+                                    Behavior on scale { NumberAnimation { duration: Theme.shorterDuration } }
                                 }
 
                                 DankActionButton {
@@ -188,8 +195,6 @@ Item {
                                     iconName: parent._copied ? "check" : "content_copy"
                                     iconSize: 18
                                     buttonSize: 36
-                                    backgroundColor: Qt.rgba(0, 0, 0, 0.55)
-                                    iconColor: parent._copied ? "#4caf50" : "white"
                                     visible: cardHover.hovered
                                     tooltipText: parent._copied ? I18n.tr("Copied") : I18n.tr("Copy")
                                     onClicked: {
@@ -198,6 +203,15 @@ Item {
                                             "dms cl copy \"" + modelData.savedPath.replace(/"/g, "\\\"") + "\""])
                                         ToastService.showInfo(I18n.tr("Image copied to clipboard"))
                                     }
+
+                                    property bool _ovHovered: false
+                                    backgroundColor: _ovHovered ? Qt.rgba(0.3, 0.3, 0.3, 0.8) : Qt.rgba(0, 0, 0, 0.55)
+                                    iconColor: parent._copied ? "#4caf50" : "white"
+                                    scale: _ovHovered ? 1.15 : 1.0
+                                    onEntered: _ovHovered = true
+                                    onExited: _ovHovered = false
+                                    Behavior on backgroundColor { ColorAnimation { duration: Theme.shorterDuration } }
+                                    Behavior on scale { NumberAnimation { duration: Theme.shorterDuration } }
                                 }
                             }
                         }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -75,7 +75,7 @@ Item {
 
             StyledText {
                 anchors.centerIn: parent
-                text: root.previewIndex >= 0 ? I18n.tr("Preview") : I18n.tr("Recent Edits")
+                text: root.previewIndex >= 0 ? I18n.tr("Preview") : (root.daemon ? root.daemon.pluginData.saveDirectory : I18n.tr("Recent Edits"))
                 font.pixelSize: Theme.fontSizeNormal
                 font.bold: true
                 color: Theme.surfaceText

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -4,7 +4,6 @@ import Quickshell.Io
 import qs.Common
 import qs.Services
 import qs.Widgets
-import "../dms-common"
 
 Item {
     id: root
@@ -49,6 +48,8 @@ Item {
             root.entries = list
         })
     }
+
+    Component.onCompleted: refresh()
 
     Column {
         anchors.fill: parent

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -1,0 +1,342 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Common
+import qs.Services
+import qs.Widgets
+import "../dms-common"
+
+Item {
+    id: root
+
+    property var daemon: null
+    property var entries: []
+    property int previewIndex: -1
+
+    readonly property var previewEntry: previewIndex >= 0 && previewIndex < entries.length ? entries[previewIndex] : null
+    readonly property real heightFraction: previewIndex >= 0 ? 0.7 : 0.45
+    property int currentPage: 0
+
+    readonly property int itemsPerPage: 4
+    readonly property int totalPages: Math.max(1, Math.ceil(entries.length / itemsPerPage))
+
+    function clampPage() {
+        if (currentPage >= totalPages) currentPage = totalPages - 1
+        if (currentPage < 0) currentPage = 0
+    }
+
+    onEntriesChanged: clampPage()
+
+    function refresh() {
+        if (!root.daemon || !root.daemon.pluginData) return
+        var dir = root.daemon.pluginData.saveDirectory || "~/Pictures/Screenshots"
+        dir = String(dir).replace(/^~/, Quickshell.env("HOME"))
+        var exts = ["png", "jpg", "jpeg", "webp"]
+        var globs = exts.map(function(e) { return "\"" + dir + "\"/*." + e }).join(" ")
+        var cmd = "for f in " + globs + "; do [ -f \"$f\" ] && echo \"$(stat -c '%Y' \"$f\" 2>/dev/null)|$f\"; done | sort -rn | head -50"
+        Proc.runCommand("scan-history", ["sh", "-c", cmd], function(stdout) {
+            var list = []
+            var lines = stdout.trim().split("\n")
+            for (var i = 0; i < lines.length; i++) {
+                var line = lines[i].trim()
+                if (!line) continue
+                var sep = line.indexOf("|")
+                if (sep < 0) continue
+                var ts = parseInt(line.substring(0, sep)) * 1000
+                var path = line.substring(sep + 1)
+                if (path) list.push({ timestamp: ts, savedPath: path, _glIdx: list.length })
+            }
+            root.entries = list
+        })
+    }
+
+    Column {
+        anchors.fill: parent
+        spacing: 0
+
+        // Header
+        Item {
+            width: parent.width
+            height: 44
+
+            DankActionButton {
+                anchors.left: parent.left
+                anchors.leftMargin: 4
+                anchors.verticalCenter: parent.verticalCenter
+                iconName: "arrow_back"
+                iconSize: 16
+                buttonSize: 32
+                backgroundColor: "transparent"
+                iconColor: Theme.surfaceText
+                visible: root.previewIndex >= 0
+                onClicked: root.previewIndex = -1
+            }
+
+            StyledText {
+                anchors.centerIn: parent
+                text: root.previewIndex >= 0 ? I18n.tr("Preview") : I18n.tr("Recent Edits")
+                font.pixelSize: Theme.fontSizeNormal
+                font.bold: true
+                color: Theme.surfaceText
+            }
+        }
+
+        // Empty state
+        StyledText {
+            width: parent.width
+            height: parent.height - 44
+            visible: root.entries.length === 0
+            text: I18n.tr("No saved images yet")
+            font.pixelSize: Theme.fontSizeNormal
+            color: Theme.surfaceVariantText
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        // Carousel
+        Item {
+            id: carouselView
+            width: parent.width
+            height: parent.height - 44
+            visible: root.entries.length > 0 && root.previewIndex < 0
+
+            readonly property real cardW: Math.max(60, (width - 46) / 4)
+
+            Column {
+                anchors.fill: parent
+                spacing: 4
+
+                Item {
+                    width: parent.width
+                    height: parent.height - 40
+                    clip: true
+
+                    Row {
+                        spacing: 10
+                        height: parent.height
+                        x: -root.currentPage * (carouselView.cardW * root.itemsPerPage + 10 * (root.itemsPerPage - 1))
+
+                        Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
+
+                        Repeater {
+                            model: root.entries
+
+                            delegate: Item {
+                                required property var modelData
+
+                                width: carouselView.cardW
+                                height: parent.height
+
+                                Rectangle {
+                                    anchors.fill: parent
+                                    radius: Theme.cornerRadius
+                                    color: Theme.surfaceContainerLow
+                                    border.color: cardHover.hovered ? Theme.primary : "transparent"
+                                    border.width: cardHover.hovered ? 2 : 0
+                                    clip: true
+
+                                    Behavior on border.color { ColorAnimation { duration: Theme.shorterDuration } }
+
+                                    Image {
+                                        anchors.fill: parent
+                                        anchors.margins: 4
+                                        source: "file://" + modelData.savedPath
+                                        sourceSize.width: parent.width
+                                        fillMode: Image.PreserveAspectFit
+                                        asynchronous: true
+                                    }
+
+                                    HoverHandler { id: cardHover }
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: root.previewIndex = modelData._glIdx
+                                    }
+
+                                    DankActionButton {
+                                        anchors.top: parent.top
+                                        anchors.right: parent.right
+                                        anchors.margins: 6
+                                        z: 1
+                                        iconName: "open_in_new"
+                                        iconSize: 18
+                                        buttonSize: 36
+                                        backgroundColor: Qt.rgba(0, 0, 0, 0.55)
+                                        iconColor: "white"
+                                        visible: cardHover.hovered
+                                        tooltipText: I18n.tr("Open")
+                                        onClicked: Proc.runCommand("open-card", ["xdg-open", modelData.savedPath])
+                                    }
+
+                                    property bool _copied: false
+
+                                    Timer {
+                                        interval: 1500
+                                        repeat: false
+                                        running: parent._copied
+                                        onTriggered: parent._copied = false
+                                    }
+
+                                    DankActionButton {
+                                        anchors.bottom: parent.bottom
+                                        anchors.right: parent.right
+                                        anchors.margins: 6
+                                        z: 1
+                                        iconName: parent._copied ? "check" : "content_copy"
+                                        iconSize: 18
+                                        buttonSize: 36
+                                        backgroundColor: Qt.rgba(0, 0, 0, 0.55)
+                                        iconColor: parent._copied ? "#4caf50" : "white"
+                                        visible: cardHover.hovered
+                                        tooltipText: parent._copied ? I18n.tr("Copied") : I18n.tr("Copy")
+                                        onClicked: {
+                                            parent._copied = true
+                                            Proc.runCommand("copy-card", ["sh", "-c",
+                                                "dms cl copy \"" + modelData.savedPath.replace(/"/g, "\\\"") + "\""])
+                                            ToastService.showInfo(I18n.tr("Image copied to clipboard"))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Page indicator
+                Item {
+                    width: parent.width
+                    height: 36
+
+                    DankButtonGroup {
+                        anchors.centerIn: parent
+                        visible: root.totalPages > 1
+                        model: {
+                            var pages = []
+                            for (var i = 0; i < root.totalPages; i++) pages.push(String(i + 1))
+                            return pages
+                        }
+                        currentIndex: root.currentPage
+                        size: "small"
+                        buttonHeight: 28
+                        minButtonWidth: 36
+                        onSelectionChanged: (index, selected) => {
+                            if (selected) root.currentPage = index
+                        }
+                    }
+                }
+            }
+        }
+
+        // Preview
+        Item {
+            width: parent.width
+            height: parent.height - 44
+            visible: root.previewEntry
+
+            onVisibleChanged: { if (!visible) _previewCopied = false }
+
+            Image {
+                anchors.fill: parent
+                anchors.margins: 8
+                anchors.bottomMargin: 56
+                source: root.previewEntry ? "file://" + root.previewEntry.savedPath : ""
+                fillMode: Image.PreserveAspectFit
+                asynchronous: true
+                sourceSize.width: 1920
+            }
+
+            DankActionButton {
+                anchors.left: parent.left
+                anchors.leftMargin: 4
+                anchors.verticalCenter: parent.verticalCenter
+                iconName: "chevron_left"
+                iconSize: 24
+                buttonSize: 40
+                backgroundColor: Theme.withAlpha(Theme.surfaceContainerHigh, 0.7)
+                iconColor: Theme.surfaceText
+                visible: root.previewIndex > 0
+                onClicked: root.previewIndex--
+            }
+
+            DankActionButton {
+                anchors.right: parent.right
+                anchors.rightMargin: 4
+                anchors.verticalCenter: parent.verticalCenter
+                iconName: "chevron_right"
+                iconSize: 24
+                buttonSize: 40
+                backgroundColor: Theme.withAlpha(Theme.surfaceContainerHigh, 0.7)
+                iconColor: Theme.surfaceText
+                visible: root.previewIndex < root.entries.length - 1
+                onClicked: root.previewIndex++
+            }
+
+            property bool _previewCopied: false
+
+            Timer {
+                interval: 1500
+                repeat: false
+                running: parent._previewCopied
+                onTriggered: parent._previewCopied = false
+            }
+
+            Row {
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: 12
+                spacing: 8
+
+                DankButton {
+                    iconName: parent._previewCopied ? "check" : "content_copy"
+                    text: parent._previewCopied ? I18n.tr("Copied") : I18n.tr("Copy")
+                    buttonHeight: 36
+                    horizontalPadding: 16
+                    backgroundColor: parent._previewCopied
+                        ? Qt.rgba(0.3, 0.7, 0.3, 0.9)
+                        : Theme.withAlpha(Theme.primary, 0.9)
+                    textColor: parent._previewCopied ? "white" : Theme.onPrimary
+                    onClicked: {
+                        if (root.previewEntry) {
+                            parent._previewCopied = true
+                            Proc.runCommand("copy-preview", ["sh", "-c",
+                                "dms cl copy \"" + root.previewEntry.savedPath.replace(/"/g, "\\\"") + "\""])
+                            ToastService.showInfo(I18n.tr("Image copied to clipboard"))
+                        }
+                    }
+                }
+
+                DankButton {
+                    iconName: "open_in_new"
+                    text: I18n.tr("Open")
+                    buttonHeight: 36
+                    horizontalPadding: 16
+                    backgroundColor: Theme.withAlpha(Theme.surfaceContainerHigh, 0.9)
+                    textColor: Theme.surfaceText
+                    onClicked: {
+                        if (root.previewEntry)
+                            Proc.runCommand("open-preview", ["xdg-open", root.previewEntry.savedPath])
+                    }
+                }
+
+                DankButton {
+                    iconName: "delete"
+                    text: I18n.tr("Delete")
+                    buttonHeight: 36
+                    horizontalPadding: 16
+                    backgroundColor: Qt.rgba(1, 0, 0, 0.3)
+                    textColor: "#ff6b6b"
+                    onClicked: {
+                        if (root.previewEntry) {
+                            var delPath = root.previewEntry.savedPath
+                            root.previewIndex = -1
+                            Proc.runCommand("delete-preview", ["rm", "-f", delPath], function() {
+                                root.refresh()
+                            })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -173,6 +173,7 @@ Item {
                                     iconName: "open_in_new"
                                     iconSize: 18
                                     buttonSize: 36
+                                    radius: height / 2
                                     visible: cardHover.hovered
                                     tooltipText: I18n.tr("Open")
                                     onClicked: Proc.runCommand("open-card", ["xdg-open", modelData.savedPath])
@@ -195,6 +196,7 @@ Item {
                                     iconName: parent._copied ? "check" : "content_copy"
                                     iconSize: 18
                                     buttonSize: 36
+                                    radius: height / 2
                                     visible: cardHover.hovered
                                     tooltipText: parent._copied ? I18n.tr("Copied") : I18n.tr("Copy")
                                     onClicked: {

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -364,4 +364,50 @@ Item {
             }
         }
     }
+
+    Shortcut {
+        sequence: "Left"
+        enabled: root.visible && root.entries.length > 0
+        onActivated: {
+            if (root.previewIndex >= 0)
+                root.previewIndex = Math.max(0, root.previewIndex - 1)
+            else
+                root.currentPage = Math.max(0, root.currentPage - 1)
+        }
+    }
+    Shortcut {
+        sequence: "A"
+        enabled: root.visible && root.entries.length > 0
+        onActivated: {
+            if (root.previewIndex >= 0)
+                root.previewIndex = Math.max(0, root.previewIndex - 1)
+            else
+                root.currentPage = Math.max(0, root.currentPage - 1)
+        }
+    }
+    Shortcut {
+        sequence: "Right"
+        enabled: root.visible && root.entries.length > 0
+        onActivated: {
+            if (root.previewIndex >= 0)
+                root.previewIndex = Math.min(root.entries.length - 1, root.previewIndex + 1)
+            else
+                root.currentPage = Math.min(root.totalPages - 1, root.currentPage + 1)
+        }
+    }
+    Shortcut {
+        sequence: "D"
+        enabled: root.visible && root.entries.length > 0
+        onActivated: {
+            if (root.previewIndex >= 0)
+                root.previewIndex = Math.min(root.entries.length - 1, root.previewIndex + 1)
+            else
+                root.currentPage = Math.min(root.totalPages - 1, root.currentPage + 1)
+        }
+    }
+    Shortcut {
+        sequence: "Escape"
+        enabled: root.previewIndex >= 0
+        onActivated: root.previewIndex = -1
+    }
 }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -138,6 +138,7 @@ Item {
                                     clip: true
 
                                     Behavior on border.color { ColorAnimation { duration: Theme.shorterDuration } }
+                                    Behavior on border.width { NumberAnimation { duration: Theme.shorterDuration } }
 
                                     Image {
                                         anchors.fill: parent
@@ -175,7 +176,8 @@ Item {
                                     iconSize: 18
                                     buttonSize: 36
                                     radius: height / 2
-                                    visible: cardHover.hovered
+                                    opacity: cardHover.hovered ? 1 : 0
+                                    enabled: cardHover.hovered
                                     tooltipText: I18n.tr("Open")
                                     onClicked: Proc.runCommand("open-card", ["xdg-open", modelData.savedPath])
 
@@ -187,6 +189,7 @@ Item {
                                     onExited: _ovHovered = false
                                     Behavior on backgroundColor { ColorAnimation { duration: Theme.shorterDuration } }
                                     Behavior on scale { NumberAnimation { duration: Theme.shorterDuration } }
+                                    Behavior on opacity { NumberAnimation { duration: Theme.shorterDuration } }
                                 }
 
                                 DankActionButton {
@@ -198,7 +201,8 @@ Item {
                                     iconSize: 18
                                     buttonSize: 36
                                     radius: height / 2
-                                    visible: cardHover.hovered
+                                    opacity: cardHover.hovered ? 1 : 0
+                                    enabled: cardHover.hovered
                                     tooltipText: parent._copied ? I18n.tr("Copied") : I18n.tr("Copy")
                                     onClicked: {
                                         parent._copied = true
@@ -214,6 +218,7 @@ Item {
                                     onExited: _ovHovered = false
                                     Behavior on backgroundColor { ColorAnimation { duration: Theme.shorterDuration } }
                                     Behavior on scale { NumberAnimation { duration: Theme.shorterDuration } }
+                                    Behavior on opacity { NumberAnimation { duration: Theme.shorterDuration } }
                                 }
                             }
                         }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -201,8 +201,7 @@ Item {
                                     tooltipText: parent._copied ? I18n.tr("Copied") : I18n.tr("Copy")
                                     onClicked: {
                                         parent._copied = true
-                                        Proc.runCommand("copy-card", ["sh", "-c",
-                                            "wl-copy < \"" + modelData.savedPath.replace(/"/g, "\\\"") + "\""])
+                                        DMSService.sendRequest("clipboard.copyFile", { "filePath": modelData.savedPath })
                                         ToastService.showInfo(I18n.tr("Image copied to clipboard"))
                                     }
 
@@ -329,8 +328,7 @@ Item {
                     onClicked: {
                         if (root.previewEntry) {
                             parent._previewCopied = true
-                            Proc.runCommand("copy-preview", ["sh", "-c",
-                                "wl-copy < \"" + root.previewEntry.savedPath.replace(/"/g, "\\\"") + "\""])
+                            DMSService.sendRequest("clipboard.copyFile", { "filePath": root.previewEntry.savedPath })
                             ToastService.showInfo(I18n.tr("Image copied to clipboard"))
                         }
                     }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -298,54 +298,56 @@ Item {
                 onTriggered: parent._previewCopied = false
             }
 
-            DankButton {
+            Row {
+                anchors.horizontalCenter: parent.horizontalCenter
                 anchors.bottom: parent.bottom
-                anchors.left: parent.left
-                anchors.margins: 8
-                iconName: "open_in_new"
-                text: I18n.tr("Open")
-                buttonHeight: 36
-                horizontalPadding: 16
-                backgroundColor: Theme.withAlpha(Theme.surfaceContainerHigh, 0.9)
-                textColor: Theme.surfaceText
-                onClicked: {
-                    if (root.previewEntry)
-                        Proc.runCommand("open-preview", ["xdg-open", root.previewEntry.savedPath])
-                }
-            }
+                anchors.bottomMargin: 12
+                spacing: 8
 
-            DankButton {
-                anchors.bottom: parent.bottom
-                anchors.right: parent.right
-                anchors.margins: 8
-                iconName: parent._previewCopied ? "check" : "content_copy"
-                text: parent._previewCopied ? I18n.tr("Copied") : I18n.tr("Copy")
-                buttonHeight: 36
-                horizontalPadding: 16
-                backgroundColor: parent._previewCopied
-                    ? Qt.rgba(0.3, 0.7, 0.3, 0.9)
-                    : Theme.withAlpha(Theme.primary, 0.9)
-                textColor: parent._previewCopied ? "white" : Theme.onPrimary
-                onClicked: {
-                    if (root.previewEntry) {
-                        parent._previewCopied = true
-                        Proc.runCommand("copy-preview", ["sh", "-c",
-                            "wl-copy < \"" + root.previewEntry.savedPath.replace(/"/g, "\\\"") + "\""])
-                        ToastService.showInfo(I18n.tr("Image copied to clipboard"))
+                DankButton {
+                    iconName: "open_in_new"
+                    text: I18n.tr("Open")
+                    buttonHeight: 36
+                    horizontalPadding: 16
+                    backgroundColor: Theme.withAlpha(Theme.surfaceContainerHigh, 0.9)
+                    textColor: Theme.surfaceText
+                    onClicked: {
+                        if (root.previewEntry)
+                            Proc.runCommand("open-preview", ["xdg-open", root.previewEntry.savedPath])
+                    }
+                }
+
+                DankButton {
+                    iconName: parent._previewCopied ? "check" : "content_copy"
+                    text: parent._previewCopied ? I18n.tr("Copied") : I18n.tr("Copy")
+                    buttonHeight: 36
+                    horizontalPadding: 16
+                    backgroundColor: parent._previewCopied
+                        ? Qt.rgba(0.3, 0.7, 0.3, 0.9)
+                        : Theme.withAlpha(Theme.primary, 0.9)
+                    textColor: parent._previewCopied ? "white" : Theme.onPrimary
+                    onClicked: {
+                        if (root.previewEntry) {
+                            parent._previewCopied = true
+                            Proc.runCommand("copy-preview", ["sh", "-c",
+                                "wl-copy < \"" + root.previewEntry.savedPath.replace(/"/g, "\\\"") + "\""])
+                            ToastService.showInfo(I18n.tr("Image copied to clipboard"))
+                        }
                     }
                 }
             }
 
-            DankButton {
+            DankActionButton {
                 anchors.top: parent.top
                 anchors.right: parent.right
                 anchors.margins: 8
                 iconName: "delete"
-                text: I18n.tr("Delete")
-                buttonHeight: 36
-                horizontalPadding: 16
-                backgroundColor: Qt.rgba(1, 0, 0, 0.3)
-                textColor: "#ff6b6b"
+                iconSize: 18
+                buttonSize: 32
+                radius: height / 2
+                backgroundColor: Qt.rgba(1, 0, 0, 0.25)
+                iconColor: "#ff6b6b"
+                tooltipText: I18n.tr("Delete")
                 onClicked: {
                     if (root.previewEntry) {
                         var delPath = root.previewEntry.savedPath

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -202,7 +202,7 @@ Item {
                                     onClicked: {
                                         parent._copied = true
                                         Proc.runCommand("copy-card", ["sh", "-c",
-                                            "dms cl copy \"" + modelData.savedPath.replace(/"/g, "\\\"") + "\""])
+                                            "wl-copy < \"" + modelData.savedPath.replace(/"/g, "\\\"") + "\""])
                                         ToastService.showInfo(I18n.tr("Image copied to clipboard"))
                                     }
 
@@ -298,59 +298,61 @@ Item {
                 onTriggered: parent._previewCopied = false
             }
 
-            Row {
-                anchors.horizontalCenter: parent.horizontalCenter
+            DankButton {
                 anchors.bottom: parent.bottom
-                anchors.bottomMargin: 12
-                spacing: 8
+                anchors.left: parent.left
+                anchors.margins: 8
+                iconName: "open_in_new"
+                text: I18n.tr("Open")
+                buttonHeight: 36
+                horizontalPadding: 16
+                backgroundColor: Theme.withAlpha(Theme.surfaceContainerHigh, 0.9)
+                textColor: Theme.surfaceText
+                onClicked: {
+                    if (root.previewEntry)
+                        Proc.runCommand("open-preview", ["xdg-open", root.previewEntry.savedPath])
+                }
+            }
 
-                DankButton {
-                    iconName: parent._previewCopied ? "check" : "content_copy"
-                    text: parent._previewCopied ? I18n.tr("Copied") : I18n.tr("Copy")
-                    buttonHeight: 36
-                    horizontalPadding: 16
-                    backgroundColor: parent._previewCopied
-                        ? Qt.rgba(0.3, 0.7, 0.3, 0.9)
-                        : Theme.withAlpha(Theme.primary, 0.9)
-                    textColor: parent._previewCopied ? "white" : Theme.onPrimary
-                    onClicked: {
-                        if (root.previewEntry) {
-                            parent._previewCopied = true
-                            Proc.runCommand("copy-preview", ["sh", "-c",
-                                "dms cl copy \"" + root.previewEntry.savedPath.replace(/"/g, "\\\"") + "\""])
-                            ToastService.showInfo(I18n.tr("Image copied to clipboard"))
-                        }
+            DankButton {
+                anchors.bottom: parent.bottom
+                anchors.right: parent.right
+                anchors.margins: 8
+                iconName: parent._previewCopied ? "check" : "content_copy"
+                text: parent._previewCopied ? I18n.tr("Copied") : I18n.tr("Copy")
+                buttonHeight: 36
+                horizontalPadding: 16
+                backgroundColor: parent._previewCopied
+                    ? Qt.rgba(0.3, 0.7, 0.3, 0.9)
+                    : Theme.withAlpha(Theme.primary, 0.9)
+                textColor: parent._previewCopied ? "white" : Theme.onPrimary
+                onClicked: {
+                    if (root.previewEntry) {
+                        parent._previewCopied = true
+                        Proc.runCommand("copy-preview", ["sh", "-c",
+                            "wl-copy < \"" + root.previewEntry.savedPath.replace(/"/g, "\\\"") + "\""])
+                        ToastService.showInfo(I18n.tr("Image copied to clipboard"))
                     }
                 }
+            }
 
-                DankButton {
-                    iconName: "open_in_new"
-                    text: I18n.tr("Open")
-                    buttonHeight: 36
-                    horizontalPadding: 16
-                    backgroundColor: Theme.withAlpha(Theme.surfaceContainerHigh, 0.9)
-                    textColor: Theme.surfaceText
-                    onClicked: {
-                        if (root.previewEntry)
-                            Proc.runCommand("open-preview", ["xdg-open", root.previewEntry.savedPath])
-                    }
-                }
-
-                DankButton {
-                    iconName: "delete"
-                    text: I18n.tr("Delete")
-                    buttonHeight: 36
-                    horizontalPadding: 16
-                    backgroundColor: Qt.rgba(1, 0, 0, 0.3)
-                    textColor: "#ff6b6b"
-                    onClicked: {
-                        if (root.previewEntry) {
-                            var delPath = root.previewEntry.savedPath
-                            root.previewIndex = -1
-                            Proc.runCommand("delete-preview", ["rm", "-f", delPath], function() {
-                                root.refresh()
-                            })
-                        }
+            DankButton {
+                anchors.top: parent.top
+                anchors.right: parent.right
+                anchors.margins: 8
+                iconName: "delete"
+                text: I18n.tr("Delete")
+                buttonHeight: 36
+                horizontalPadding: 16
+                backgroundColor: Qt.rgba(1, 0, 0, 0.3)
+                textColor: "#ff6b6b"
+                onClicked: {
+                    if (root.previewEntry) {
+                        var delPath = root.previewEntry.savedPath
+                        root.previewIndex = -1
+                        Proc.runCommand("delete-preview", ["rm", "-f", delPath], function() {
+                            root.refresh()
+                        })
                     }
                 }
             }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -115,7 +115,7 @@ Item {
                     Row {
                         spacing: 10
                         height: parent.height
-                        x: -root.currentPage * (carouselView.cardW * root.itemsPerPage + 10 * (root.itemsPerPage - 1))
+                        x: -root.currentPage * root.itemsPerPage * (carouselView.cardW + 10)
 
                         Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
 

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -146,57 +146,57 @@ Item {
                                         fillMode: Image.PreserveAspectFit
                                         asynchronous: true
                                     }
+                                }
 
-                                    HoverHandler { id: cardHover }
+                                HoverHandler { id: cardHover }
 
-                                    MouseArea {
-                                        anchors.fill: parent
-                                        cursorShape: Qt.PointingHandCursor
-                                        onClicked: root.previewIndex = modelData._glIdx
-                                    }
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: root.previewIndex = modelData._glIdx
+                                }
 
-                                    DankActionButton {
-                                        anchors.top: parent.top
-                                        anchors.right: parent.right
-                                        anchors.margins: 6
-                                        z: 1
-                                        iconName: "open_in_new"
-                                        iconSize: 18
-                                        buttonSize: 36
-                                        backgroundColor: Qt.rgba(0, 0, 0, 0.55)
-                                        iconColor: "white"
-                                        visible: cardHover.hovered
-                                        tooltipText: I18n.tr("Open")
-                                        onClicked: Proc.runCommand("open-card", ["xdg-open", modelData.savedPath])
-                                    }
+                                property bool _copied: false
 
-                                    property bool _copied: false
+                                Timer {
+                                    interval: 1500
+                                    repeat: false
+                                    running: parent._copied
+                                    onTriggered: parent._copied = false
+                                }
 
-                                    Timer {
-                                        interval: 1500
-                                        repeat: false
-                                        running: parent._copied
-                                        onTriggered: parent._copied = false
-                                    }
+                                DankActionButton {
+                                    anchors.top: parent.top
+                                    anchors.right: parent.right
+                                    anchors.margins: 6
+                                    z: 1
+                                    iconName: "open_in_new"
+                                    iconSize: 18
+                                    buttonSize: 36
+                                    backgroundColor: Qt.rgba(0, 0, 0, 0.55)
+                                    iconColor: "white"
+                                    visible: cardHover.hovered
+                                    tooltipText: I18n.tr("Open")
+                                    onClicked: Proc.runCommand("open-card", ["xdg-open", modelData.savedPath])
+                                }
 
-                                    DankActionButton {
-                                        anchors.bottom: parent.bottom
-                                        anchors.right: parent.right
-                                        anchors.margins: 6
-                                        z: 1
-                                        iconName: parent._copied ? "check" : "content_copy"
-                                        iconSize: 18
-                                        buttonSize: 36
-                                        backgroundColor: Qt.rgba(0, 0, 0, 0.55)
-                                        iconColor: parent._copied ? "#4caf50" : "white"
-                                        visible: cardHover.hovered
-                                        tooltipText: parent._copied ? I18n.tr("Copied") : I18n.tr("Copy")
-                                        onClicked: {
-                                            parent._copied = true
-                                            Proc.runCommand("copy-card", ["sh", "-c",
-                                                "dms cl copy \"" + modelData.savedPath.replace(/"/g, "\\\"") + "\""])
-                                            ToastService.showInfo(I18n.tr("Image copied to clipboard"))
-                                        }
+                                DankActionButton {
+                                    anchors.bottom: parent.bottom
+                                    anchors.right: parent.right
+                                    anchors.margins: 6
+                                    z: 1
+                                    iconName: parent._copied ? "check" : "content_copy"
+                                    iconSize: 18
+                                    buttonSize: 36
+                                    backgroundColor: Qt.rgba(0, 0, 0, 0.55)
+                                    iconColor: parent._copied ? "#4caf50" : "white"
+                                    visible: cardHover.hovered
+                                    tooltipText: parent._copied ? I18n.tr("Copied") : I18n.tr("Copy")
+                                    onClicked: {
+                                        parent._copied = true
+                                        Proc.runCommand("copy-card", ["sh", "-c",
+                                            "dms cl copy \"" + modelData.savedPath.replace(/"/g, "\\\"") + "\""])
+                                        ToastService.showInfo(I18n.tr("Image copied to clipboard"))
                                     }
                                 }
                             }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -75,7 +75,8 @@ Item {
 
             StyledText {
                 anchors.centerIn: parent
-                text: root.previewIndex >= 0 ? I18n.tr("Preview") : (root.daemon ? root.daemon.pluginData.saveDirectory : I18n.tr("Recent Edits"))
+                text: root.previewIndex >= 0 ? I18n.tr("Preview") : 
+                     (root.daemon && root.daemon.pluginData ? root.daemon.pluginData.saveDirectory || "~/Pictures/Screenshots" : I18n.tr("Recent Edits"))
                 font.pixelSize: Theme.fontSizeNormal
                 font.bold: true
                 color: Theme.surfaceText

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -49,7 +49,7 @@ Item {
         })
     }
 
-    Component.onCompleted: refresh()
+    onDaemonChanged: { if (root.daemon && root.daemon.pluginData) refresh() }
 
     Column {
         anchors.fill: parent

--- a/translations/en.json
+++ b/translations/en.json
@@ -58,5 +58,13 @@
   "Thickness": "Thickness",
   "Tool": "Tool",
   "Underline": "Underline",
-  "Window capture mode is only supported on Hyprland or DWL.": "Window capture mode is only supported on Hyprland or DWL."
+  "Window capture mode is only supported on Hyprland or DWL.": "Window capture mode is only supported on Hyprland or DWL.",
+  "Preview": "Preview",
+  "Recent Edits": "Recent Edits",
+  "No saved images yet": "No saved images yet",
+  "Open": "Open",
+  "Copy": "Copy",
+  "Copied": "Copied",
+  "Image copied to clipboard": "Image copied to clipboard",
+  "Delete": "Delete"
 }


### PR DESCRIPTION
## Summary

- **New `RecentEditsCarousel.qml`**: Image browser modal that shows the last 50 screenshots from `saveDirectory`
- Paginated carousel (4 per page) with thumbnail hover buttons (Open/Copy)
- Full-size preview mode with navigation (◀ ▶), Open/Copy/Delete actions
- Copy uses `DMSService.clipboard.copyFile` to copy actual image data
- **Widget**: "history" icon button in popout header opens the carousel
- **Shortcuts**: Left/A (prev), Right/D (next), Escape (back) work in both carousel and preview
- **UI**: Circular action buttons with scale+fade hover animations, Open+Copy bottom bar, Delete icon top-right

## Files
- `components/RecentEditsCarousel.qml` — new (413 lines)
- `QuickCaptureDaemon.qml` — added DankModal with Component content
- `QuickCaptureWidget.qml` — history button, popoutWidth 250
- `translations/en.json` — 10 new entries

## Summary by Sourcery

Add a history carousel modal to browse and manage recent screenshot edits from the quick-capture plugin.

New Features:
- Introduce RecentEditsCarousel component for browsing up to 50 recent screenshots with paginated thumbnails and full-size preview.
- Add a history icon button to the quick-capture widget header to open the recent edits carousel modal.
- Provide keyboard shortcuts for carousel and preview navigation (Left/A, Right/D, Escape).

Enhancements:
- Adjust quick-capture popout width to better accommodate the new header actions and history entry.
- Integrate a centered DankModal in the daemon to host the recent edits carousel with responsive sizing based on the target screen.