### PR TITLE
Feat: Scale modal to screen shot size

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -960,13 +960,15 @@ DankModal {
     // Chrome = boardContainer margins plus the edge the toolbar occupies (56px rail + its margin)
     readonly property real _chromeW: Theme.spacingM * 2 + (window.toolbarVisible && !_toolbarHorizontal ? 56 + Theme.spacingM : 0)
     readonly property real _chromeH: Theme.spacingM * 2 + (window.toolbarVisible && _toolbarHorizontal ? 56 + Theme.spacingM : 0)
-    readonly property real _minModalW: (_toolbarHorizontal && window.toolbarItem) ? window.toolbarItem.width + Theme.spacingM * 2 : 400
-    readonly property real _minModalH: (!_toolbarHorizontal && window.toolbarItem) ? window.toolbarItem.height + Theme.spacingM * 2 : 300
-    readonly property bool _bgSizeKnown: window.bgImageItem !== null && window.bgImageItem.status === Image.Ready && window.bgImageItem.sourceSize.width > 0
+    readonly property real _minModalW: _toolbarHorizontal && window.toolbarItem?.width ? window.toolbarItem.width + Theme.spacingM * 2 : 400
+    readonly property real _minModalH: !_toolbarHorizontal && window.toolbarItem?.height ? window.toolbarItem.height + Theme.spacingM * 2 : 300
+    readonly property bool _bgSizeKnown: window.bgImageItem?.status === Image.Ready
+                                         && (window.bgImageItem?.sourceSize.width ?? 0) > 0
+                                         && (window.bgImageItem?.sourceSize.height ?? 0) > 0
     // Compositor scale (not Screen.devicePixelRatio, which reports the integer buffer scale)
     readonly property real _outputScale: (window.targetScreen && CompositorService.getScreenScale(window.targetScreen)) || 1
-    modalWidth: _bgSizeKnown ? Math.round(Math.min(_maxModalW, Math.max(_minModalW, window.bgImageItem.sourceSize.width / _outputScale + _chromeW))) : _maxModalW
-    modalHeight: _bgSizeKnown ? Math.round(Math.min(_maxModalH, Math.max(_minModalH, window.bgImageItem.sourceSize.height / _outputScale + _chromeH))) : _maxModalH
+    modalWidth: _bgSizeKnown ? Math.round(Math.min(_maxModalW, Math.max(_minModalW, (window.bgImageItem?.sourceSize.width ?? 0) / _outputScale + _chromeW))) : _maxModalW
+    modalHeight: _bgSizeKnown ? Math.round(Math.min(_maxModalH, Math.max(_minModalH, (window.bgImageItem?.sourceSize.height ?? 0) / _outputScale + _chromeH))) : _maxModalH
     enableShadow: true
     positioning: "center"
 

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -950,11 +950,23 @@ DankModal {
 
     shouldBeVisible: false
     
-    // Spacious modal dimensions occupying 90% width and 90% height of the screen
+    // Modal sized to the screenshot (logical px), clamped between the toolbar's
+    // footprint and 90% of the screen; falls back to 90% until the image loads
     readonly property real _screenW: window.targetScreen ? window.targetScreen.width : (Quickshell.screens[0] ? Quickshell.screens[0].width : 1920)
     readonly property real _screenH: window.targetScreen ? window.targetScreen.height : (Quickshell.screens[0] ? Quickshell.screens[0].height : 1080)
-    modalWidth: Math.round((config.modalAspectRatio === "portrait" ? Math.min(_screenW, _screenH) : Math.max(_screenW, _screenH)) * 0.9)
-    modalHeight: Math.round((config.modalAspectRatio === "portrait" ? Math.max(_screenW, _screenH) : Math.min(_screenW, _screenH)) * 0.9)
+    readonly property real _maxModalW: Math.round((config.modalAspectRatio === "portrait" ? Math.min(_screenW, _screenH) : Math.max(_screenW, _screenH)) * 0.9)
+    readonly property real _maxModalH: Math.round((config.modalAspectRatio === "portrait" ? Math.max(_screenW, _screenH) : Math.min(_screenW, _screenH)) * 0.9)
+    readonly property bool _toolbarHorizontal: window.toolbarPosition === "top" || window.toolbarPosition === "bottom"
+    // Chrome = boardContainer margins plus the edge the toolbar occupies (56px rail + its margin)
+    readonly property real _chromeW: Theme.spacingM * 2 + (window.toolbarVisible && !_toolbarHorizontal ? 56 + Theme.spacingM : 0)
+    readonly property real _chromeH: Theme.spacingM * 2 + (window.toolbarVisible && _toolbarHorizontal ? 56 + Theme.spacingM : 0)
+    readonly property real _minModalW: (_toolbarHorizontal && window.toolbarItem) ? window.toolbarItem.width + Theme.spacingM * 2 : 400
+    readonly property real _minModalH: (!_toolbarHorizontal && window.toolbarItem) ? window.toolbarItem.height + Theme.spacingM * 2 : 300
+    readonly property bool _bgSizeKnown: window.bgImageItem !== null && window.bgImageItem.status === Image.Ready && window.bgImageItem.sourceSize.width > 0
+    // Compositor scale (not Screen.devicePixelRatio, which reports the integer buffer scale)
+    readonly property real _outputScale: (window.targetScreen && CompositorService.getScreenScale(window.targetScreen)) || 1
+    modalWidth: _bgSizeKnown ? Math.round(Math.min(_maxModalW, Math.max(_minModalW, window.bgImageItem.sourceSize.width / _outputScale + _chromeW))) : _maxModalW
+    modalHeight: _bgSizeKnown ? Math.round(Math.min(_maxModalH, Math.max(_minModalH, window.bgImageItem.sourceSize.height / _outputScale + _chromeH))) : _maxModalH
     enableShadow: true
     positioning: "center"
 

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -967,8 +967,9 @@ DankModal {
                                          && (window.bgImageItem?.sourceSize.height ?? 0) > 0
     // Compositor scale (not Screen.devicePixelRatio, which reports the integer buffer scale)
     readonly property real _outputScale: (window.targetScreen && CompositorService.getScreenScale(window.targetScreen)) || 1
-    modalWidth: _bgSizeKnown ? Math.round(Math.min(_maxModalW, Math.max(_minModalW, (window.bgImageItem?.sourceSize.width ?? 0) / _outputScale + _chromeW))) : _maxModalW
-    modalHeight: _bgSizeKnown ? Math.round(Math.min(_maxModalH, Math.max(_minModalH, (window.bgImageItem?.sourceSize.height ?? 0) / _outputScale + _chromeH))) : _maxModalH
+    readonly property bool _shouldScale: window.parentWidget?.pluginData?.modalScaleToContent ?? false
+    modalWidth: _shouldScale && _bgSizeKnown ? Math.round(Math.min(_maxModalW, Math.max(_minModalW, (window.bgImageItem?.sourceSize.width ?? 0) / _outputScale + _chromeW))) : _maxModalW
+    modalHeight: _shouldScale && _bgSizeKnown ? Math.round(Math.min(_maxModalH, Math.max(_minModalH, (window.bgImageItem?.sourceSize.height ?? 0) / _outputScale + _chromeH))) : _maxModalH
     enableShadow: true
     positioning: "center"
 

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -1125,13 +1125,14 @@ PluginSettings {
         SectionTitle {
             text: I18n.tr("Editor")
             icon: "aspect_ratio"
-            showReset: overlayOpacity.isDirty || showCanvasBorder.isDirty || editQuality.isDirty || modalDisplayTarget.isDirty || modalAspectRatio.isDirty
+            showReset: overlayOpacity.isDirty || showCanvasBorder.isDirty || editQuality.isDirty || modalDisplayTarget.isDirty || modalAspectRatio.isDirty || scaleToContent.isDirty
             onResetClicked: {
                 overlayOpacity.resetToDefault();
                 showCanvasBorder.resetToDefault();
                 editQuality.resetToDefault();
                 modalDisplayTarget.resetToDefault();
                 modalAspectRatio.resetToDefault();
+                scaleToContent.resetToDefault();
             }
         }
 
@@ -1215,6 +1216,16 @@ PluginSettings {
         InfoText {
             text: I18n.tr("Lower the resolution limit if you experience lag while editing.")
             opacity: 0.8
+        }
+
+        Separator {}
+
+        ToggleSettingPlus {
+            id: scaleToContent
+            settingKey: "modalScaleToContent"
+            label: I18n.tr("Scale Editor to Screenshot Size")
+            description: I18n.tr("When enabled, the editor shrinks to match the captured region instead of filling 90% of the screen.")
+            defaultValue: false
         }
     }
 
@@ -3290,7 +3301,8 @@ PluginSettings {
             "toolbar_color_3": c3.value,
             "toolbar_color_4": c4.value,
             "toolbar_color_5": c5.value,
-            "toolbar_color_6": c6.value
+            "toolbar_color_6": c6.value,
+            "modalScaleToContent": scaleToContent.value
         }
     }
 


### PR DESCRIPTION
The editor modal now opens at the captured image's on-screen size (sourceSize divided by the compositor scale, plus toolbar/margin so small region captures get a compact editor instead of being blown up to fill the screen. The size is hard-clamped to the previous 90%-of-screen maximum (still honoring the portrait/landscape setting), so full-screen captures behave exactly as before, and floored to the toolbar's footprint so the tools always fit.

Uses CompositorService.getScreenScale() rather than Screen.devicePixelRatio, which reports the integer buffer scale (2) on fractional-scale outputs (1.25) and would shrink the image.

## Summary by Sourcery

Scale the quick capture modal to match the captured image’s on-screen size while preserving the previous 90%-of-screen maximum.

New Features:
- Size the editor modal based on the screenshot’s logical dimensions and compositor output scale instead of always using a fixed 90% of screen.

Enhancements:
- Clamp modal size between the toolbar’s minimum footprint and the existing 90%-of-screen limit, ensuring tools remain visible for very small captures.