### PR TITLE
feat: showHistory IPC, optimistic delete, backdrop blur fix, injection fix

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -260,6 +260,11 @@ PluginComponent {
             return "SUCCESS";
         }
 
+        function showHistory() : string {
+            root.showHistoryCarousel();
+            return "SUCCESS";
+        }
+
         target: "quickCapture"
         enabled: true
     }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -357,7 +357,7 @@ DankModal {
     readonly property real editScale: {
         if (!window.bgImageItem) return 1.0;
         // When backdrop is active, render at screen resolution for sharp preview
-        if (window.effectiveBackdropMode !== "none") return window.fitScale;
+        if (window.effectiveBackdropMode !== "none") return Math.max(1e-3, window.fitScale);
         const w = window.bgImageItem.sourceSize.width;
         const h = window.bgImageItem.sourceSize.height;
         const max = Math.max(w, h);

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2160,7 +2160,8 @@ DankModal {
                         scale: drawingCanvas.scale
                         transformOrigin: drawingCanvas.transformOrigin
                         clip: true
-                        visible: window.effectiveBackdropMode === "none"
+                        visible: true
+                        z: window.effectiveBackdropMode !== "none" ? 1.5 : 0
 
                         Image {
                             id: staticBgImage
@@ -2168,14 +2169,25 @@ DankModal {
                             cache: false
                             smooth: true
                             mipmap: true
-                            
-                            // Handle crop positioning
-                            x: window.hasActiveCropSelection ? -window.cropRect.x * window.editScale : 0
-                            y: window.hasActiveCropSelection ? -window.cropRect.y * window.editScale : 0
-                            
-                            // Scale to original size if cropped, otherwise fit to canvas
-                            width: window.hasActiveCropSelection ? window.bgImageItem.sourceSize.width * window.editScale : parent.width
-                            height: window.hasActiveCropSelection ? window.bgImageItem.sourceSize.height * window.editScale : parent.height
+
+                            // Handle crop + backdrop positioning
+                            x: ((window.effectiveBackdropMode !== "none" ? window.screenshotXOffset : 0)
+                                - (window.hasActiveCropSelection ? window.cropRect.x : 0))
+                               * window.editScale
+                            y: ((window.effectiveBackdropMode !== "none" ? window.screenshotYOffset : 0)
+                                - (window.hasActiveCropSelection ? window.cropRect.y : 0))
+                               * window.editScale
+
+                            width: window.hasActiveCropSelection
+                                ? window.bgImageItem.sourceSize.width * window.editScale
+                                : (window.effectiveBackdropMode !== "none"
+                                    ? window.screenshotWidth * window.editScale
+                                    : parent.width)
+                            height: window.hasActiveCropSelection
+                                ? window.bgImageItem.sourceSize.height * window.editScale
+                                : (window.effectiveBackdropMode !== "none"
+                                    ? window.screenshotHeight * window.editScale
+                                    : parent.height)
                         }
                     }
 
@@ -2211,7 +2223,7 @@ DankModal {
                             if (isBackdropActive) {
                                 window.drawBackdropBackground(ctx, window.canvasWidth, window.canvasHeight);
                                 window.drawScreenshotShadow(ctx);
-                                window.drawScreenshotImage(ctx, bgImage);
+                                // Screenshot drawn by hardware Image layer (bgImageLayer) — skip to keep sharp
                             } else if (window.currentTool === "colorpicker") {
                                 if (bgImage.status === Image.Ready) {
                                     if (window.hasSelection) {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -356,6 +356,8 @@ DankModal {
     }
     readonly property real editScale: {
         if (!window.bgImageItem) return 1.0;
+        // When backdrop is active, render at screen resolution for sharp preview
+        if (window.effectiveBackdropMode !== "none") return window.fitScale;
         const w = window.bgImageItem.sourceSize.width;
         const h = window.bgImageItem.sourceSize.height;
         const max = Math.max(w, h);
@@ -2160,8 +2162,7 @@ DankModal {
                         scale: drawingCanvas.scale
                         transformOrigin: drawingCanvas.transformOrigin
                         clip: true
-                        visible: true
-                        z: window.effectiveBackdropMode !== "none" ? 1.5 : 0
+                        visible: window.effectiveBackdropMode === "none"
 
                         Image {
                             id: staticBgImage
@@ -2170,24 +2171,13 @@ DankModal {
                             smooth: true
                             mipmap: true
 
-                            // Handle crop + backdrop positioning
-                            x: ((window.effectiveBackdropMode !== "none" ? window.screenshotXOffset : 0)
-                                - (window.hasActiveCropSelection ? window.cropRect.x : 0))
-                               * window.editScale
-                            y: ((window.effectiveBackdropMode !== "none" ? window.screenshotYOffset : 0)
-                                - (window.hasActiveCropSelection ? window.cropRect.y : 0))
-                               * window.editScale
+                            // Handle crop positioning
+                            x: window.hasActiveCropSelection ? -window.cropRect.x * window.editScale : 0
+                            y: window.hasActiveCropSelection ? -window.cropRect.y * window.editScale : 0
 
-                            width: window.hasActiveCropSelection
-                                ? window.bgImageItem.sourceSize.width * window.editScale
-                                : (window.effectiveBackdropMode !== "none"
-                                    ? window.screenshotWidth * window.editScale
-                                    : parent.width)
-                            height: window.hasActiveCropSelection
-                                ? window.bgImageItem.sourceSize.height * window.editScale
-                                : (window.effectiveBackdropMode !== "none"
-                                    ? window.screenshotHeight * window.editScale
-                                    : parent.height)
+                            // Scale to original size if cropped, otherwise fit to canvas
+                            width: window.hasActiveCropSelection ? window.bgImageItem.sourceSize.width * window.editScale : parent.width
+                            height: window.hasActiveCropSelection ? window.bgImageItem.sourceSize.height * window.editScale : parent.height
                         }
                     }
 
@@ -2223,7 +2213,7 @@ DankModal {
                             if (isBackdropActive) {
                                 window.drawBackdropBackground(ctx, window.canvasWidth, window.canvasHeight);
                                 window.drawScreenshotShadow(ctx);
-                                // Screenshot drawn by hardware Image layer (bgImageLayer) — skip to keep sharp
+                                window.drawScreenshotImage(ctx, bgImage);
                             } else if (window.currentTool === "colorpicker") {
                                 if (bgImage.status === Image.Ready) {
                                     if (window.hasSelection) {

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -3261,6 +3261,11 @@ PluginSettings {
                 text: "dms ipc call quickCapture close"
             }
 
+            CopyBox {
+                label: I18n.tr("Show Recent Edits History")
+                text: "dms ipc call quickCapture showHistory"
+            }
+
             Separator { opacity: 0.1 }
 
             CopyBox {

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ git checkout main && git pull
 
 ## IPC Commands
 
-Each command accepts an `action` parameter — use `edit` to open the editor or `float` to spawn an always-on-top window.
+Commands that capture or open images accept an `action` parameter — use `edit` to open the editor or `float` to spawn an always-on-top window.
 
 ```bash
 dms ipc call quickCapture <command> [arg] edit|float
@@ -162,6 +162,7 @@ dms ipc call quickCapture screenshot region float  # float directly
 | `fromClipboard` | — | Annotate image from clipboard |
 | `openImage` | `path` | Open a specific image in the annotator |
 | `close` | — | Close the annotator window |
+| `showHistory` | — | Open Recent Edits history carousel |
 
 ### Keybinding Examples (Niri)
 

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -50,11 +50,10 @@ Item {
 
     onDaemonChanged: { if (root.daemon && root.daemon.pluginData) refresh() }
 
-    function removeEntryAndRefresh(path) {
+    function removeEntry(path) {
         root.entries = root.entries.filter(function(e) { return e.savedPath !== path })
         if (root.previewIndex >= root.entries.length)
             root.previewIndex = root.entries.length - 1
-        root.refresh()
     }
 
     Column {
@@ -245,8 +244,9 @@ Item {
                                         if (root.previewIndex === modelData._glIdx)
                                             root.previewIndex = -1
                                         var delPath = modelData.savedPath
-                                        Proc.runCommand("delete-card", ["rm", "-f", delPath], function() {
-                                            root.removeEntryAndRefresh(delPath)
+                                        root.removeEntry(delPath)
+                                        Proc.runCommand("delete-card", ["rm", "-f", "--", delPath], function() {
+                                            root.refresh()
                                         })
                                     }
 
@@ -388,8 +388,9 @@ Item {
                     if (root.previewEntry) {
                         var delPath = root.previewEntry.savedPath
                         root.previewIndex = -1
-                        Proc.runCommand("delete-preview", ["rm", "-f", delPath], function() {
-                            root.removeEntryAndRefresh(delPath)
+                        root.removeEntry(delPath)
+                        Proc.runCommand("delete-preview", ["rm", "-f", "--", delPath], function() {
+                            root.refresh()
                         })
                     }
                 }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -50,6 +50,13 @@ Item {
 
     onDaemonChanged: { if (root.daemon && root.daemon.pluginData) refresh() }
 
+    function removeEntryAndRefresh(path) {
+        root.entries = root.entries.filter(function(e) { return e.savedPath !== path })
+        if (root.previewIndex >= root.entries.length)
+            root.previewIndex = root.entries.length - 1
+        root.refresh()
+    }
+
     Column {
         anchors.fill: parent
         spacing: 0
@@ -237,8 +244,9 @@ Item {
                                     onClicked: {
                                         if (root.previewIndex === modelData._glIdx)
                                             root.previewIndex = -1
-                                        Proc.runCommand("delete-card", ["rm", "-f", modelData.savedPath], function() {
-                                            root.refresh()
+                                        var delPath = modelData.savedPath
+                                        Proc.runCommand("delete-card", ["rm", "-f", delPath], function() {
+                                            root.removeEntryAndRefresh(delPath)
                                         })
                                     }
 
@@ -381,7 +389,7 @@ Item {
                         var delPath = root.previewEntry.savedPath
                         root.previewIndex = -1
                         Proc.runCommand("delete-preview", ["rm", "-f", delPath], function() {
-                            root.refresh()
+                            root.removeEntryAndRefresh(delPath)
                         })
                     }
                 }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -219,6 +219,31 @@ Item {
                                     Behavior on scale { NumberAnimation { duration: Theme.shorterDuration } }
                                     Behavior on opacity { NumberAnimation { duration: Theme.shorterDuration } }
                                 }
+
+                                DankActionButton {
+                                    anchors.top: parent.top
+                                    anchors.left: parent.left
+                                    anchors.margins: 6
+                                    z: 1
+                                    iconName: "delete"
+                                    iconSize: 16
+                                    buttonSize: 28
+                                    radius: height / 2
+                                    opacity: cardHover.hovered ? 1 : 0
+                                    enabled: cardHover.hovered
+                                    tooltipText: I18n.tr("Delete")
+                                    backgroundColor: Qt.rgba(1, 0, 0, 0.25)
+                                    iconColor: "#ff6b6b"
+                                    onClicked: {
+                                        if (root.previewIndex === modelData._glIdx)
+                                            root.previewIndex = -1
+                                        Proc.runCommand("delete-card", ["rm", "-f", modelData.savedPath], function() {
+                                            root.refresh()
+                                        })
+                                    }
+
+                                    Behavior on opacity { NumberAnimation { duration: Theme.shorterDuration } }
+                                }
                             }
                         }
                     }

--- a/components/RecentEditsCarousel.qml
+++ b/components/RecentEditsCarousel.qml
@@ -29,11 +29,10 @@ Item {
     function refresh() {
         if (!root.daemon || !root.daemon.pluginData) return
         var dir = root.daemon.pluginData.saveDirectory || "~/Pictures/Screenshots"
-        dir = String(dir).replace(/^~/, Quickshell.env("HOME"))
+        dir = String(dir).replace(/^~/, Quickshell.env("HOME") || "")
         var exts = ["png", "jpg", "jpeg", "webp"]
-        var globs = exts.map(function(e) { return "\"" + dir + "\"/*." + e }).join(" ")
-        var cmd = "for f in " + globs + "; do [ -f \"$f\" ] && echo \"$(stat -c '%Y' \"$f\" 2>/dev/null)|$f\"; done | sort -rn | head -50"
-        Proc.runCommand("scan-history", ["sh", "-c", cmd], function(stdout) {
+        var cmd = "d=\"$1\"; shift; for e in \"$@\"; do for f in \"$d\"/*.\"$e\"; do [ -f \"$f\" ] && echo \"$(stat -c '%Y' \"$f\" 2>/dev/null)|$f\"; done; done | sort -rn | head -50"
+        Proc.runCommand("scan-history", ["sh", "-c", cmd, "sh", dir].concat(exts), function(stdout) {
             var list = []
             var lines = stdout.trim().split("\n")
             for (var i = 0; i < lines.length; i++) {
@@ -144,7 +143,7 @@ Item {
                                         anchors.fill: parent
                                         anchors.margins: 4
                                         source: "file://" + modelData.savedPath
-                                        sourceSize.width: parent.width
+                                        sourceSize.width: 400
                                         fillMode: Image.PreserveAspectFit
                                         asynchronous: true
                                     }

--- a/docs/ipc-and-settings.md
+++ b/docs/ipc-and-settings.md
@@ -14,7 +14,7 @@ dms ipc call quickCapture <command> [arg] edit|float
 
 ### Supported Commands
 
-All commands accept an `action` parameter (`edit` / `float`) — use `float` to spawn an always-on-top window instead of the editor.
+Commands that capture or open images accept an `action` parameter (`edit` / `float`) — use `float` to spawn an always-on-top window instead of the editor.
 
 | Command | Arguments | Description |
 | :--- | :--- | :--- |
@@ -23,6 +23,7 @@ All commands accept an `action` parameter (`edit` / `float`) — use `float` to 
 | `fromClipboard` | `action` (`edit` / `float`) | Imports image from clipboard. |
 | `openImage` | `path`, `action` (`edit` / `float`) | Opens a local image file. |
 | `close` | *(none)* | Closes the annotator. |
+| `showHistory` | *(none)* | Opens the Recent Edits history carousel. |
 
 ```bash
 dms ipc call quickCapture screenshot region edit    # open editor


### PR DESCRIPTION
## Fixes

- **Backdrop preview blurry**: When backdrop active, `editScale = fitScale` (screen resolution) instead of edit quality limit (720px) -- preview stays sharp, export unaffected. Reverts hardware Image layer approach (had z-order annotations issue).
- **Delete delay**: Optimistic removal of entry from carousel list before filesystem refresh -- no visible delay after delete.
- **Command injection**: Pass `saveDirectory` as shell `$1` argument instead of string interpolation into glob patterns -- safe with special characters in path.
- **Performance**: Thumbnail `sourceSize.width: 400` instead of `parent.width` -- avoid re-decoding on resize.

## Features

- **IPC `showHistory`**: New command `dms ipc call quickCapture showHistory` to open Recent Edits carousel.
- **Delete from carousel**: Delete button (top-left, circular, red) on each carousel thumbnail -- deletes file and instantly removes entry from UI.
- **Delete from preview**: Delete icon-only button top-right in full-size preview -- uses same optimistic removal.

## Docs

- Updated IPC tables in `README.md` and `docs/ipc-and-settings.md` with `showHistory`.
- Updated action parameter description: not all commands accept `edit`/`float`.
- Added `showHistory` CopyBox in Settings IPC help section.

## Files Changed

| File | Change |
| :--- | :--- |
| `QuickCaptureDaemon.qml` | +`showHistory()` IPC handler |
| `QuickCaptureModal.qml` | `editScale = fitScale` when backdrop active |
| `components/RecentEditsCarousel.qml` | Delete button on carousel cards, optimistic delete, command injection fix, `sourceSize.width: 400` |
| `QuickCaptureSettings.qml` | Added `showHistory` CopyBox |
| `README.md` | IPC table updated |
| `docs/ipc-and-settings.md` | IPC table updated, action param note fixed |

## Summary by Sourcery

Add an IPC command to open the Recent Edits history carousel, improve deletion UX, and address image preview quality and shell command safety issues.

New Features:
- Introduce a `showHistory` IPC command to open the Recent Edits history carousel from external callers.
- Add a delete button to each Recent Edits carousel thumbnail for removing screenshots directly from the history view.

Bug Fixes:
- Ensure the edit preview uses screen-resolution scaling when a backdrop is active to avoid blurry previews.
- Harden the filesystem scan for recent edits by passing the save directory as a shell argument instead of interpolating it into glob patterns, preventing command injection and path edge cases.

Enhancements:
- Use a fixed thumbnail source width to avoid unnecessary image re-decoding on carousel resize.
- Apply optimistic removal of deleted entries from the carousel and preview to eliminate visible delay after deletion.

Documentation:
- Document the new `showHistory` IPC command in README and IPC docs, including updating the IPC command table and example usage.
- Clarify that only commands which capture or open images accept the `action` (`edit` / `float`) parameter in the IPC documentation.