### PR TITLE
feat: shift angle snap for selected line/arrow/highlighter endpoints

### DIFF
--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -118,34 +118,30 @@ MouseArea {
                         }
                     } else if (tool === "line" || tool === "arrow" || tool === "highlighter") {
                         const newPoints = [...window.selectedStroke.points];
+                        let targetIdx = -1;
+                        let fixedIdx = -1;
                         if (window.activeHandle === "start") {
-                            let newPt = Qt.point(orig[0].x + dx, orig[0].y + dy);
-                            if (mouse.modifiers & Qt.ShiftModifier) {
-                                const fixed = orig[orig.length - 1];
-                                const sdx = newPt.x - fixed.x;
-                                const sdy = newPt.y - fixed.y;
-                                const L = Math.sqrt(sdx * sdx + sdy * sdy);
-                                if (L > 0) {
-                                    const angle = Math.atan2(sdy, sdx);
-                                    const snapped = Math.round(angle / (Math.PI / 12)) * (Math.PI / 12);
-                                    newPt = Qt.point(fixed.x + L * Math.cos(snapped), fixed.y + L * Math.sin(snapped));
-                                }
-                            }
-                            newPoints[0] = newPt;
+                            targetIdx = 0;
+                            fixedIdx = orig.length - 1;
                         } else if (window.activeHandle === "end") {
-                            let newPt = Qt.point(orig[orig.length - 1].x + dx, orig[orig.length - 1].y + dy);
+                            targetIdx = orig.length - 1;
+                            fixedIdx = 0;
+                        }
+                        if (targetIdx !== -1) {
+                            let newPt = Qt.point(orig[targetIdx].x + dx, orig[targetIdx].y + dy);
                             if (mouse.modifiers & Qt.ShiftModifier) {
-                                const fixed = orig[0];
+                                const fixed = orig[fixedIdx];
                                 const sdx = newPt.x - fixed.x;
                                 const sdy = newPt.y - fixed.y;
                                 const L = Math.sqrt(sdx * sdx + sdy * sdy);
                                 if (L > 0) {
                                     const angle = Math.atan2(sdy, sdx);
-                                    const snapped = Math.round(angle / (Math.PI / 12)) * (Math.PI / 12);
+                                    const SNAP_STEP = Math.PI / 12;
+                                    const snapped = Math.round(angle / SNAP_STEP) * SNAP_STEP;
                                     newPt = Qt.point(fixed.x + L * Math.cos(snapped), fixed.y + L * Math.sin(snapped));
                                 }
                             }
-                            newPoints[newPoints.length - 1] = newPt;
+                            newPoints[targetIdx] = newPt;
                         }
                         window.selectedStroke.points = newPoints;
                     } else if (tool === "callout" && window.activeHandle && window.activeHandle.indexOf("src_") === 0 && orig.length === 4) {

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -60,6 +60,7 @@ MouseArea {
                 if (window.activeHandle === "none" && window.originalPoints.length > 0) {
                     const dx = absPt.x - window.pressCoords.x;
                     const dy = absPt.y - window.pressCoords.y;
+
                     if (window.selectedStroke.tool === "callout" && window.calloutDestDragging && window.originalPoints.length === 4) {
                         const newPoints = [...window.selectedStroke.points];
                         newPoints[2] = Qt.point(window.originalPoints[2].x + dx, window.originalPoints[2].y + dy);
@@ -118,9 +119,33 @@ MouseArea {
                     } else if (tool === "line" || tool === "arrow" || tool === "highlighter") {
                         const newPoints = [...window.selectedStroke.points];
                         if (window.activeHandle === "start") {
-                            newPoints[0] = Qt.point(orig[0].x + dx, orig[0].y + dy);
+                            let newPt = Qt.point(orig[0].x + dx, orig[0].y + dy);
+                            if (mouse.modifiers & Qt.ShiftModifier) {
+                                const fixed = orig[orig.length - 1];
+                                const sdx = newPt.x - fixed.x;
+                                const sdy = newPt.y - fixed.y;
+                                const L = Math.sqrt(sdx * sdx + sdy * sdy);
+                                if (L > 0) {
+                                    const angle = Math.atan2(sdy, sdx);
+                                    const snapped = Math.round(angle / (Math.PI / 12)) * (Math.PI / 12);
+                                    newPt = Qt.point(fixed.x + L * Math.cos(snapped), fixed.y + L * Math.sin(snapped));
+                                }
+                            }
+                            newPoints[0] = newPt;
                         } else if (window.activeHandle === "end") {
-                            newPoints[newPoints.length - 1] = Qt.point(orig[orig.length - 1].x + dx, orig[orig.length - 1].y + dy);
+                            let newPt = Qt.point(orig[orig.length - 1].x + dx, orig[orig.length - 1].y + dy);
+                            if (mouse.modifiers & Qt.ShiftModifier) {
+                                const fixed = orig[0];
+                                const sdx = newPt.x - fixed.x;
+                                const sdy = newPt.y - fixed.y;
+                                const L = Math.sqrt(sdx * sdx + sdy * sdy);
+                                if (L > 0) {
+                                    const angle = Math.atan2(sdy, sdx);
+                                    const snapped = Math.round(angle / (Math.PI / 12)) * (Math.PI / 12);
+                                    newPt = Qt.point(fixed.x + L * Math.cos(snapped), fixed.y + L * Math.sin(snapped));
+                                }
+                            }
+                            newPoints[newPoints.length - 1] = newPt;
                         }
                         window.selectedStroke.points = newPoints;
                     } else if (tool === "callout" && window.activeHandle && window.activeHandle.indexOf("src_") === 0 && orig.length === 4) {


### PR DESCRIPTION
## Summary

Add Shift constraint for selected line/arrow/highlighter endpoints — hold Shift while dragging a start/end handle to snap the angle to 15-degree increments.

### Changes

- **DrawMouseArea.qml**: When `selectedStroke` is line/arrow/highlighter and `activeHandle` is `start` or `end`, holding Shift snaps the endpoint to the nearest 15° (π/12) relative to the fixed endpoint. Same math as Shift during stroke creation (line 278–291).

### Scope

Only 2-point tools (line, arrow, highlighter). No move constraint, no shape aspect-ratio, no stamp, no callout.

## Summary by Sourcery

New Features:
- Allow snapping the angle of selected line, arrow, and highlighter endpoints to 15-degree increments while dragging with Shift held.