### PR TITLE
fix: blank editor canvas and stale export callback (#167)

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -962,16 +962,17 @@ DankModal {
     // Chrome = boardContainer margins plus the edge the toolbar occupies (56px rail + its margin)
     readonly property real _chromeW: Theme.spacingM * 2 + (window.toolbarVisible && !_toolbarHorizontal ? 56 + Theme.spacingM : 0)
     readonly property real _chromeH: Theme.spacingM * 2 + (window.toolbarVisible && _toolbarHorizontal ? 56 + Theme.spacingM : 0)
-    readonly property real _minModalW: _toolbarHorizontal && window.toolbarItem?.width ? window.toolbarItem.width + Theme.spacingM * 2 : 400
-    readonly property real _minModalH: !_toolbarHorizontal && window.toolbarItem?.height ? window.toolbarItem.height + Theme.spacingM * 2 : 300
-    readonly property bool _bgSizeKnown: window.bgImageItem?.status === Image.Ready
-                                         && (window.bgImageItem?.sourceSize.width ?? 0) > 0
-                                         && (window.bgImageItem?.sourceSize.height ?? 0) > 0
+    readonly property real _minModalW: _toolbarHorizontal && window.toolbarItem && window.toolbarItem.width ? window.toolbarItem.width + Theme.spacingM * 2 : 400
+    readonly property real _minModalH: !_toolbarHorizontal && window.toolbarItem && window.toolbarItem.height ? window.toolbarItem.height + Theme.spacingM * 2 : 300
+    readonly property bool _bgSizeKnown: window.bgImageItem !== null
+                                         && window.bgImageItem.status === Image.Ready
+                                         && window.bgImageItem.sourceSize.width > 0
+                                         && window.bgImageItem.sourceSize.height > 0
     // Compositor scale (not Screen.devicePixelRatio, which reports the integer buffer scale)
     readonly property real _outputScale: (window.targetScreen && CompositorService.getScreenScale(window.targetScreen)) || 1
-    readonly property bool _shouldScale: window.parentWidget?.pluginData?.modalScaleToContent ?? false
-    modalWidth: _shouldScale && _bgSizeKnown ? Math.round(Math.min(_maxModalW, Math.max(_minModalW, (window.bgImageItem?.sourceSize.width ?? 0) / _outputScale + _chromeW))) : _maxModalW
-    modalHeight: _shouldScale && _bgSizeKnown ? Math.round(Math.min(_maxModalH, Math.max(_minModalH, (window.bgImageItem?.sourceSize.height ?? 0) / _outputScale + _chromeH))) : _maxModalH
+    readonly property bool _shouldScale: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.modalScaleToContent ? window.parentWidget.pluginData.modalScaleToContent : false
+    modalWidth: _shouldScale && _bgSizeKnown ? Math.round(Math.min(_maxModalW, Math.max(_minModalW, window.bgImageItem.sourceSize.width / _outputScale + _chromeW))) : _maxModalW
+    modalHeight: _shouldScale && _bgSizeKnown ? Math.round(Math.min(_maxModalH, Math.max(_minModalH, window.bgImageItem.sourceSize.height / _outputScale + _chromeH))) : _maxModalH
     enableShadow: true
     positioning: "center"
 
@@ -1289,6 +1290,8 @@ DankModal {
         if (window.isTyping) {
             window.commitTypingText();
         }
+        // Clear any stale callback from a previous session that never completed
+        window.exportCallback = null;
         window.exportCallback = callback;
         if (!window.exportCanvasItem) {
             console.warn("exportCanvasItem is not initialized yet");
@@ -1751,7 +1754,8 @@ DankModal {
             window.bgImageSource = window.restoreSource;
         } else if (window.currentCapturePath) {
             window.bgImageSource = "file://" + window.currentCapturePath;
-            window.currentCapturePath = "";
+            // currentCapturePath is cleared in onDialogClosed to prevent losing it
+            // if this signal fires more than once during layout/screen changes
         }
         window.isScreenshotDark = false;
         window.hasSampledContrast = false;
@@ -1864,6 +1868,12 @@ DankModal {
                         if (window.activeCanvas) {
                             window.activeCanvas.unloadImage(source);
                             window.activeCanvas.loadImage(source);
+                        }
+                        // bakedCanvas must also call loadImage so its onImageLoaded fires
+                        // and triggers requestPaint — without this the background is never drawn
+                        if (window.bakedCanvas) {
+                            window.bakedCanvas.unloadImage(source);
+                            window.bakedCanvas.loadImage(source);
                         }
                         contrastSampler.requestPaint();
                         offscreenSampler.requestPaint();
@@ -3173,5 +3183,15 @@ DankModal {
         window.selectedStroke = null;
         window.copiedStroke = null;
         window.close();
+    }
+
+    onDialogClosed: {
+        // Reset path state only after modal is fully closed, not in onOpened.
+        // This prevents blank canvas if the opened signal fires multiple times
+        // (e.g. during screen/layout changes) which would re-clear the source.
+        window.currentCapturePath = "";
+        window.restoreSource = "";
+        window.bgImageSource = "";
+        window.exportCallback = null;
     }
 }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -964,13 +964,13 @@ DankModal {
     readonly property real _chromeH: Theme.spacingM * 2 + (window.toolbarVisible && _toolbarHorizontal ? 56 + Theme.spacingM : 0)
     readonly property real _minModalW: _toolbarHorizontal && window.toolbarItem && window.toolbarItem.width ? window.toolbarItem.width + Theme.spacingM * 2 : 400
     readonly property real _minModalH: !_toolbarHorizontal && window.toolbarItem && window.toolbarItem.height ? window.toolbarItem.height + Theme.spacingM * 2 : 300
-    readonly property bool _bgSizeKnown: window.bgImageItem !== null
+    readonly property bool _bgSizeKnown: window.bgImageItem
                                          && window.bgImageItem.status === Image.Ready
                                          && window.bgImageItem.sourceSize.width > 0
                                          && window.bgImageItem.sourceSize.height > 0
     // Compositor scale (not Screen.devicePixelRatio, which reports the integer buffer scale)
     readonly property real _outputScale: (window.targetScreen && CompositorService.getScreenScale(window.targetScreen)) || 1
-    readonly property bool _shouldScale: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.modalScaleToContent ? window.parentWidget.pluginData.modalScaleToContent : false
+    readonly property bool _shouldScale: !!(window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.modalScaleToContent)
     modalWidth: _shouldScale && _bgSizeKnown ? Math.round(Math.min(_maxModalW, Math.max(_minModalW, window.bgImageItem.sourceSize.width / _outputScale + _chromeW))) : _maxModalW
     modalHeight: _shouldScale && _bgSizeKnown ? Math.round(Math.min(_maxModalH, Math.max(_minModalH, window.bgImageItem.sourceSize.height / _outputScale + _chromeH))) : _maxModalH
     enableShadow: true
@@ -1291,7 +1291,6 @@ DankModal {
             window.commitTypingText();
         }
         // Clear any stale callback from a previous session that never completed
-        window.exportCallback = null;
         window.exportCallback = callback;
         if (!window.exportCanvasItem) {
             console.warn("exportCanvasItem is not initialized yet");

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1290,7 +1290,6 @@ DankModal {
         if (window.isTyping) {
             window.commitTypingText();
         }
-        // Clear any stale callback from a previous session that never completed
         window.exportCallback = callback;
         if (!window.exportCanvasItem) {
             console.warn("exportCanvasItem is not initialized yet");
@@ -1753,8 +1752,7 @@ DankModal {
             window.bgImageSource = window.restoreSource;
         } else if (window.currentCapturePath) {
             window.bgImageSource = "file://" + window.currentCapturePath;
-            // currentCapturePath is cleared in onDialogClosed to prevent losing it
-            // if this signal fires more than once during layout/screen changes
+            // currentCapturePath is consumed in onDialogClosed to survive re-fires during screen changes
         }
         window.isScreenshotDark = false;
         window.hasSampledContrast = false;
@@ -3185,9 +3183,8 @@ DankModal {
     }
 
     onDialogClosed: {
-        // Reset path state only after modal is fully closed, not in onOpened.
-        // This prevents blank canvas if the opened signal fires multiple times
-        // (e.g. during screen/layout changes) which would re-clear the source.
+        // Reset path state here (not in onOpened) so re-fires during layout/screen changes
+        // don't wipe bgImageSource before the image has a chance to render.
         window.currentCapturePath = "";
         window.restoreSource = "";
         window.bgImageSource = "";


### PR DESCRIPTION
## What

Fixes the blank/empty editor modal reported in #167, where the canvas shows nothing after the plugin has been running for a while (or immediately on first use for some users).

## Why

The render pipeline was broken at `bgImage.onStatusChanged`:

- `loadImage()` was only called on `drawingCanvas` (activeCanvas), but `bakedCanvas` — which is responsible for drawing the background image via `ctx.drawImage(bgImage, ...)` — was never told to load the image. As a result, `bakedCanvas.onImageLoaded` never fired, `requestPaint()` was never triggered, and the canvas stayed blank.
- A stale `exportCallback` from a failed previous session could persist and fire on the next open with an empty `bgImageSource`, producing a blank exported file and instantly closing the modal.
- `currentCapturePath` was consumed (set to `""`) inside `onOpened`. If the `opened` signal fires more than once (e.g. during screen/layout changes), the path is lost and the source stays empty on subsequent fires.
- Optional chaining (`?.`) and nullish coalescing (`??`) in property bindings cause parse errors on Qt < 6.8.

## How tested

- `qmllint QuickCaptureModal.qml` passes with no warnings or errors.
- Manual flow: capture → modal shows image → save/copy works → close → capture again → image shows correctly.
- Repeated captures (~10x) with no blank canvas occurrence.

Closes #167

## Summary by Sourcery

Fix blank editor canvases and stale export callbacks in the quick capture modal to ensure captured screenshots reliably display and export.

Bug Fixes:
- Ensure the background image canvas loads and paints the screenshot so the editor canvas is no longer blank.
- Prevent stale export callbacks from previous sessions from running with empty image sources.
- Avoid losing the current capture path when the modal is reopened or layout changes trigger multiple open events.
- Remove use of optional chaining and nullish coalescing in QML bindings to maintain compatibility with older Qt versions.

Enhancements:
- Simplify and harden modal sizing and scaling logic based on background image size and plugin configuration.
- Reset capture and export state when the dialog closes to avoid leaking state across sessions.