### PR TITLE
feat: add scrolling capture mode

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -22,6 +22,8 @@ PluginComponent {
     property bool isDownloading: false
     property string currentCapturePath: ""
     property string captureOutputName: ""
+    readonly property int captureTimeoutMs: 60000
+    readonly property int scrollCaptureTimeoutMs: 120000
     // Exposed so the widget surface can read annotation state without accessing internal modal id
     readonly property bool isAnnotating: modal.shouldBeVisible
 
@@ -44,7 +46,7 @@ PluginComponent {
         }
 
         if (mode === "scroll") {
-            const interval = parseInt(pluginData.scrollInterval || "500", 10);
+            const interval = parseInt(pluginData.scrollInterval, 10) || 500;
             args.push("--interval", String(interval));
         }
 
@@ -116,7 +118,7 @@ PluginComponent {
                     ToastService.showError(errorMsg);
                 }
             }
-        }, 0, root.screenshotMode() === "scroll" ? 120000 : 60000);
+        }, 0, root.screenshotMode() === "scroll" ? root.scrollCaptureTimeoutMs : root.captureTimeoutMs);
     }
 
     function selectImageAndAnnotateWithAction(action) {

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -17,7 +17,7 @@ PluginComponent {
     // ── State ────────────────────────────────────────────────────────────────
     property bool isCapturing: false
     readonly property string captureMode: (pluginData.captureMode || "region")
-    readonly property var allowedModes: ["region", "window", "full", "output", "all", "last", ""]
+    readonly property var allowedModes: ["region", "window", "full", "output", "all", "last", "scroll", ""]
     property string activeIpcMode: ""
     property bool isDownloading: false
     property string currentCapturePath: ""
@@ -41,6 +41,11 @@ PluginComponent {
 
         if (mode === "region" && pluginData.skipConfirm !== false) {
             args.push("--no-confirm");
+        }
+
+        if (mode === "scroll") {
+            const interval = parseInt(pluginData.scrollInterval || "500", 10);
+            args.push("--interval", String(interval));
         }
 
         if (mode === "output") {
@@ -111,7 +116,7 @@ PluginComponent {
                     ToastService.showError(errorMsg);
                 }
             }
-        }, 0, 60000);
+        }, 0, root.screenshotMode() === "scroll" ? 120000 : 60000);
     }
 
     function selectImageAndAnnotateWithAction(action) {

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -657,6 +657,7 @@ PluginSettings {
                 anchors.verticalCenter: parent.verticalCenter
 
                 DankIcon {
+                    id: scrollCaptureInfoIcon
                     name: "info"
                     size: 16
                     color: Theme.primary
@@ -664,7 +665,7 @@ PluginSettings {
                 }
 
                 StyledText {
-                    width: parent.width - 24
+                    width: parent.width - scrollCaptureInfoIcon.width - warningScrollRow.spacing
                     text: I18n.tr("Scroll capture: select a region, scroll content, then press Enter to finish.")
                     font.pixelSize: Theme.fontSizeSmall
                     color: Theme.surfaceText

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -573,7 +573,8 @@ PluginSettings {
                 { label: I18n.tr("All Combined Outputs"), value: "all" },
                 { label: I18n.tr("Specific Output"), value: "output" },
                 { label: I18n.tr("Focused Window"), value: "window" },
-                { label: I18n.tr("Last Selected Region"), value: "last" }
+                { label: I18n.tr("Last Selected Region"), value: "last" },
+                { label: I18n.tr("Scrolling Capture"), value: "scroll" }
             ]
             defaultValue: "region"
         }
@@ -642,6 +643,49 @@ PluginSettings {
             settingKey: "includeCursor"
             label: I18n.tr("Include Cursor")
             defaultValue: false
+        }
+
+        Item {
+            width: parent.width
+            height: visible ? warningScrollRow.implicitHeight + 4 : 0
+            visible: captureMode.value === "scroll"
+
+            Row {
+                id: warningScrollRow
+                width: parent.width
+                spacing: Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+
+                DankIcon {
+                    name: "info"
+                    size: 16
+                    color: Theme.primary
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                StyledText {
+                    width: parent.width - 24
+                    text: I18n.tr("Scroll capture: select a region, scroll content, then press Enter to finish.")
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceText
+                    wrapMode: Text.Wrap
+                }
+            }
+        }
+
+        SliderSettingPlus {
+            id: scrollInterval
+            settingKey: "scrollInterval"
+            label: I18n.tr("Scroll Interval")
+            defaultValue: 500
+            minimum: 200
+            maximum: 2000
+            stepSize: 50
+            unit: "ms"
+            leftLabel: "200"
+            rightLabel: "2000"
+            visible: captureMode.value === "scroll"
+            height: visible ? implicitHeight : 0
         }
     }
 

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -156,6 +156,7 @@ PluginComponent {
                 Repeater {
                     model: [
                         { icon: "restart_alt", text: I18n.tr("Last Region"), modeKey: "last" },
+                        { icon: "vertical_align_top", text: I18n.tr("Scrolling"), modeKey: "scroll" },
                         { icon: "grid_view", text: I18n.tr("All Outputs"), modeKey: "all" },
                     ]
                     delegate: menuItemComp

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Screenshot and vector annotation plugin for DankMaterialShell (DMS).
 
 ## Requirements
 
-- DankMaterialShell >= 1.5
+- DankMaterialShell >= 1.5.2 (scroll capture requires DMS >= 1.5.2)
 - **ImageMagick** (provides `magick`/`mogrify`, required for WebP/JPEG exports, rotation/mirroring, and OCR/QR crop)
 - **img2pdf** (required for PDF export)
 - **tesseract** (required for OCR text scanner)
@@ -63,6 +63,7 @@ git checkout main && git pull
 2. **Select area** — drag to choose the screenshot region.
 3. **Annotate** — use the toolbar, keyboard shortcuts, or radial menus.
 4. **Finish** — press <kbd>Enter</kbd> (action depends on settings) or <kbd>Esc</kbd> to discard.
+   - **Scroll mode**: select a region, scroll the content, then press <kbd>Enter</kbd> to finish stitching. Adjust scroll interval in settings.
 
 ## Annotation Tools
 
@@ -155,7 +156,7 @@ dms ipc call quickCapture screenshot region float  # float directly
 
 | Command | Arguments | Description |
 |---------|-----------|-------------|
-| `screenshot` | `mode` (`default`, `region`, `full`, `all`, `output`, `window`, `last`) | Trigger capture |
+| `screenshot` | `mode` (`default`, `region`, `full`, `all`, `output`, `window`, `last`, `scroll`) | Trigger capture |
 | `selectFile` | — | Open file browser to pick an image |
 | `fromClipboard` | — | Annotate image from clipboard |
 | `openImage` | `path` | Open a specific image in the annotator |


### PR DESCRIPTION
Closes #82 

## What
Adds a scrolling capture mode to the quick capture plugin.

## Why
Users need to capture content that extends beyond the visible screen area by scrolling and stitching screenshots.

## How
- Adds `scroll` to the allowed capture modes in `QuickCaptureDaemon.qml`.
- Reads `scrollInterval` settings (default: `500ms`) and passes it as `--interval` arguments when executing the screenshot command.
- Increases daemon execution timeout to 120 seconds for scroll capture mode to allow sufficient time for manual scrolling and stitching.
- Adds settings options (warning/info message and a slider to adjust the scroll interval) in `QuickCaptureSettings.qml`.
- Adds a shortcut button to the quick capture widget menu.
- Documented requirements and usage in `README.md`.

## Summary by Sourcery

Add a new scrolling capture mode to the quick capture plugin, including UI controls, daemon support, and documentation updates.

New Features:
- Introduce a 'Scrolling Capture' mode as a selectable capture option in quick capture settings and widget menu.
- Allow configuration of a scroll interval for scroll capture via a dedicated settings slider.

Enhancements:
- Extend the daemon to recognize the scroll capture mode, pass an interval argument to the screenshot command, and increase timeout for long-running scroll captures.

Documentation:
- Document scroll capture requirements, usage instructions, and the new 'scroll' screenshot mode in the README.