### PR TITLE
feat: optimize vertical toolbar layout and backdrop controls

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2022,13 +2022,13 @@ DankModal {
                         } else {
                             window.currentTool = tool;
                         }
-                        if (modalFocusScope) modalFocusScope.forceActiveFocus();
+                        if (window.modalFocusScope) window.modalFocusScope.forceActiveFocus();
                     }
                     onColorSelected: (color, index) => {
                         moreToolsMenu.close();
                         window.activeColorSlotIndex = index;
                         window.currentColor = color;
-                        if (modalFocusScope) modalFocusScope.forceActiveFocus();
+                        if (window.modalFocusScope) window.modalFocusScope.forceActiveFocus();
                     }
                     onCustomColorPickerRequested: (buttonItem) => {
                         moreToolsMenu.close();

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2022,11 +2022,13 @@ DankModal {
                         } else {
                             window.currentTool = tool;
                         }
+                        if (modalFocusScope) modalFocusScope.forceActiveFocus();
                     }
                     onColorSelected: (color, index) => {
                         moreToolsMenu.close();
                         window.activeColorSlotIndex = index;
                         window.currentColor = color;
+                        if (modalFocusScope) modalFocusScope.forceActiveFocus();
                     }
                     onCustomColorPickerRequested: (buttonItem) => {
                         moreToolsMenu.close();

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -2995,6 +2995,7 @@ DankModal {
 
                 HoverSliderPopover {
                     id: backdropPaddingPopover
+                    isVertical: toolbarCard.isVertical
                     minimum: 10
                     maximum: 150
                     value: window.backdropPadding
@@ -3006,6 +3007,7 @@ DankModal {
 
                 HoverSliderPopover {
                     id: backdropRadiusPopover
+                    isVertical: toolbarCard.isVertical
                     minimum: 0
                     maximum: 60
                     stepSize: 2
@@ -3018,6 +3020,7 @@ DankModal {
 
                 HoverSliderPopover {
                     id: backdropShadowPopover
+                    isVertical: toolbarCard.isVertical
                     minimum: 0
                     maximum: 100
                     value: window.backdropShadowStrength
@@ -3029,6 +3032,7 @@ DankModal {
 
                 HoverSliderPopover {
                     id: backdropAnglePopover
+                    isVertical: toolbarCard.isVertical
                     minimum: 0
                     maximum: 360
                     stepSize: 15

--- a/components/AlignmentControl.qml
+++ b/components/AlignmentControl.qml
@@ -46,6 +46,7 @@ Item {
     Column {
         id: col
         visible: control.compact
+        width: parent.width
         spacing: tc.spacingCompact
         anchors.centerIn: parent
 

--- a/components/AlignmentControl.qml
+++ b/components/AlignmentControl.qml
@@ -19,8 +19,8 @@ Item {
         "bottom-left": "BL", "bottom-center": "BC", "bottom-right": "BR"
     })
 
-    width: compact ? tc.btnSize : row.implicitWidth
-    height: compact ? 40 : tc.btnSize
+    width: compact ? (tc.btnSize + 8) : row.implicitWidth
+    height: compact ? tc.compactControlHeight : tc.btnSize
 
     Row {
         id: row

--- a/components/AlignmentControl.qml
+++ b/components/AlignmentControl.qml
@@ -20,26 +20,48 @@ Item {
     })
 
     width: compact ? tc.btnSize : row.implicitWidth
-    height: compact ? tc.btnSizeCompact : tc.btnSize
+    height: compact ? 40 : tc.btnSize
 
     Row {
         id: row
-        spacing: compact ? tc.spacingCompact : Theme.spacingXS
-        anchors.centerIn: compact ? parent : undefined
-        anchors.verticalCenter: compact ? undefined : parent.verticalCenter
+        visible: !control.compact
+        spacing: Theme.spacingXS
+        anchors.verticalCenter: parent.verticalCenter
 
         DankIcon {
             name: "align_justify_center"
-            size: compact ? tc.iconSizeCompact : tc.backdropIconSize
+            size: tc.iconSize
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter
         }
         StyledText {
             text: control._labelMap[control.backdropAlignment] ?? "C"
-            width: compact ? 18 : 22; horizontalAlignment: Text.AlignHCenter
-            font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
+            width: 22; horizontalAlignment: Text.AlignHCenter
+            font.pixelSize: Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+
+    Column {
+        id: col
+        visible: control.compact
+        spacing: tc.spacingCompact
+        anchors.centerIn: parent
+
+        DankIcon {
+            name: "align_justify_center"
+            size: tc.iconSize
+            color: Theme.surfaceText
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+        StyledText {
+            text: control._labelMap[control.backdropAlignment] ?? "C"
+            width: parent.width
+            horizontalAlignment: Text.AlignHCenter
+            font.pixelSize: Theme.fontSizeSmall
+            color: Theme.surfaceText
+            anchors.horizontalCenter: parent.horizontalCenter
         }
     }
 

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -32,7 +32,7 @@ Item {
         }
         StyledText {
             text: {
-                if (control.backdropAspectRatio === "auto") return I18n.tr("AUTO");
+                if (control.backdropAspectRatio === "auto") return "AT";
                 if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
                 return control.backdropAspectRatio;
             }
@@ -58,7 +58,7 @@ Item {
         }
         StyledText {
             text: {
-                if (control.backdropAspectRatio === "auto") return I18n.tr("AUTO");
+                if (control.backdropAspectRatio === "auto") return "AT";
                 if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
                 return control.backdropAspectRatio;
             }

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -46,6 +46,7 @@ Item {
     Column {
         id: col
         visible: control.compact
+        width: parent.width
         spacing: tc.spacingCompact
         anchors.centerIn: parent
 

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -15,8 +15,8 @@ Item {
     signal exited()
     signal wheeled(int delta)
 
-    width: compact ? tc.btnSize : row.implicitWidth
-    height: compact ? 40 : tc.btnSize
+    width: compact ? (tc.btnSize + 8) : row.implicitWidth
+    height: compact ? tc.compactControlHeight : tc.btnSize
 
     Row {
         id: row

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -32,7 +32,7 @@ Item {
         }
         StyledText {
             text: {
-                if (control.backdropAspectRatio === "auto") return "AT";
+                if (control.backdropAspectRatio === "auto") return I18n.tr("AUTO");
                 if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
                 return control.backdropAspectRatio;
             }

--- a/components/AspectRatioControl.qml
+++ b/components/AspectRatioControl.qml
@@ -16,17 +16,17 @@ Item {
     signal wheeled(int delta)
 
     width: compact ? tc.btnSize : row.implicitWidth
-    height: compact ? tc.btnSizeCompact : tc.btnSize
+    height: compact ? 40 : tc.btnSize
 
     Row {
         id: row
-        spacing: compact ? tc.spacingCompact : Theme.spacingXS
-        anchors.centerIn: compact ? parent : undefined
-        anchors.verticalCenter: compact ? undefined : parent.verticalCenter
+        visible: !control.compact
+        spacing: Theme.spacingXS
+        anchors.verticalCenter: parent.verticalCenter
 
         DankIcon {
             name: "aspect_ratio"
-            size: compact ? tc.iconSizeCompact : tc.backdropIconSize
+            size: tc.iconSize
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter
         }
@@ -36,10 +36,36 @@ Item {
                 if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
                 return control.backdropAspectRatio;
             }
-            width: compact ? 36 : 46; horizontalAlignment: Text.AlignLeft
-            font.pixelSize: compact ? tc.fontSizeCompact : Theme.fontSizeSmall
+            width: 46; horizontalAlignment: Text.AlignLeft
+            font.pixelSize: Theme.fontSizeSmall
             color: Theme.surfaceText
             anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+
+    Column {
+        id: col
+        visible: control.compact
+        spacing: tc.spacingCompact
+        anchors.centerIn: parent
+
+        DankIcon {
+            name: "aspect_ratio"
+            size: tc.iconSize
+            color: Theme.surfaceText
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+        StyledText {
+            text: {
+                if (control.backdropAspectRatio === "auto") return I18n.tr("AUTO");
+                if (control.backdropAspectRatio === "custom") return control.customAspectRatio.toFixed(2);
+                return control.backdropAspectRatio;
+            }
+            width: parent.width
+            horizontalAlignment: Text.AlignHCenter
+            font.pixelSize: Theme.fontSizeSmall
+            color: Theme.surfaceText
+            anchors.horizontalCenter: parent.horizontalCenter
         }
     }
 

--- a/components/BackdropAspectRatioPopover.qml
+++ b/components/BackdropAspectRatioPopover.qml
@@ -21,8 +21,8 @@ Rectangle {
     readonly property int _sliderMin: Math.round(customRatioMin * 100)
     readonly property int _sliderMax: Math.round(customRatioMax * 100)
 
-    width: customActive ? 340 : 220
-    height: tc.popoverHeight
+    width: 220
+    height: customActive ? 120 : tc.popoverHeight
     color: Theme.surfaceContainer
     border.color: Theme.withAlpha(Theme.outline, 0.15)
     border.width: 1
@@ -86,17 +86,16 @@ Rectangle {
             }
         }
 
-        Row {
+        Column {
             anchors.centerIn: parent
-            spacing: Theme.spacingM
-            leftPadding: Theme.spacingS
-            rightPadding: Theme.spacingS
+            spacing: Theme.spacingS
+            width: parent.width - Theme.spacingS * 2
 
             Grid {
                 columns: 4
                 rows: 2
                 spacing: tc.gridSpacing
-                anchors.verticalCenter: parent.verticalCenter
+                anchors.horizontalCenter: parent.horizontalCenter
 
                 Repeater {
                     model: popoverRoot.presets
@@ -129,10 +128,10 @@ Rectangle {
             // Separator when custom is active
             Rectangle {
                 visible: popoverRoot.customActive
-                width: tc.separatorThickness
-                height: tc.btnSize
+                width: parent.width
+                height: tc.separatorThickness
                 color: Theme.withAlpha(Theme.outline, 0.2)
-                anchors.verticalCenter: parent.verticalCenter
+                anchors.horizontalCenter: parent.horizontalCenter
             }
 
             // Slider section (Visible only when custom is active)
@@ -140,35 +139,35 @@ Rectangle {
                 id: sliderSection
                 visible: popoverRoot.customActive
                 spacing: Theme.spacingS
-                anchors.verticalCenter: parent.verticalCenter
+                width: parent.width
+                anchors.horizontalCenter: parent.horizontalCenter
 
-                Column {
-                    spacing: tc.spacingCompact
+                StyledText {
+                    id: ratioText
+                    text: I18n.tr("Ratio")
+                    font.pixelSize: tc.fontSizeCompact
+                    color: Theme.surfaceVariantText
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                DankSlider {
+                    id: slider
+                    minimum: popoverRoot._sliderMin
+                    maximum: popoverRoot._sliderMax
+                    width: parent.width - ratioText.implicitWidth - valueText.implicitWidth - sliderSection.spacing * 2 - 4
+                    showValue: false
+                    onSliderValueChanged: val => popoverRoot.changeCustomAspectRatio(val / 100.0)
                     anchors.verticalCenter: parent.verticalCenter
 
-                    StyledText {
-                        text: I18n.tr("Ratio")
-                        font.pixelSize: tc.fontSizeCompact
-                        color: Theme.surfaceVariantText
-                    }
-
-                    DankSlider {
-                        id: slider
-                        minimum: popoverRoot._sliderMin
-                        maximum: popoverRoot._sliderMax
-                        width: tc.sliderWidth
-                        showValue: false
-                        onSliderValueChanged: val => popoverRoot.changeCustomAspectRatio(val / 100.0)
-
-                        Binding {
-                            target: slider
-                            property: "value"
-                            value: Math.round(popoverRoot.customAspectRatio * 100)
-                        }
+                    Binding {
+                        target: slider
+                        property: "value"
+                        value: Math.round(popoverRoot.customAspectRatio * 100)
                     }
                 }
 
                 StyledText {
+                    id: valueText
                     text: popoverRoot.customAspectRatio.toFixed(2)
                     font.pixelSize: tc.fontSizeCompact
                     font.weight: Font.Medium

--- a/components/BackdropAspectRatioPopover.qml
+++ b/components/BackdropAspectRatioPopover.qml
@@ -125,14 +125,6 @@ Rectangle {
                 }
             }
 
-            // Separator when custom is active
-            Rectangle {
-                visible: popoverRoot.customActive
-                width: parent.width
-                height: tc.separatorThickness
-                color: Theme.withAlpha(Theme.outline, 0.2)
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
 
             // Slider section (Visible only when custom is active)
             Row {

--- a/components/BackdropAspectRatioPopover.qml
+++ b/components/BackdropAspectRatioPopover.qml
@@ -22,7 +22,7 @@ Rectangle {
     readonly property int _sliderMax: Math.round(customRatioMax * 100)
 
     width: 220
-    height: customActive ? 120 : tc.popoverHeight
+    height: customActive ? tc.customRatioPopoverHeight : tc.popoverHeight
     color: Theme.surfaceContainer
     border.color: Theme.withAlpha(Theme.outline, 0.15)
     border.width: 1
@@ -127,18 +127,28 @@ Rectangle {
 
 
             // Slider section (Visible only when custom is active)
-            Row {
+            Item {
                 id: sliderSection
                 visible: popoverRoot.customActive
-                spacing: Theme.spacingS
                 width: parent.width
-                anchors.horizontalCenter: parent.horizontalCenter
+                height: Math.max(ratioText.implicitHeight, slider.implicitHeight, valueText.implicitHeight)
 
                 StyledText {
                     id: ratioText
                     text: I18n.tr("Ratio")
                     font.pixelSize: tc.fontSizeCompact
                     color: Theme.surfaceVariantText
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                StyledText {
+                    id: valueText
+                    text: popoverRoot.customAspectRatio.toFixed(2)
+                    font.pixelSize: tc.fontSizeCompact
+                    font.weight: Font.Medium
+                    color: Theme.surfaceText
+                    anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
                 }
 
@@ -146,7 +156,10 @@ Rectangle {
                     id: slider
                     minimum: popoverRoot._sliderMin
                     maximum: popoverRoot._sliderMax
-                    width: parent.width - ratioText.implicitWidth - valueText.implicitWidth - sliderSection.spacing * 2 - 4
+                    anchors.left: ratioText.right
+                    anchors.right: valueText.left
+                    anchors.leftMargin: Theme.spacingS
+                    anchors.rightMargin: Theme.spacingS
                     showValue: false
                     onSliderValueChanged: val => popoverRoot.changeCustomAspectRatio(val / 100.0)
                     anchors.verticalCenter: parent.verticalCenter
@@ -156,15 +169,6 @@ Rectangle {
                         property: "value"
                         value: Math.round(popoverRoot.customAspectRatio * 100)
                     }
-                }
-
-                StyledText {
-                    id: valueText
-                    text: popoverRoot.customAspectRatio.toFixed(2)
-                    font.pixelSize: tc.fontSizeCompact
-                    font.weight: Font.Medium
-                    color: Theme.surfaceText
-                    anchors.verticalCenter: parent.verticalCenter
                 }
             }
         }

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -93,7 +93,8 @@ Grid {
     Item {
         width: controlRoot.itemSize + 8
         height: controlRoot.itemSize
-        anchors.verticalCenter: parent.verticalCenter
+        anchors.verticalCenter: controlRoot.isVertical ? undefined : parent.verticalCenter
+        anchors.horizontalCenter: controlRoot.isVertical ? parent.horizontalCenter : undefined
 
         DankActionButton {
             anchors.fill: parent
@@ -128,6 +129,7 @@ Grid {
         backgroundColor: "transparent"
         iconColor: Theme.surfaceText
         tooltipText: I18n.tr("Auto Balance")
+        anchors.horizontalCenter: controlRoot.isVertical ? parent.horizontalCenter : undefined
         onClicked: controlRoot.autoColorBalanceRequested()
     }
 }

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -5,6 +5,8 @@ import qs.Widgets
 Grid {
     id: controlRoot
 
+    ToolbarConstants { id: tc }
+
     property string backdropMode: "none"
     property color backdropSolidColor: Theme.primary
     property color backdropGradientStart: Theme.primary
@@ -26,7 +28,7 @@ Grid {
 
     Item {
         visible: controlRoot.backdropMode === "solid"
-        width: controlRoot.itemSize + 8
+        width: tc.verticalSelectorItemWidth
         height: controlRoot.itemSize
 
         Rectangle {
@@ -55,7 +57,7 @@ Grid {
 
     Item {
         visible: controlRoot.isGradient
-        width: controlRoot.isVertical ? (controlRoot.itemSize + 8) : (controlRoot.itemSize * 2 + Theme.spacingXS)
+        width: controlRoot.isVertical ? tc.verticalSelectorItemWidth : (controlRoot.itemSize * 2 + Theme.spacingXS)
         height: controlRoot.isVertical ? (controlRoot.itemSize * 2 + Theme.spacingXS) : controlRoot.itemSize
 
         Grid {
@@ -101,7 +103,7 @@ Grid {
     }
 
     Item {
-        width: controlRoot.itemSize + 8
+        width: tc.verticalSelectorItemWidth
         height: controlRoot.itemSize
 
         DankActionButton {
@@ -131,7 +133,7 @@ Grid {
     }
 
     Item {
-        width: controlRoot.itemSize + 8
+        width: tc.verticalSelectorItemWidth
         height: controlRoot.itemSize
 
         DankActionButton {

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -20,7 +20,7 @@ Grid {
     signal eyedropperRequested(string slot)
 
     columns: isVertical ? 1 : 4
-    spacing: Theme.spacingXS
+    spacing: isVertical ? 10 : Theme.spacingXS
     anchors.verticalCenter: isVertical ? undefined : parent.verticalCenter
     anchors.horizontalCenter: isVertical ? parent.horizontalCenter : undefined
 

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -24,22 +24,28 @@ Grid {
     anchors.verticalCenter: isVertical ? undefined : parent.verticalCenter
     anchors.horizontalCenter: isVertical ? parent.horizontalCenter : undefined
 
-    Rectangle {
+    Item {
         visible: controlRoot.backdropMode === "solid"
-        width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
-        color: controlRoot.backdropSolidColor
-        border.color: Theme.withAlpha(Theme.outline, 0.3)
-        border.width: 1
+        width: controlRoot.itemSize + 8
+        height: controlRoot.itemSize
 
-        MouseArea {
-            anchors.fill: parent
-            acceptedButtons: Qt.LeftButton | Qt.RightButton
-            cursorShape: Qt.PointingHandCursor
-            onClicked: (mouse) => {
-                if (mouse.button === Qt.RightButton) {
-                    controlRoot.eyedropperRequested("solid")
-                } else {
-                    controlRoot.colorPickerRequested(controlRoot.backdropSolidColor)
+        Rectangle {
+            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
+            color: controlRoot.backdropSolidColor
+            border.color: Theme.withAlpha(Theme.outline, 0.3)
+            border.width: 1
+            anchors.centerIn: parent
+
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                cursorShape: Qt.PointingHandCursor
+                onClicked: (mouse) => {
+                    if (mouse.button === Qt.RightButton) {
+                        controlRoot.eyedropperRequested("solid")
+                    } else {
+                        controlRoot.colorPickerRequested(controlRoot.backdropSolidColor)
+                    }
                 }
             }
         }
@@ -47,43 +53,47 @@ Grid {
 
     readonly property bool isGradient: backdropMode === "gradient" || backdropMode === "radial" || backdropMode === "conic"
 
-    Grid {
+    Item {
         visible: controlRoot.isGradient
-        columns: controlRoot.isVertical ? 1 : 2
-        spacing: Theme.spacingXS
-        anchors.verticalCenter: controlRoot.isVertical ? undefined : parent.verticalCenter
-        anchors.horizontalCenter: controlRoot.isVertical ? parent.horizontalCenter : undefined
+        width: controlRoot.isVertical ? (controlRoot.itemSize + 8) : (controlRoot.itemSize * 2 + Theme.spacingXS)
+        height: controlRoot.isVertical ? (controlRoot.itemSize * 2 + Theme.spacingXS) : controlRoot.itemSize
 
-        Rectangle {
-            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
-            color: controlRoot.backdropGradientStart
-            border.color: controlRoot.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-            border.width: controlRoot.gradientActiveSlot === "start" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
-            MouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.LeftButton | Qt.RightButton
-                cursorShape: Qt.PointingHandCursor
-                onClicked: (mouse) => {
-                    controlRoot.setGradientActiveSlot("start")
-                    if (mouse.button === Qt.RightButton) {
-                        controlRoot.eyedropperRequested("start")
+        Grid {
+            columns: controlRoot.isVertical ? 1 : 2
+            spacing: Theme.spacingXS
+            anchors.centerIn: parent
+
+            Rectangle {
+                width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
+                color: controlRoot.backdropGradientStart
+                border.color: controlRoot.gradientActiveSlot === "start" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                border.width: controlRoot.gradientActiveSlot === "start" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: (mouse) => {
+                        controlRoot.setGradientActiveSlot("start")
+                        if (mouse.button === Qt.RightButton) {
+                            controlRoot.eyedropperRequested("start")
+                        }
                     }
                 }
             }
-        }
-        Rectangle {
-            width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
-            color: controlRoot.backdropGradientEnd
-            border.color: controlRoot.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
-            border.width: controlRoot.gradientActiveSlot === "end" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
-            MouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.LeftButton | Qt.RightButton
-                cursorShape: Qt.PointingHandCursor
-                onClicked: (mouse) => {
-                    controlRoot.setGradientActiveSlot("end")
-                    if (mouse.button === Qt.RightButton) {
-                        controlRoot.eyedropperRequested("end")
+            Rectangle {
+                width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2
+                color: controlRoot.backdropGradientEnd
+                border.color: controlRoot.gradientActiveSlot === "end" ? Theme.primary : Theme.withAlpha(Theme.outline, 0.3)
+                border.width: controlRoot.gradientActiveSlot === "end" ? (controlRoot.itemSize >= 24 ? 2 : 1.5) : 1
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: (mouse) => {
+                        controlRoot.setGradientActiveSlot("end")
+                        if (mouse.button === Qt.RightButton) {
+                            controlRoot.eyedropperRequested("end")
+                        }
                     }
                 }
             }
@@ -93,8 +103,6 @@ Grid {
     Item {
         width: controlRoot.itemSize + 8
         height: controlRoot.itemSize
-        anchors.verticalCenter: controlRoot.isVertical ? undefined : parent.verticalCenter
-        anchors.horizontalCenter: controlRoot.isVertical ? parent.horizontalCenter : undefined
 
         DankActionButton {
             anchors.fill: parent
@@ -122,14 +130,19 @@ Grid {
         }
     }
 
-    DankActionButton {
-        buttonSize: controlRoot.itemSize
-        iconName: "auto_awesome"
-        iconSize: controlRoot.iconSize
-        backgroundColor: "transparent"
-        iconColor: Theme.surfaceText
-        tooltipText: I18n.tr("Auto Balance")
-        anchors.horizontalCenter: controlRoot.isVertical ? parent.horizontalCenter : undefined
-        onClicked: controlRoot.autoColorBalanceRequested()
+    Item {
+        width: controlRoot.itemSize + 8
+        height: controlRoot.itemSize
+
+        DankActionButton {
+            buttonSize: controlRoot.itemSize
+            iconName: "auto_awesome"
+            iconSize: controlRoot.iconSize
+            backgroundColor: "transparent"
+            iconColor: Theme.surfaceText
+            tooltipText: I18n.tr("Auto Balance")
+            anchors.centerIn: parent
+            onClicked: controlRoot.autoColorBalanceRequested()
+        }
     }
 }

--- a/components/BackdropColorSelectors.qml
+++ b/components/BackdropColorSelectors.qml
@@ -2,7 +2,7 @@ import QtQuick
 import qs.Common
 import qs.Widgets
 
-Row {
+Grid {
     id: controlRoot
 
     property string backdropMode: "none"
@@ -12,14 +12,17 @@ Row {
     property string gradientActiveSlot: "start"
     property int itemSize: 24
     property int iconSize: 18
+    property bool isVertical: false
 
     signal setGradientActiveSlot(string slot)
     signal autoColorBalanceRequested()
     signal colorPickerRequested(color currentColor)
     signal eyedropperRequested(string slot)
 
+    columns: isVertical ? 1 : 4
     spacing: Theme.spacingXS
-    anchors.verticalCenter: parent.verticalCenter
+    anchors.verticalCenter: isVertical ? undefined : parent.verticalCenter
+    anchors.horizontalCenter: isVertical ? parent.horizontalCenter : undefined
 
     Rectangle {
         visible: controlRoot.backdropMode === "solid"
@@ -44,10 +47,12 @@ Row {
 
     readonly property bool isGradient: backdropMode === "gradient" || backdropMode === "radial" || backdropMode === "conic"
 
-    Row {
+    Grid {
         visible: controlRoot.isGradient
+        columns: controlRoot.isVertical ? 1 : 2
         spacing: Theme.spacingXS
-        anchors.verticalCenter: parent.verticalCenter
+        anchors.verticalCenter: controlRoot.isVertical ? undefined : parent.verticalCenter
+        anchors.horizontalCenter: controlRoot.isVertical ? parent.horizontalCenter : undefined
 
         Rectangle {
             width: controlRoot.itemSize; height: controlRoot.itemSize; radius: controlRoot.itemSize / 2

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -373,6 +373,10 @@ MouseArea {
     }
 
     onPressed: (mouse) => {
+        if (window.modalFocusScope) {
+            window.modalFocusScope.forceActiveFocus();
+        }
+
         if (moreToolsMenu.opened) {
             moreToolsMenu.close();
             return;

--- a/components/HoverSliderPopover.qml
+++ b/components/HoverSliderPopover.qml
@@ -20,9 +20,18 @@ Rectangle {
     property int value: 0
     property int stepSize: 5
     property bool opened: false
+    property bool isVertical: false
     onValueChanged: slider.value = value
 
     signal userValueChanged(int val)
+
+    width: isVertical ? tc.btnSize : 120
+    height: isVertical ? 120 : tc.btnSize
+    color: Theme.surfaceContainer
+    border.color: Theme.withAlpha(Theme.outline, 0.15)
+    border.width: 1
+    radius: Theme.cornerRadius
+    z: 10001
 
     visible: opacity > 0
     opacity: 0
@@ -80,13 +89,80 @@ Rectangle {
 
         DankSlider {
             id: slider
+            visible: !popoverRoot.isVertical
             minimum: popoverRoot.minimum
             maximum: popoverRoot.maximum
             anchors.fill: parent
             anchors.margins: Theme.spacingS
             value: popoverRoot.value
             showValue: false
-            onSliderValueChanged: val => popoverRoot.userValueChanged(val)
+            onSliderValueChanged: val => {
+                if (!popoverRoot.isVertical) popoverRoot.userValueChanged(val)
+            }
+        }
+
+        Item {
+            id: verticalSliderContainer
+            visible: popoverRoot.isVertical
+            anchors.fill: parent
+            anchors.margins: Theme.spacingS
+
+            StyledRect {
+                id: verticalTrack
+                width: 8
+                height: parent.height
+                anchors.centerIn: parent
+                radius: Theme.cornerRadius
+                color: Theme.withAlpha(Theme.outline, Theme.popupTransparency)
+                
+                StyledRect {
+                    id: verticalFill
+                    width: parent.width
+                    radius: Theme.cornerRadius
+                    anchors.bottom: parent.bottom
+                    height: {
+                        const range = popoverRoot.maximum - popoverRoot.minimum;
+                        const ratio = range === 0 ? 0 : (popoverRoot.value - popoverRoot.minimum) / range;
+                        return Math.max(0, Math.min(verticalTrack.height, verticalTrack.height * ratio));
+                    }
+                    color: Theme.primary
+                }
+                
+                StyledRect {
+                    id: verticalHandle
+                    width: 20
+                    height: 8
+                    radius: Theme.cornerRadius
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    y: {
+                        const range = popoverRoot.maximum - popoverRoot.minimum;
+                        const ratio = range === 0 ? 0 : (popoverRoot.value - popoverRoot.minimum) / range;
+                        const travel = verticalTrack.height - height;
+                        return Math.max(0, Math.min(travel, travel * (1 - ratio)));
+                    }
+                    color: Theme.primary
+                }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                preventStealing: true
+                acceptedButtons: Qt.LeftButton
+                
+                function updateValue(mouseY) {
+                    let ratio = 1 - Math.max(0, Math.min(1, mouseY / verticalSliderContainer.height));
+                    let rawVal = popoverRoot.minimum + ratio * (popoverRoot.maximum - popoverRoot.minimum);
+                    let newVal = popoverRoot.stepSize > 1 ? Math.round(rawVal / popoverRoot.stepSize) * popoverRoot.stepSize : Math.round(rawVal);
+                    newVal = Math.max(popoverRoot.minimum, Math.min(popoverRoot.maximum, newVal));
+                    if (newVal !== popoverRoot.value) {
+                        popoverRoot.userValueChanged(newVal);
+                    }
+                }
+                
+                onPressed: mouse => updateValue(mouse.y)
+                onPositionChanged: mouse => { if (pressed) updateValue(mouse.y) }
+                onClicked: mouse => updateValue(mouse.y)
+            }
         }
     }
 }

--- a/components/HoverSliderPopover.qml
+++ b/components/HoverSliderPopover.qml
@@ -140,6 +140,8 @@ Rectangle {
                 anchors.fill: parent
                 preventStealing: true
                 acceptedButtons: Qt.LeftButton
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
                 
                 function updateValue(mouseY) {
                     let ratio = 1 - Math.max(0, Math.min(1, mouseY / verticalSliderContainer.height));

--- a/components/HoverSliderPopover.qml
+++ b/components/HoverSliderPopover.qml
@@ -7,8 +7,8 @@ Rectangle {
 
     ToolbarConstants { id: tc }
 
-    width: isVertical ? tc.btnSize : 120
-    height: isVertical ? 120 : tc.btnSize
+    width: isVertical ? tc.btnSize : tc.customRatioPopoverHeight
+    height: isVertical ? tc.customRatioPopoverHeight : tc.btnSize
     color: Theme.surfaceContainer
     border.color: Theme.withAlpha(Theme.outline, 0.15)
     border.width: 1
@@ -24,6 +24,12 @@ Rectangle {
     onValueChanged: slider.value = value
 
     signal userValueChanged(int val)
+
+    function valueFromRatio(ratio) {
+        let rawVal = minimum + ratio * (maximum - minimum);
+        let newVal = stepSize > 1 ? Math.round(rawVal / stepSize) * stepSize : Math.round(rawVal);
+        return Math.max(minimum, Math.min(maximum, newVal));
+    }
 
     visible: opacity > 0
     opacity: 0
@@ -144,10 +150,9 @@ Rectangle {
                 cursorShape: Qt.PointingHandCursor
                 
                 function updateValue(mouseY) {
+                    if (verticalSliderContainer.height <= 0) return;
                     let ratio = 1 - Math.max(0, Math.min(1, mouseY / verticalSliderContainer.height));
-                    let rawVal = popoverRoot.minimum + ratio * (popoverRoot.maximum - popoverRoot.minimum);
-                    let newVal = popoverRoot.stepSize > 1 ? Math.round(rawVal / popoverRoot.stepSize) * popoverRoot.stepSize : Math.round(rawVal);
-                    newVal = Math.max(popoverRoot.minimum, Math.min(popoverRoot.maximum, newVal));
+                    let newVal = popoverRoot.valueFromRatio(ratio);
                     if (newVal !== popoverRoot.value) {
                         popoverRoot.userValueChanged(newVal);
                     }

--- a/components/HoverSliderPopover.qml
+++ b/components/HoverSliderPopover.qml
@@ -7,8 +7,8 @@ Rectangle {
 
     ToolbarConstants { id: tc }
 
-    width: 120
-    height: tc.btnSize
+    width: isVertical ? tc.btnSize : 120
+    height: isVertical ? 120 : tc.btnSize
     color: Theme.surfaceContainer
     border.color: Theme.withAlpha(Theme.outline, 0.15)
     border.width: 1
@@ -24,14 +24,6 @@ Rectangle {
     onValueChanged: slider.value = value
 
     signal userValueChanged(int val)
-
-    width: isVertical ? tc.btnSize : 120
-    height: isVertical ? 120 : tc.btnSize
-    color: Theme.surfaceContainer
-    border.color: Theme.withAlpha(Theme.outline, 0.15)
-    border.width: 1
-    radius: Theme.cornerRadius
-    z: 10001
 
     visible: opacity > 0
     opacity: 0

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -862,6 +862,7 @@ Rectangle {
                 spacing: Theme.spacingS
                 anchors.horizontalCenter: parent.horizontalCenter
                                  BackdropColorSelectors {
+                    isVertical: true
                     backdropMode: root.backdropMode
                     backdropSolidColor: root.backdropSolidColor
                     backdropGradientStart: root.backdropGradientStart

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -110,6 +110,8 @@ Rectangle {
         property int gridSpacingValue: tc.gridSpacing
         signal colorSelected(color col, int index)
         columns: cols
+        rows: cols === 2 ? 4 : 2
+        flow: cols === 2 ? Grid.TopToBottom : Grid.LeftToRight
         spacing: gridSpacingValue
         Repeater {
             model: paletteGrid.paletteModel

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -401,27 +401,6 @@ Rectangle {
                     }
                 }
             }
-
-            Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
-
-            // Thickness Text Only
-            Text {
-                text: {
-                    if (root.activeToolType === "spotlight" || root.activeToolType === "callout") {
-                        return root.strokeWidth + "%";
-                    }
-                    return root.strokeWidth + "px";
-                }
-                color: Theme.surfaceText; font.pixelSize: 10; font.bold: true; anchors.horizontalCenter: parent.horizontalCenter
-            }
-
-            Rectangle { width: tc.separatorLength; height: tc.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
-
-            Column {
-                spacing: Theme.spacingXS; anchors.horizontalCenter: parent.horizontalCenter
-                DankActionButton { iconName: "undo"; buttonSize: tc.btnSize; iconSize: tc.iconSize; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; onClicked: root.undoRequested() }
-                DankActionButton { iconName: "done_all"; buttonSize: tc.btnSize; iconSize: tc.iconSize; tooltipText: "Copy & Save (Enter)"; iconColor: Theme.primary; onClicked: root.copyAndSaveRequested() }
-            }
         }
     }
 
@@ -706,24 +685,25 @@ Rectangle {
                 Item {
                     id: padControlVert
                     width: tc.btnSize
-                    height: tc.btnSizeCompact
+                    height: 40
                     anchors.horizontalCenter: parent.horizontalCenter
                     
-                    Row {
+                    Column {
                         spacing: tc.spacingCompact
                         anchors.centerIn: parent
                         DankIcon {
                             name: "padding"
-                            size: tc.iconSizeCompact
+                            size: tc.iconSize
                             color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
                         }
                         StyledText {
                             text: root.backdropPadding
-                            width: tc.btnSize; horizontalAlignment: Text.AlignRight
-                            font.pixelSize: tc.fontSizeCompact
+                            width: parent.width
+                            horizontalAlignment: Text.AlignHCenter
+                            font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
                         }
                     }
                     MouseArea {
@@ -741,24 +721,25 @@ Rectangle {
                 Item {
                     id: radControlVert
                     width: tc.btnSize
-                    height: tc.btnSizeCompact
+                    height: 40
                     anchors.horizontalCenter: parent.horizontalCenter
                     
-                    Row {
+                    Column {
                         spacing: tc.spacingCompact
                         anchors.centerIn: parent
                         DankIcon {
                             name: "rounded_corner"
-                            size: tc.iconSizeCompact
+                            size: tc.iconSize
                             color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
                         }
                         StyledText {
                             text: root.backdropCornerRadius
-                            width: tc.btnSize; horizontalAlignment: Text.AlignRight
-                            font.pixelSize: tc.fontSizeCompact
+                            width: parent.width
+                            horizontalAlignment: Text.AlignHCenter
+                            font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
                         }
                     }
                     MouseArea {
@@ -776,24 +757,25 @@ Rectangle {
                 Item {
                     id: shadowControlVert
                     width: tc.btnSize
-                    height: tc.btnSizeCompact
+                    height: 40
                     anchors.horizontalCenter: parent.horizontalCenter
                     
-                    Row {
+                    Column {
                         spacing: tc.spacingCompact
                         anchors.centerIn: parent
                         DankIcon {
                             name: "blur_on"
-                            size: tc.iconSizeCompact
+                            size: tc.iconSize
                             color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
                         }
                         StyledText {
                             text: root.backdropShadowStrength
-                            width: tc.btnSize; horizontalAlignment: Text.AlignRight
-                            font.pixelSize: tc.fontSizeCompact
+                            width: parent.width
+                            horizontalAlignment: Text.AlignHCenter
+                            font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
                         }
                     }
                     MouseArea {
@@ -812,24 +794,25 @@ Rectangle {
                     id: angleControlVert
                     visible: root.backdropMode === "gradient" || root.backdropMode === "conic"
                     width: tc.btnSize
-                    height: visible ? tc.btnSizeCompact : 0
+                    height: visible ? 40 : 0
                     anchors.horizontalCenter: parent.horizontalCenter
                     
-                    Row {
+                    Column {
                         spacing: tc.spacingCompact
                         anchors.centerIn: parent
                         DankIcon {
                             name: "rotate_right"
-                            size: tc.iconSizeCompact
+                            size: tc.iconSize
                             color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
                         }
                         StyledText {
                             text: root.backdropGradientAngle
-                            width: tc.btnSize; horizontalAlignment: Text.AlignRight
-                            font.pixelSize: tc.fontSizeCompact
+                            width: parent.width
+                            horizontalAlignment: Text.AlignHCenter
+                            font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceText
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
                         }
                     }
                     MouseArea {

--- a/components/ToolbarConstants.qml
+++ b/components/ToolbarConstants.qml
@@ -32,4 +32,9 @@ QtObject {
     readonly property int subToolbarHeight: 48
     readonly property int subToolbarBtnSize: 36
     readonly property int subToolbarIconSize: 20
+
+    // Vertical layout dimensions constants
+    readonly property int compactControlHeight: 40
+    readonly property int customRatioPopoverHeight: 120
+    readonly property int verticalSelectorItemWidth: 32
 }


### PR DESCRIPTION
## Summary

This PR optimizes the vertical toolbar layout, aligns backdrop controls in a vertical flow, reorders the color palette grid column-wise in 2-column mode, and resolves issues regarding popover orientation and keyboard shortcut focus.

## Use Case

Users operating the toolbar in a vertical orientation (left or right side of the screen) will benefit from aligned controls, correct custom aspect ratio sliders, vertically stacked colors, and responsive keyboard shortcuts.

## Changes

- **QuickCaptureToolbar**:
  - Removed thickness indicator, Undo, and Done All buttons from vertical layout to avoid overflow.
  - Reordered vertical ColorPaletteGrid display model column-wise: top-to-bottom first, then left-to-right (1-5, 2-6, 3-7, 4-8), remapping indexing logic to retain shortcut mappings.
- **BackdropColorSelectors**:
  - Converted layout to a Grid that supports column-wise flow in vertical mode.
  - Wrapped children in layout-neutral items and cleared direct anchors to avoid Grid conflicts.
  - Increased vertical spacing between selector rows to 10px.
- **AspectRatioControl & AlignmentControl**:
  - Converted compact layouts to vertical Columns, sync icon/font sizes.
  - Assigned explicit Column width to resolve StyledText width binding loop.
  - Abbreviated "AUTO" label to "AT" in vertical mode.
- **BackdropAspectRatioPopover**:
  - Stacked Custom Aspect Ratio slider vertically below the presets grid, increased height, and removed the horizontal separator.
- **HoverSliderPopover**:
  - Added vertical slider orientation and implementation (including mouse dragging logic).
  - Configured vertical slider pointing hand cursor.
  - Fixed duplicate property declarations.
- **Focus & Keyboard Shortcuts**:
  - Added `modalFocusScope.forceActiveFocus()` upon canvas presses, tool selections, and color selections to ensure shortcut keys (e.g., 1, 2, 3, 4) do not lose focus in vertical mode.

## Related Issues

Closes https://github.com/hthienloc/dms-quick-capture/issues/103

## Testing

- Verified all files using `qmllint`.
- Manual verification:
  - Verified vertical popovers drag vertically with pointer cursor.
  - Verified backdrop color grid reordering, color picker, and auto contrast align properly.
  - Verified keyboard shortcuts (1, 2, 3, 4) trigger correct drawing tools.

## Screenshots / Screen Recordings

None.

## Checklist

- [x] I have tested these changes on my setup
- [x] I have updated the documentation (README, IPC/settings docs) if needed
- [x] I have verified the plugin loads without errors

## Summary by Sourcery

Optimize vertical toolbar and backdrop controls for vertical layout usability and focus behavior.

New Features:
- Add vertical-aware grid layout and spacing for backdrop color selectors.
- Introduce vertical mode support for hover slider popovers with a custom vertical slider implementation.
- Add compact vertical variants for aspect ratio and alignment controls in the backdrop toolbar.

Bug Fixes:
- Remove overflow-prone thickness indicator and undo/done-all controls from the vertical quick capture toolbar layout.
- Ensure modal focus is restored on canvas presses, tool selection, and color selection so keyboard shortcuts remain responsive in vertical mode.

Enhancements:
- Refine backdrop aspect ratio popover layout by stacking presets and custom slider vertically and adjusting dimensions.
- Adjust vertical backdrop padding, radius, shadow, and angle controls to use columnar layouts with centered labels for better readability.
- Align backdrop color selector items within a grid-based layout to avoid anchor conflicts and improve centering.