### PR TITLE
feat: add speech bubble option to text tool

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -669,6 +669,8 @@ DankModal {
     property point typingCoords: Qt.point(0,0)
     property string currentTypingText: ""
     property var editingStroke: null
+    property bool typingIsSpeechBubble: false
+    property point typingTargetCoords: Qt.point(0,0)
 
     backgroundOpacity: {
         const data = window.parentWidget && window.parentWidget.pluginData;
@@ -3149,7 +3151,11 @@ DankModal {
                 s.isUnderline = window.textUnderline;
                 s.hasBackground = window.textBackground;
                 s.cornerRadius = window.textCornerRadius;
-                s.points = [window.typingCoords];
+                if (s.isSpeechBubble) {
+                    s.points = [window.typingTargetCoords, window.typingCoords];
+                } else {
+                    s.points = [window.typingCoords];
+                }
                 const idx = window.strokes.indexOf(s);
                 if (idx !== -1) {
                     const list = [...window.strokes];
@@ -3178,7 +3184,10 @@ DankModal {
                 isUnderline: window.textUnderline,
                 hasBackground: window.textBackground,
                 cornerRadius: window.textCornerRadius,
-                points: [Qt.point(window.typingCoords.x, window.typingCoords.y)],
+                isSpeechBubble: window.typingIsSpeechBubble,
+                points: window.typingIsSpeechBubble
+                    ? [Qt.point(window.typingTargetCoords.x, window.typingTargetCoords.y), Qt.point(window.typingCoords.x, window.typingCoords.y)]
+                    : [Qt.point(window.typingCoords.x, window.typingCoords.y)],
                 text: textStr
             });
         }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ git checkout main && git pull
 2. **Select area** — drag to choose the screenshot region.
 3. **Annotate** — use the toolbar, keyboard shortcuts, or radial menus.
 4. **Finish** — press <kbd>Enter</kbd> (action depends on settings) or <kbd>Esc</kbd> to discard.
-   - **Scroll mode**: select a region, scroll the content, then press <kbd>Enter</kbd> to finish stitching. Adjust scroll interval in settings.
+
+**Scrolling Capture (Stitching):** Select a region, scroll the content, then press <kbd>Enter</kbd> to finish stitching. Adjust the scroll interval in settings.
 
 ## Annotation Tools
 
@@ -96,6 +97,8 @@ git checkout main && git pull
 - **Quick Erase:** **Middle-click** on any element to delete it.
 - **Copy / Duplicate:** Select a vector with the **Select** tool (<kbd>V</kbd>), then press **<kbd>C</kbd>** to duplicate. Pressing **<kbd>C</kbd>** without a selection pastes the last copied vector at the cursor.
 - **Undo:** <kbd>Ctrl</kbd> + <kbd>Z</kbd>.
+- **Speech Bubble (Text Tool):** Click and drag to draw a speech bubble. The click location defines the tail target point, and the release location is the text bubble. A single click without dragging writes normal text.
+- **Leader Line (Stamp Tool):** Click and drag to create a stamp with a leader line. The click location points to the target, and the release location places the stamp body. A single click without dragging drops a normal stamp.
 - **Shift Constraint:** Hold **<kbd>Shift</kbd>** while drawing to constrain shapes:
 
   | Tool | Shift Behavior |

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -34,3 +34,10 @@ const defaultRadialTools = ["pen", "arrow", "rect", "highlighter", "ellipse", "s
 
 // Selection resize handles
 const selectionHandleSize = 10;
+
+// Text speech bubble configuration
+const textBubblePaddingMultiplierX = 0.5;
+const textBubblePaddingMultiplierY = 0.3;
+const textBubbleDefaultRadius = 8;
+const textBubbleMinRadius = 8;
+const textBubbleDragThreshold = 10;

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -138,7 +138,7 @@ MouseArea {
                         if (tool === "redact") {
                             window.selectedStroke.cachedCleanColor = undefined;
                         }
-                    } else if (tool === "line" || tool === "arrow" || tool === "highlighter") {
+                    } else if (tool === "line" || tool === "arrow" || tool === "highlighter" || (tool === "text" && window.selectedStroke.isSpeechBubble)) {
                         const newPoints = [...window.selectedStroke.points];
                         let targetIdx = -1;
                         let fixedIdx = -1;
@@ -362,7 +362,7 @@ MouseArea {
                       window.currentStroke.points.push(finalPt);
                   }
               } else if (window.currentTool === "rect" || window.currentTool === "ellipse" || window.currentTool === "arrow" || window.currentTool === "line"
-                       || window.currentTool === "pixelate" || window.currentTool === "highlighter" || window.currentTool === "spotlight" || window.currentTool === "callout") {
+                       || window.currentTool === "pixelate" || window.currentTool === "highlighter" || window.currentTool === "spotlight" || window.currentTool === "callout" || window.currentTool === "text") {
                   
                  let finalPt = absPt;
                  if ((mouse.modifiers & Qt.ShiftModifier) && (window.currentTool === "line" || window.currentTool === "arrow" || window.currentTool === "highlighter")) {
@@ -390,6 +390,18 @@ MouseArea {
                   } else {
                       window.currentStroke.points.push(finalPt);
                   }
+
+                 if (window.currentTool === "text") {
+                     const p0 = window.currentStroke.points[0];
+                     const dx = finalPt.x - p0.x;
+                     const dy = finalPt.y - p0.y;
+                     const dist = Math.sqrt(dx * dx + dy * dy);
+                     if (dist > 10 / window.editScale) {
+                         window.currentStroke.isSpeechBubble = true;
+                     } else {
+                         window.currentStroke.isSpeechBubble = false;
+                     }
+                 }
               } else if (window.currentTool === "stamp") {
                    const p0 = window.currentStroke.points[0];
                    if (p0) {
@@ -689,12 +701,22 @@ MouseArea {
 
         // Annotation Mode: perform drawing!
         if (window.currentTool === "text") {
-            window.typingCoords = getAbsolutePoint(mouse.x, mouse.y);
-            window.currentTypingText = "";
-            window.isTyping = true;
-            if (window.textInputMode === "popup") {
-                textInputDialog.open();
-            }
+            const absPt = getAbsolutePoint(mouse.x, mouse.y);
+            window.pressCoords = absPt;
+            window.currentStroke = {
+                tool: "text",
+                color: window.currentColor.toString(),
+                width: window.textFontSize,
+                points: [absPt],
+                isSpeechBubble: false,
+                text: "",
+                isBold: window.textBold,
+                isItalic: window.textItalic,
+                isUnderline: window.textUnderline,
+                hasBackground: window.textBackground,
+                cornerRadius: window.textCornerRadius,
+                fontFamily: window.textFontFamily
+            };
             if (window.activeCanvas) window.activeCanvas.requestPaint();
             return;
         }
@@ -767,7 +789,13 @@ MouseArea {
 
         window.editingStroke = stroke;
         window.selectedStroke = null;
-        window.typingCoords = Qt.point(stroke.points[0].x, stroke.points[0].y);
+        window.typingIsSpeechBubble = stroke.isSpeechBubble || false;
+        window.typingCoords = (stroke.isSpeechBubble && stroke.points.length >= 2)
+            ? Qt.point(stroke.points[1].x, stroke.points[1].y)
+            : Qt.point(stroke.points[0].x, stroke.points[0].y);
+        if (stroke.isSpeechBubble && stroke.points.length >= 2) {
+            window.typingTargetCoords = Qt.point(stroke.points[0].x, stroke.points[0].y);
+        }
         window.currentTypingText = stroke.text;
         window.isTyping = true;
         window.currentColor = stroke.color;
@@ -834,6 +862,22 @@ MouseArea {
 
         if (!window.currentStroke) return;
         let stroke = window.currentStroke;
+        if (stroke.tool === "text") {
+            const hasDrag = stroke.isSpeechBubble && stroke.points.length >= 2;
+            window.typingIsSpeechBubble = hasDrag;
+            window.typingCoords = hasDrag ? stroke.points[1] : stroke.points[0];
+            if (hasDrag) {
+                window.typingTargetCoords = stroke.points[0];
+            }
+            window.currentTypingText = "";
+            window.isTyping = true;
+            window.currentStroke = null;
+            if (window.textInputMode === "popup") {
+                textInputDialog.open();
+            }
+            if (window.activeCanvas) window.activeCanvas.requestPaint();
+            return;
+        }
         if (stroke.tool === "callout" && stroke.points.length >= 2) {
             const p0 = stroke.points[0];
             const p1 = stroke.points[stroke.points.length - 1];

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -3,6 +3,7 @@ import Quickshell
 import qs.Common
 import qs.Services
 import "Helpers.js" as Helpers
+import "Constants.js" as Constants
 
 MouseArea {
     id: drawMouseArea
@@ -396,7 +397,7 @@ MouseArea {
                      const dx = finalPt.x - p0.x;
                      const dy = finalPt.y - p0.y;
                      const dist = Math.sqrt(dx * dx + dy * dy);
-                     if (dist > 10 / window.editScale) {
+                     if (dist > Constants.textBubbleDragThreshold / window.editScale) {
                          window.currentStroke.isSpeechBubble = true;
                      } else {
                          window.currentStroke.isSpeechBubble = false;
@@ -409,7 +410,7 @@ MouseArea {
                        const dx = absPt.x - p0.x;
                        const dy = absPt.y - p0.y;
                        const dist = Math.sqrt(dx * dx + dy * dy);
-                       if (dist > 10 / window.editScale) {
+                       if (dist > Constants.textBubbleDragThreshold / window.editScale) {
                            window.currentStroke.hasLeaderLine = true;
                            
                            if (mouse.modifiers & Qt.ShiftModifier) {

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -527,7 +527,7 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         }
 
     } else if (stroke.tool === "text") {
-        const pt = stroke.points[0];
+        const pt = (stroke.isSpeechBubble && stroke.points.length >= 2) ? stroke.points[1] : stroke.points[0];
         ctx.fillStyle = stroke.color;
         
         let styleStr = "";
@@ -542,41 +542,159 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
         const lines = (stroke.text || "").split("\n");
         const lineHeight = stroke.width * 1.35;
 
-        if (stroke.hasBackground) {
+        const isBubble = stroke.isSpeechBubble && stroke.points.length >= 2;
+
+        if (isBubble || stroke.hasBackground) {
             let maxWidth = 0;
             for (let li = 0; li < lines.length; li++) {
                 const m = ctx.measureText(lines[li]);
                 if (m.width > maxWidth) maxWidth = m.width;
             }
             const h = stroke.width;
-            const padX = h * 0.3;
-            const padY = h * 0.15;
+            const padX = h * 0.5;
+            const padY = h * 0.3;
             const totalH = lines.length * lineHeight - (lineHeight - h);
             const rx = pt.x - padX;
             const ry = pt.y - padY;
             const rw = maxWidth + padX * 2;
             const rh = totalH + padY * 2;
-            const radius = stroke.cornerRadius || 0;
+            const radius = Math.max(8, stroke.cornerRadius || 8);
 
-            ctx.fillStyle = Helpers.getContrastingColor(stroke.color, Qt);
+            ctx.save();
 
-            if (radius > 0) {
+            if (isBubble) {
+                const contrastColor = Helpers.getContrastingColor(stroke.color, Qt);
+                ctx.fillStyle = (contrastColor === "#ffffff") ? "rgba(255, 255, 255, 0.95)" : "rgba(30, 30, 30, 0.95)";
+            } else {
+                ctx.fillStyle = Helpers.getContrastingColor(stroke.color, Qt);
+            }
+
+            if (isBubble) {
+                const p1 = stroke.points[0];
+                const tx = p1.x;
+                const ty = p1.y;
+                const cx = rx + rw / 2;
+                const cy = ry + rh / 2;
+                const inBubble = tx >= rx && tx <= rx + rw && ty >= ry && ty <= ry + rh;
+
+                let activeEdge = "";
+                if (!inBubble) {
+                    const dx = tx - cx;
+                    const dy = ty - cy;
+                    const angle = Math.atan2(dy, dx);
+                    const diagAngle = Math.atan2(rh, rw);
+
+                    if (angle >= -diagAngle && angle < diagAngle) {
+                        activeEdge = "right";
+                    } else if (angle >= diagAngle && angle < Math.PI - diagAngle) {
+                        activeEdge = "bottom";
+                    } else if (angle >= Math.PI - diagAngle || angle < -Math.PI + diagAngle) {
+                        activeEdge = "left";
+                    } else {
+                        activeEdge = "top";
+                    }
+                }
+
+                let base1X = 0, base1Y = 0, base2X = 0, base2Y = 0;
+                const tailBaseSize = Math.max(8, stroke.width * 0.3);
+
+                if (activeEdge === "top") {
+                    let closestX = Math.max(rx, Math.min(tx, rx + rw));
+                    closestX = Math.max(rx + radius + tailBaseSize, Math.min(closestX, rx + rw - radius - tailBaseSize));
+                    base1X = closestX - tailBaseSize;
+                    base1Y = ry;
+                    base2X = closestX + tailBaseSize;
+                    base2Y = ry;
+                } else if (activeEdge === "bottom") {
+                    let closestX = Math.max(rx, Math.min(tx, rx + rw));
+                    closestX = Math.max(rx + radius + tailBaseSize, Math.min(closestX, rx + rw - radius - tailBaseSize));
+                    base1X = closestX - tailBaseSize;
+                    base1Y = ry + rh;
+                    base2X = closestX + tailBaseSize;
+                    base2Y = ry + rh;
+                } else if (activeEdge === "left") {
+                    let closestY = Math.max(ry, Math.min(ty, ry + rh));
+                    closestY = Math.max(ry + radius + tailBaseSize, Math.min(closestY, ry + rh - radius - tailBaseSize));
+                    base1X = rx;
+                    base1Y = closestY - tailBaseSize;
+                    base2X = rx;
+                    base2Y = closestY + tailBaseSize;
+                } else if (activeEdge === "right") {
+                    let closestY = Math.max(ry, Math.min(ty, ry + rh));
+                    closestY = Math.max(ry + radius + tailBaseSize, Math.min(closestY, ry + rh - radius - tailBaseSize));
+                    base1X = rx + rw;
+                    base1Y = closestY - tailBaseSize;
+                    base2X = rx + rw;
+                    base2Y = closestY + tailBaseSize;
+                }
+
                 ctx.beginPath();
                 ctx.moveTo(rx + radius, ry);
+
+                // Top edge
+                if (activeEdge === "top") {
+                    ctx.lineTo(base1X, ry);
+                    ctx.lineTo(tx, ty);
+                    ctx.lineTo(base2X, ry);
+                }
                 ctx.lineTo(rx + rw - radius, ry);
                 ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + radius);
+
+                // Right edge
+                if (activeEdge === "right") {
+                    ctx.lineTo(rx + rw, base1Y);
+                    ctx.lineTo(tx, ty);
+                    ctx.lineTo(rx + rw, base2Y);
+                }
                 ctx.lineTo(rx + rw, ry + rh - radius);
                 ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - radius, ry + rh);
+
+                // Bottom edge
+                if (activeEdge === "bottom") {
+                    ctx.lineTo(base2X, ry + rh);
+                    ctx.lineTo(tx, ty);
+                    ctx.lineTo(base1X, ry + rh);
+                }
                 ctx.lineTo(rx + radius, ry + rh);
                 ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - radius);
+
+                // Left edge
+                if (activeEdge === "left") {
+                    ctx.lineTo(rx, base2Y);
+                    ctx.lineTo(tx, ty);
+                    ctx.lineTo(rx, base1Y);
+                }
                 ctx.lineTo(rx, ry + radius);
                 ctx.quadraticCurveTo(rx, ry, rx + radius, ry);
                 ctx.closePath();
+
                 ctx.fill();
+
+                // Draw border for bubble
+                ctx.shadowColor = "transparent";
+                ctx.strokeStyle = stroke.color;
+                ctx.lineWidth = Math.max(1.5, Math.round(stroke.width * 0.05));
+                ctx.stroke();
             } else {
-                ctx.fillRect(rx, ry, rw, rh);
+                if (radius > 0) {
+                    ctx.beginPath();
+                    ctx.moveTo(rx + radius, ry);
+                    ctx.lineTo(rx + rw - radius, ry);
+                    ctx.quadraticCurveTo(rx + rw, ry, rx + rw, ry + radius);
+                    ctx.lineTo(rx + rw, ry + rh - radius);
+                    ctx.quadraticCurveTo(rx + rw, ry + rh, rx + rw - radius, ry + rh);
+                    ctx.lineTo(rx + radius, ry + rh);
+                    ctx.quadraticCurveTo(rx, ry + rh, rx, ry + rh - radius);
+                    ctx.lineTo(rx, ry + radius);
+                    ctx.quadraticCurveTo(rx, ry, rx + radius, ry);
+                    ctx.closePath();
+                    ctx.fill();
+                } else {
+                    ctx.fillRect(rx, ry, rw, rh);
+                }
             }
-            
+            ctx.restore();
+
             ctx.fillStyle = stroke.color;
         }
 
@@ -695,6 +813,30 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
     }
 
     if (stroke.tool === "text") {
+        if (stroke.isSpeechBubble && stroke.points.length >= 2) {
+            const p0 = stroke.points[0];
+            const p1 = stroke.points[1];
+
+            ctx.save();
+            ctx.strokeStyle = Theme.primary;
+            ctx.lineWidth = 1;
+            ctx.setLineDash([4, 4]);
+            ctx.beginPath();
+            ctx.moveTo(p0.x, p0.y);
+            ctx.lineTo(p1.x, p1.y);
+            ctx.stroke();
+            ctx.restore();
+
+            ctx.fillStyle = "#ffffff";
+            ctx.strokeStyle = Theme.primary;
+            ctx.lineWidth = 1.5;
+            ctx.fillRect(p0.x - hh, p0.y - hh, hs, hs);
+            ctx.strokeRect(p0.x - hh, p0.y - hh, hs, hs);
+            ctx.fillRect(p1.x - hh, p1.y - hh, hs, hs);
+            ctx.strokeRect(p1.x - hh, p1.y - hh, hs, hs);
+            return;
+        }
+
         const p = stroke.points[0];
         const fontSize = stroke.width;
         const txt = stroke.text || "";

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -551,14 +551,14 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 if (m.width > maxWidth) maxWidth = m.width;
             }
             const h = stroke.width;
-            const padX = h * 0.5;
-            const padY = h * 0.3;
+            const padX = h * (isBubble ? Constants.textBubblePaddingMultiplierX : Constants.textPaddingMultiplierX);
+            const padY = h * (isBubble ? Constants.textBubblePaddingMultiplierY : Constants.textPaddingMultiplierY);
             const totalH = lines.length * lineHeight - (lineHeight - h);
             const rx = pt.x - padX;
             const ry = pt.y - padY;
             const rw = maxWidth + padX * 2;
             const rh = totalH + padY * 2;
-            const radius = Math.max(8, stroke.cornerRadius || 8);
+            const radius = isBubble ? Math.max(Constants.textBubbleMinRadius, stroke.cornerRadius || Constants.textBubbleDefaultRadius) : (stroke.cornerRadius || 0);
 
             ctx.save();
 
@@ -600,28 +600,52 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
 
                 if (activeEdge === "top") {
                     let closestX = Math.max(rx, Math.min(tx, rx + rw));
-                    closestX = Math.max(rx + radius + tailBaseSize, Math.min(closestX, rx + rw - radius - tailBaseSize));
+                    const minAllowedX = rx + radius + tailBaseSize;
+                    const maxAllowedX = rx + rw - radius - tailBaseSize;
+                    if (maxAllowedX >= minAllowedX) {
+                        closestX = Math.max(minAllowedX, Math.min(closestX, maxAllowedX));
+                    } else {
+                        closestX = rx + rw / 2;
+                    }
                     base1X = closestX - tailBaseSize;
                     base1Y = ry;
                     base2X = closestX + tailBaseSize;
                     base2Y = ry;
                 } else if (activeEdge === "bottom") {
                     let closestX = Math.max(rx, Math.min(tx, rx + rw));
-                    closestX = Math.max(rx + radius + tailBaseSize, Math.min(closestX, rx + rw - radius - tailBaseSize));
+                    const minAllowedX = rx + radius + tailBaseSize;
+                    const maxAllowedX = rx + rw - radius - tailBaseSize;
+                    if (maxAllowedX >= minAllowedX) {
+                        closestX = Math.max(minAllowedX, Math.min(closestX, maxAllowedX));
+                    } else {
+                        closestX = rx + rw / 2;
+                    }
                     base1X = closestX - tailBaseSize;
                     base1Y = ry + rh;
                     base2X = closestX + tailBaseSize;
                     base2Y = ry + rh;
                 } else if (activeEdge === "left") {
                     let closestY = Math.max(ry, Math.min(ty, ry + rh));
-                    closestY = Math.max(ry + radius + tailBaseSize, Math.min(closestY, ry + rh - radius - tailBaseSize));
+                    const minAllowedY = ry + radius + tailBaseSize;
+                    const maxAllowedY = ry + rh - radius - tailBaseSize;
+                    if (maxAllowedY >= minAllowedY) {
+                        closestY = Math.max(minAllowedY, Math.min(closestY, maxAllowedY));
+                    } else {
+                        closestY = ry + rh / 2;
+                    }
                     base1X = rx;
                     base1Y = closestY - tailBaseSize;
                     base2X = rx;
                     base2Y = closestY + tailBaseSize;
                 } else if (activeEdge === "right") {
                     let closestY = Math.max(ry, Math.min(ty, ry + rh));
-                    closestY = Math.max(ry + radius + tailBaseSize, Math.min(closestY, ry + rh - radius - tailBaseSize));
+                    const minAllowedY = ry + radius + tailBaseSize;
+                    const maxAllowedY = ry + rh - radius - tailBaseSize;
+                    if (maxAllowedY >= minAllowedY) {
+                        closestY = Math.max(minAllowedY, Math.min(closestY, maxAllowedY));
+                    } else {
+                        closestY = ry + rh / 2;
+                    }
                     base1X = rx + rw;
                     base1Y = closestY - tailBaseSize;
                     base2X = rx + rw;

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -462,8 +462,8 @@ function getStrokeBBox(stroke, estimateTextWidthFn) {
         let textY = txtPt.y;
 
         if (stroke.hasBackground || stroke.isSpeechBubble) {
-            const padX = fontSize * (stroke.isSpeechBubble ? 0.5 : Constants.textPaddingMultiplierX);
-            const padY = fontSize * (stroke.isSpeechBubble ? 0.3 : Constants.textPaddingMultiplierY);
+            const padX = fontSize * (stroke.isSpeechBubble ? Constants.textBubblePaddingMultiplierX : Constants.textPaddingMultiplierX);
+            const padY = fontSize * (stroke.isSpeechBubble ? Constants.textBubblePaddingMultiplierY : Constants.textPaddingMultiplierY);
             textX -= padX;
             textY -= padY;
             textW += padX * 2;
@@ -660,8 +660,8 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
             let textX = txtPt.x;
 
             if (stroke.isSpeechBubble) {
-                const padX = fontSize * 0.5;
-                const padY = fontSize * 0.3;
+                const padX = fontSize * Constants.textBubblePaddingMultiplierX;
+                const padY = fontSize * Constants.textBubblePaddingMultiplierY;
                 textX -= padX;
                 textY -= padY;
                 textW += padX * 2;

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -446,7 +446,7 @@ function getStrokeBBox(stroke, estimateTextWidthFn) {
     if (len === 0) return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
 
     if (stroke.tool === "text") {
-        const p0 = pts[0];
+        const txtPt = (stroke.isSpeechBubble && len >= 2) ? pts[1] : pts[0];
         const fontSize = stroke.width;
         const txt = stroke.text || "";
         const lines = String(txt).split("\n");
@@ -458,12 +458,12 @@ function getStrokeBBox(stroke, estimateTextWidthFn) {
             textW = Math.max(Constants.minTextWidth, estimateTextWidthFn(txt, fontSize, stroke.isBold === true, stroke.isMonospace === true));
         }
         let textH = fontSize + (numLines - 1) * lineHeight;
-        let textX = p0.x;
-        let textY = p0.y;
+        let textX = txtPt.x;
+        let textY = txtPt.y;
 
-        if (stroke.hasBackground) {
-            const padX = fontSize * Constants.textPaddingMultiplierX;
-            const padY = fontSize * Constants.textPaddingMultiplierY;
+        if (stroke.hasBackground || stroke.isSpeechBubble) {
+            const padX = fontSize * (stroke.isSpeechBubble ? 0.5 : Constants.textPaddingMultiplierX);
+            const padY = fontSize * (stroke.isSpeechBubble ? 0.3 : Constants.textPaddingMultiplierY);
             textX -= padX;
             textY -= padY;
             textW += padX * 2;
@@ -473,6 +473,14 @@ function getStrokeBBox(stroke, estimateTextWidthFn) {
         maxX = textX + textW;
         minY = textY;
         maxY = textY + textH;
+
+        if (stroke.isSpeechBubble && len >= 2) {
+            const pTarget = pts[0];
+            minX = Math.min(minX, pTarget.x);
+            maxX = Math.max(maxX, pTarget.x);
+            minY = Math.min(minY, pTarget.y);
+            maxY = Math.max(maxY, pTarget.y);
+        }
     } else if (stroke.tool === "stamp") {
         const radius = stroke.width * Constants.stampRadiusMultiplier + Constants.stampSelectThresholdOffset;
         if (stroke.hasLeaderLine && len >= 2) {
@@ -639,7 +647,7 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 if (dist <= radius) return i;
             }
         } else if (stroke.tool === "text") {
-            const p0 = stroke.points[0];
+            const txtPt = (stroke.isSpeechBubble && stroke.points.length >= 2) ? stroke.points[1] : stroke.points[0];
             const fontSize = stroke.width;
             const txt = stroke.text || "";
             const lines = String(txt).split("\n");
@@ -648,20 +656,51 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
 
             let textW = Math.max(Constants.minTextWidth, estimateTextWidthFn(txt, fontSize, stroke.isBold === true, stroke.isMonospace === true));
             let textH = fontSize + (numLines - 1) * lineHeight;
-            let textY = p0.y;
-            let textX = p0.x;
+            let textY = txtPt.y;
+            let textX = txtPt.x;
 
-            if (stroke.hasBackground) {
-                const padX = fontSize * Constants.textPaddingMultiplierX;
-                const padY = fontSize * Constants.textPaddingMultiplierY;
+            if (stroke.isSpeechBubble) {
+                const padX = fontSize * 0.5;
+                const padY = fontSize * 0.3;
                 textX -= padX;
                 textY -= padY;
                 textW += padX * 2;
                 textH += padY * 2;
-            }
 
-            if (mx >= textX - Constants.ocrSelectionPadding && mx <= textX + textW + Constants.ocrSelectionPadding && my >= textY - Constants.ocrSelectionPadding && my <= textY + textH + Constants.ocrSelectionPadding) {
-                return i;
+                if (mx >= textX - Constants.ocrSelectionPadding && mx <= textX + textW + Constants.ocrSelectionPadding && my >= textY - Constants.ocrSelectionPadding && my <= textY + textH + Constants.ocrSelectionPadding) {
+                    return i;
+                }
+
+                if (stroke.points.length >= 2) {
+                    const pTarget = stroke.points[0];
+                    const dx = pTarget.x - txtPt.x;
+                    const dy = pTarget.y - txtPt.y;
+                    const lenSq = dx * dx + dy * dy;
+                    let dist = Infinity;
+                    if (lenSq === 0) {
+                        dist = Math.sqrt((mx - txtPt.x) * (mx - txtPt.x) + (my - txtPt.y) * (my - txtPt.y));
+                    } else {
+                        let t = ((mx - txtPt.x) * dx + (my - txtPt.y) * dy) / lenSq;
+                        t = Math.max(0, Math.min(1, t));
+                        const px = txtPt.x + t * dx;
+                        const py = txtPt.y + t * dy;
+                        dist = Math.sqrt((mx - px) * (mx - px) + (my - py) * (my - py));
+                    }
+                    if (dist < threshold) return i;
+                }
+            } else {
+                if (stroke.hasBackground) {
+                    const padX = fontSize * Constants.textPaddingMultiplierX;
+                    const padY = fontSize * Constants.textPaddingMultiplierY;
+                    textX -= padX;
+                    textY -= padY;
+                    textW += padX * 2;
+                    textH += padY * 2;
+                }
+
+                if (mx >= textX - Constants.ocrSelectionPadding && mx <= textX + textW + Constants.ocrSelectionPadding && my >= textY - Constants.ocrSelectionPadding && my <= textY + textH + Constants.ocrSelectionPadding) {
+                    return i;
+                }
             }
         } else if (stroke.tool === "callout" && stroke.points.length === 4) {
             const srcP0 = stroke.points[0];
@@ -751,6 +790,14 @@ function getStrokeHandleAt(mx, my, stroke, estimateTextWidthFn) {
         if (Math.abs(mx - cx) <= threshold && Math.abs(my - y2) <= threshold) return "src_bc";
         if (Math.abs(mx - x1) <= threshold && Math.abs(my - cy) <= threshold) return "src_lc";
         if (Math.abs(mx - x2) <= threshold && Math.abs(my - cy) <= threshold) return "src_rc";
+        return "none";
+    }
+
+    if (stroke.tool === "text" && stroke.isSpeechBubble && stroke.points.length >= 2) {
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[1];
+        if (Math.abs(mx - p0.x) <= threshold && Math.abs(my - p0.y) <= threshold) return "start";
+        if (Math.abs(mx - p1.x) <= threshold && Math.abs(my - p1.y) <= threshold) return "end";
         return "none";
     }
 

--- a/components/StrokeProperties.js
+++ b/components/StrokeProperties.js
@@ -18,6 +18,7 @@ function copyStrokeProperties(source, target) {
     if (source.redactMode !== undefined) target.redactMode = source.redactMode;
     if (source.redactShape !== undefined) target.redactShape = source.redactShape;
     if (source.hasLeaderLine !== undefined) target.hasLeaderLine = source.hasLeaderLine;
+    if (source.isSpeechBubble !== undefined) target.isSpeechBubble = source.isSpeechBubble;
     if (source.calloutLinkLines !== undefined) target.calloutLinkLines = source.calloutLinkLines;
     if (source.id !== undefined) target.id = source.id;
 }


### PR DESCRIPTION
## What
Add speech bubble / balloon as a variant of the text tool:
- Dragging the text tool (dragging distance > 10px) registers a speech bubble with starting/ending coords (points[0] for pointer target, points[1] for bubble position).
- Normal clicks place normal text.
- Supports adjusting the pointer target handle and text bubble handle in select mode, and moving the entire bubble and pointer as a group.
- The bubble renders with a rounded rectangle, triangular pointer tail, and border.
- The bubble background automatically adapts to text color brightness to maintain contrast.
- Double-clicking to edit works properly.
- Switched off canvas shadowBlur to ensure smooth lag-free rendering.

## Why
Resolves the missing speech bubble feature request to allow pointing text annotations to specific areas in the screenshot.

Closes #114

## Summary by Sourcery

Add a speech bubble variant to the text annotation tool, including pointer-tail geometry, selection/move handles, editing support, and documentation updates.

New Features:
- Support speech bubbles as a draggable variant of the text tool, with separate tail target and bubble positions.
- Allow editing of speech bubbles via double-click, including preserving bubble/tail coordinates when updating text.

Enhancements:
- Adjust text background padding and corner radii to better suit bubbles and rounded text backgrounds.
- Improve text selection, hit-testing, and bounding box calculations to account for speech bubble geometry and leader lines.
- Unify drag handling logic so speech bubbles behave consistently with line- and arrow-like tools when moving endpoints.

Documentation:
- Document the speech bubble behavior for the text tool and leader-line behavior for the stamp tool in the README, and clarify scrolling capture instructions.