### PR TITLE
fix(selection): unify dashed selection style across all tools

### DIFF
--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -628,6 +628,7 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
         const cy = (y1 + y2) / 2;
 
         if (rw > 0 && rh > 0) {
+            ctx.save();
             ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
             ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
             ctx.setLineDash([4, 4]);
@@ -638,6 +639,7 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
             ctx.arc(0, 0, 1, 0, 2 * Math.PI);
             ctx.restore();
             ctx.stroke();
+            ctx.restore();
         }
 
         ctx.fillStyle = "#ffffff";

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -9,6 +9,37 @@
  */
 
 /**
+ * Sets up the canvas context for drawing a dashed selection border with auto-contrast color.
+ * @param {object} ctx - The Canvas 2D context.
+ * @param {object} stroke - The stroke data object (provides color and width).
+ * @param {object} Helpers - Reference to the Helpers.js library.
+ * @param {object} Qt - The Qt object for color utilities.
+ */
+function setDashedSelectionStyle(ctx, stroke, Helpers, Qt) {
+    ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
+    ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
+    ctx.setLineDash([4, 4]);
+}
+
+/**
+ * Draws white-filled selection handle squares with Theme.primary stroke at each point.
+ * @param {object} ctx - The Canvas 2D context.
+ * @param {Array} points - Array of {x, y} handle positions.
+ * @param {number} hh - Half the handle size (for centering).
+ * @param {number} hs - Handle size in pixels.
+ * @param {object} Theme - The Theme object.
+ */
+function drawHandlePoints(ctx, points, hh, hs, Theme) {
+    ctx.fillStyle = "#ffffff";
+    ctx.strokeStyle = Theme.primary;
+    ctx.lineWidth = 1.5;
+    for (let p of points) {
+        ctx.fillRect(p.x - hh, p.y - hh, hs, hs);
+        ctx.strokeRect(p.x - hh, p.y - hh, hs, hs);
+    }
+}
+
+/**
  * Draws a single stroke (annotation) onto the provided context.
  * @param {object} ctx - The Canvas 2D context.
  * @param {object} stroke - The stroke data object.
@@ -629,9 +660,7 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
 
         if (rw > 0 && rh > 0) {
             ctx.save();
-            ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
-            ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
-            ctx.setLineDash([4, 4]);
+            setDashedSelectionStyle(ctx, stroke, Helpers, Qt);
             ctx.save();
             ctx.beginPath();
             ctx.translate(x1 + rw / 2, y1 + rh / 2);
@@ -642,17 +671,10 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
             ctx.restore();
         }
 
-        ctx.fillStyle = "#ffffff";
-        ctx.strokeStyle = Theme.primary;
-        ctx.lineWidth = 1.5;
-        const handlePoints = [
+        drawHandlePoints(ctx, [
             {x: x1, y: y1}, {x: x2, y: y1}, {x: x1, y: y2}, {x: x2, y: y2},
             {x: cx, y: y1}, {x: cx, y: y2}, {x: x1, y: cy}, {x: x2, y: cy}
-        ];
-        for (let p of handlePoints) {
-            ctx.fillRect(p.x - hh, p.y - hh, hs, hs);
-            ctx.strokeRect(p.x - hh, p.y - hh, hs, hs);
-        }
+        ], hh, hs, Theme);
         return;
     }
 
@@ -669,23 +691,14 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
         const cy = (y1 + y2) / 2;
 
         ctx.save();
-        ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
-        ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
-        ctx.setLineDash([4, 4]);
+        setDashedSelectionStyle(ctx, stroke, Helpers, Qt);
         ctx.strokeRect(x1, y1, x2 - x1, y2 - y1);
         ctx.restore();
 
-        ctx.fillStyle = "#ffffff";
-        ctx.strokeStyle = Theme.primary;
-        ctx.lineWidth = 1.5;
-        const handlePoints = [
+        drawHandlePoints(ctx, [
             {x: x1, y: y1}, {x: x2, y: y1}, {x: x1, y: y2}, {x: x2, y: y2},
             {x: cx, y: y1}, {x: cx, y: y2}, {x: x1, y: cy}, {x: x2, y: cy}
-        ];
-        for (let p of handlePoints) {
-            ctx.fillRect(p.x - hh, p.y - hh, hs, hs);
-            ctx.strokeRect(p.x - hh, p.y - hh, hs, hs);
-        }
+        ], hh, hs, Theme);
         return;
     }
 
@@ -697,9 +710,7 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
         // Draw dashed selection line along the stroke path (except highlighter to keep highlighted text readable)
         if (stroke.tool !== "highlighter") {
             ctx.save();
-            ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
-            ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
-            ctx.setLineDash([4, 4]);
+            setDashedSelectionStyle(ctx, stroke, Helpers, Qt);
             ctx.beginPath();
             ctx.moveTo(p0.x, p0.y);
             ctx.lineTo(p1.x, p1.y);
@@ -760,9 +771,7 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
         }
         const sp = 6;
         ctx.save();
-        ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
-        ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
-        ctx.setLineDash([4, 4]);
+        setDashedSelectionStyle(ctx, stroke, Helpers, Qt);
         ctx.strokeRect(tx - sp, ty - sp, tw + sp * 2, th + sp * 2);
         ctx.restore();
         return;
@@ -798,25 +807,16 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
         if (sw <= 0 || sh <= 0) return;
 
         ctx.save();
-        ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
-        ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
-        ctx.setLineDash([4, 4]);
+        setDashedSelectionStyle(ctx, stroke, Helpers, Qt);
         ctx.strokeRect(x1, y1, sw, sh);
         ctx.restore();
 
-        ctx.fillStyle = "#ffffff";
-        ctx.strokeStyle = Theme.primary;
-        ctx.lineWidth = 1.5;
-        const handlePoints = [
+        drawHandlePoints(ctx, [
             {x: x1, y: y1}, {x: x2, y: y1},
             {x: x1, y: y2}, {x: x2, y: y2},
             {x: cx, y: y1}, {x: cx, y: y2},
             {x: x1, y: cy}, {x: x2, y: cy}
-        ];
-        for (let p of handlePoints) {
-            ctx.fillRect(p.x - hh, p.y - hh, hs, hs);
-            ctx.strokeRect(p.x - hh, p.y - hh, hs, hs);
-        }
+        ], hh, hs, Theme);
         return;
     }
 }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -614,7 +614,47 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
     const hs = Constants.selectionHandleSize;
     const hh = hs / 2;
 
-    if (stroke.tool === "rect" || stroke.tool === "ellipse" || stroke.tool === "redact" ||
+    if (stroke.tool === "ellipse") {
+        if (stroke.points.length < 2) return;
+        const p0 = stroke.points[0];
+        const p1 = stroke.points[stroke.points.length - 1];
+        const x1 = Math.min(p0.x, p1.x);
+        const y1 = Math.min(p0.y, p1.y);
+        const rw = Math.abs(p1.x - p0.x);
+        const rh = Math.abs(p1.y - p0.y);
+        const x2 = x1 + rw;
+        const y2 = y1 + rh;
+        const cx = (x1 + x2) / 2;
+        const cy = (y1 + y2) / 2;
+
+        if (rw > 0 && rh > 0) {
+            ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
+            ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
+            ctx.setLineDash([4, 4]);
+            ctx.save();
+            ctx.beginPath();
+            ctx.translate(x1 + rw / 2, y1 + rh / 2);
+            ctx.scale(rw / 2, rh / 2);
+            ctx.arc(0, 0, 1, 0, 2 * Math.PI);
+            ctx.restore();
+            ctx.stroke();
+        }
+
+        ctx.fillStyle = "#ffffff";
+        ctx.strokeStyle = Theme.primary;
+        ctx.lineWidth = 1.5;
+        const handlePoints = [
+            {x: x1, y: y1}, {x: x2, y: y1}, {x: x1, y: y2}, {x: x2, y: y2},
+            {x: cx, y: y1}, {x: cx, y: y2}, {x: x1, y: cy}, {x: x2, y: cy}
+        ];
+        for (let p of handlePoints) {
+            ctx.fillRect(p.x - hh, p.y - hh, hs, hs);
+            ctx.strokeRect(p.x - hh, p.y - hh, hs, hs);
+        }
+        return;
+    }
+
+    if (stroke.tool === "rect" || stroke.tool === "redact" ||
         stroke.tool === "pixelate" || stroke.tool === "spotlight") {
         if (stroke.points.length < 2) return;
         const p0 = stroke.points[0];
@@ -627,8 +667,8 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
         const cy = (y1 + y2) / 2;
 
         ctx.save();
-        ctx.strokeStyle = Theme.primary;
-        ctx.lineWidth = 1;
+        ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
+        ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
         ctx.setLineDash([4, 4]);
         ctx.strokeRect(x1, y1, x2 - x1, y2 - y1);
         ctx.restore();
@@ -718,8 +758,8 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
         }
         const sp = 6;
         ctx.save();
-        ctx.strokeStyle = Theme.primary;
-        ctx.lineWidth = 1;
+        ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
+        ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
         ctx.setLineDash([4, 4]);
         ctx.strokeRect(tx - sp, ty - sp, tw + sp * 2, th + sp * 2);
         ctx.restore();
@@ -756,8 +796,8 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
         if (sw <= 0 || sh <= 0) return;
 
         ctx.save();
-        ctx.strokeStyle = Theme.primary;
-        ctx.lineWidth = 1;
+        ctx.strokeStyle = Helpers.getContrastingColor(stroke.color, Qt);
+        ctx.lineWidth = Math.max(1.5, Math.min(2.5, stroke.width / 2));
         ctx.setLineDash([4, 4]);
         ctx.strokeRect(x1, y1, sw, sh);
         ctx.restore();


### PR DESCRIPTION
## Summary

- Replace hardcoded `Theme.primary` with `Helpers.getContrastingColor(stroke.color, Qt)` for dashed selection border on rect, ellipse, text, and callout tools
- Match `lineWidth` formula (`Math.max(1.5, Math.min(2.5, stroke.width / 2))`) used by pen/line tools for consistency
- Ellipse selection now traces elliptical path instead of bounding rectangle

## Changes

| File | Change |
|------|--------|
| `components/DrawingRenderer.js` | Extracted ellipse into its own branch; updated dashed border color and width for rect, ellipse, text, callout |

## Testing

1. Draw a rect, ellipse, text, callout with various stroke widths and colors
2. Select each — dashed border should use auto-contrast color and proportional line width (1.5–2.5px)
3. Ellipse dashed border should follow elliptical path

## Summary by Sourcery

Unify dashed selection styling across drawing tools for consistent appearance.

Enhancements:
- Render ellipse selection borders along the actual elliptical path instead of the bounding rectangle.
- Use auto-contrasting colors for dashed selection borders based on the stroke color for rect, ellipse, text, and callout tools.
- Align dashed selection border line widths with the pen/line tools by making them proportional to stroke width.