### PR TITLE
refactor(constants): centralize magic numbers and optimize distance calculations

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -545,10 +545,10 @@ DankModal {
         const w = layout.w;
         const h = layout.h;
         
-        const opacity = (window.backdropShadowStrength / 100.0) * 0.55;
-        const STEPS = 12;
-        const maxOffset = 24.0;
-        const maxBlur = 45.0;
+        const opacity = (window.backdropShadowStrength / 100.0) * Constants.shadowBaseOpacityFactor;
+        const STEPS = Constants.defaultShadowSteps;
+        const maxOffset = Constants.maxShadowOffset;
+        const maxBlur = Constants.maxShadowBlur;
         
         // Draw 12 concentric shadow layers with quadratic spacing and falloff for smooth rendering
         for (let i = 1; i <= STEPS; i++) {

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -42,6 +42,20 @@ const textBubbleDefaultRadius = 8;
 const textBubbleMinRadius = 8;
 const textBubbleDragThreshold = 10;
 
+// Shadow rendering constants
+const defaultShadowSteps = 12;
+const maxShadowOffset = 24.0;
+const maxShadowBlur = 45.0;
+const shadowBaseOpacityFactor = 0.55;
+
+// Magnifier Loupe sizing
+const magnifierSize = 160;
+const magnifierRadius = 80;
+const magnifierCrosshairSize = 16;
+const magnifierBannerHeight = 56;
+const magnifierSwatchSize = 20;
+const magnifierSwatchRadius = 5;
+
 // Toolbar sizing constants (from ToolbarConstants.qml)
 const btnSize = 36;
 const iconSize = 18;
@@ -68,3 +82,4 @@ const subToolbarIconSize = 20;
 const compactControlHeight = 40;
 const customRatioPopoverHeight = 120;
 const verticalSelectorItemWidth = 32;
+

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -532,13 +532,13 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 const lenSq = dx * dx + dy * dy;
                 let dist = Infinity;
                 if (lenSq === 0) {
-                    dist = Math.sqrt((mx - A.x) * (mx - A.x) + (my - A.y) * (my - A.y));
+                    dist = Math.hypot(mx - A.x, my - A.y);
                 } else {
                     let t = ((mx - A.x) * dx + (my - A.y) * dy) / lenSq;
                     t = Math.max(0, Math.min(1, t));
                     const px = A.x + t * dx;
                     const py = A.y + t * dy;
-                    dist = Math.sqrt((mx - px) * (mx - px) + (my - py) * (my - py));
+                    dist = Math.hypot(mx - px, my - py);
                 }
                 if (dist < threshold) return i;
             }
@@ -606,13 +606,13 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
             const lenSq = dx * dx + dy * dy;
             let dist = Infinity;
             if (lenSq === 0) {
-                dist = Math.sqrt((mx - p0.x) * (mx - p0.x) + (my - p0.y) * (my - p0.y));
+                dist = Math.hypot(mx - p0.x, my - p0.y);
             } else {
                 let t = ((mx - p0.x) * dx + (my - p0.y) * dy) / lenSq;
                 t = Math.max(0, Math.min(1, t));
                 const px = p0.x + t * dx;
                 const py = p0.y + t * dy;
-                dist = Math.sqrt((mx - px) * (mx - px) + (my - py) * (my - py));
+                dist = Math.hypot(mx - px, my - py);
             }
             if (dist < threshold) return i;
         } else if (stroke.tool === "stamp") {
@@ -622,7 +622,7 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 const p1 = stroke.points[1];
 
                 // Check stamp circle at points[1]
-                const distStamp = Math.sqrt((mx - p1.x) * (mx - p1.x) + (my - p1.y) * (my - p1.y));
+                const distStamp = Math.hypot(mx - p1.x, my - p1.y);
                 if (distStamp <= radius) return i;
 
                 // Check leader line segment points[0] -> points[1]
@@ -631,18 +631,18 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 const lenSq = dx * dx + dy * dy;
                 let distLine = Infinity;
                 if (lenSq === 0) {
-                    distLine = Math.sqrt((mx - p0.x) * (mx - p0.x) + (my - p0.y) * (my - p0.y));
+                    distLine = Math.hypot(mx - p0.x, my - p0.y);
                 } else {
                     let t = ((mx - p0.x) * dx + (my - p0.y) * dy) / lenSq;
                     t = Math.max(0, Math.min(1, t));
                     const px = p0.x + t * dx;
                     const py = p0.y + t * dy;
-                    distLine = Math.sqrt((mx - px) * (mx - px) + (my - py) * (my - py));
+                    distLine = Math.hypot(mx - px, my - py);
                 }
                 if (distLine < threshold) return i;
             } else {
                 const p0 = stroke.points[0];
-                const dist = Math.sqrt((mx - p0.x) * (mx - p0.x) + (my - p0.y) * (my - p0.y));
+                const dist = Math.hypot(mx - p0.x, my - p0.y);
                 if (dist <= radius) return i;
             }
         } else if (stroke.tool === "text") {

--- a/components/MagnifierLoupe.qml
+++ b/components/MagnifierLoupe.qml
@@ -5,12 +5,13 @@ import qs.Widgets
 import qs.Modals.Common
 import qs.Services
 import "../dms-common"
+import "Constants.js" as Constants
 
 Rectangle {
     id: magnifier
-    width: 160
-    height: 160
-    radius: 80
+    width: Constants.magnifierSize
+    height: Constants.magnifierSize
+    radius: Constants.magnifierRadius
     border.color: Theme.primary
     border.width: 2
     color: "black"
@@ -124,14 +125,14 @@ Rectangle {
 
     Rectangle {
         anchors.centerIn: parent
-        width: 16
+        width: Constants.magnifierCrosshairSize
         height: 1.5
         color: Theme.primary
     }
     Rectangle {
         anchors.centerIn: parent
         width: 1.5
-        height: 16
+        height: Constants.magnifierCrosshairSize
         color: Theme.primary
     }
 
@@ -142,7 +143,7 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        height: 56
+        height: Constants.magnifierBannerHeight
         color: Theme.withAlpha(Theme.surfaceContainer, 0.9)
         border.color: Theme.withAlpha(Theme.outline, 0.15)
         border.width: 1
@@ -153,9 +154,9 @@ Rectangle {
 
             // Color preview swatch
             Rectangle {
-                width: 20
-                height: 20
-                radius: 5
+                width: Constants.magnifierSwatchSize
+                height: Constants.magnifierSwatchSize
+                radius: Constants.magnifierSwatchRadius
                 color: window.hoveredColor
                 border.color: Theme.withAlpha(Theme.outline, 0.3)
                 border.width: 1


### PR DESCRIPTION
## What
- Centralized shadow rendering parameters (`defaultShadowSteps`, `maxShadowOffset`, `maxShadowBlur`, `shadowBaseOpacityFactor`) and Magnifier Loupe dimensions (`magnifierSize`, `magnifierRadius`, `magnifierCrosshairSize`, `magnifierBannerHeight`, `magnifierSwatchSize`, `magnifierSwatchRadius`) into [components/Constants.js](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/Constants.js).
- Updated [QuickCaptureModal.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/QuickCaptureModal.qml) and [components/MagnifierLoupe.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/MagnifierLoupe.qml) to use centralized constants.
- Refactored 6 redundant distance calculation loops in `findStrokeAt` in [components/Helpers.js](file:///home/loccun/Documents/GitHub/dms-quick-capture/components/Helpers.js) to use `Math.hypot`.

## Why
- Eliminates hardcoded magic numbers across QML components.
- Improves code maintainability, consistency, and readability.

## How tested
- Restarted DMS shell (`dms restart`) and verified UI components render cleanly.

## Summary by Sourcery

Centralize UI sizing and shadow parameters in shared constants and streamline distance calculations in stroke hit-testing.

Enhancements:
- Replace hardcoded Magnifier Loupe dimensions with values from components/Constants.js.
- Expose shadow rendering configuration in components/Constants.js and update QuickCaptureModal to consume these shared constants.
- Simplify multiple distance computations in Helpers.findStrokeAt by using Math.hypot instead of manual squared-difference formulas.