### PR TITLE
refactor(qml): introduce pluginData helper to clean up repeated bindings and functions

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1121,42 +1121,20 @@ DankModal {
     }
 
     function getPresetTool(index) {
-        let pData = {};
-        if (window.parentWidget && window.parentWidget.pluginData) {
-            pData = window.parentWidget.pluginData;
-        } else if (typeof config !== "undefined" && config.pluginData) {
-            pData = config.pluginData;
-        }
-        const val = pData["preset_" + index + "_tool"];
-        if (val !== undefined) return val;
-        
-        return Constants.defaultRadialTools[index] || "none";
+        const val = window.pluginData["preset_" + index + "_tool"];
+        return val !== undefined ? val : (Constants.defaultRadialTools[index] || "none");
     }
 
     function getPresetColor(index) {
-        let pData = {};
-        if (window.parentWidget && window.parentWidget.pluginData) {
-            pData = window.parentWidget.pluginData;
-        } else if (typeof config !== "undefined" && config.pluginData) {
-            pData = config.pluginData;
-        }
-        const val = pData["preset_" + index + "_color"];
+        const val = window.pluginData["preset_" + index + "_color"];
         if (val !== undefined) return val;
-        
         const defaultColors = ["primary", "primary", "primary", "primary", "primary", "primary", "#000000", "#ffffff"];
         return defaultColors[index] || "primary";
     }
 
     function getPresetThickness(index) {
-        let pData = {};
-        if (window.parentWidget && window.parentWidget.pluginData) {
-            pData = window.parentWidget.pluginData;
-        } else if (typeof config !== "undefined" && config.pluginData) {
-            pData = config.pluginData;
-        }
-        const val = pData["preset_" + index + "_thickness"];
-        if (val !== undefined) return parseInt(val, 10) || 6;
-        return 6;
+        const val = window.pluginData["preset_" + index + "_thickness"];
+        return val !== undefined ? (parseInt(val, 10) || 6) : 6;
     }
 
     function updateRadialPresets() {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -680,36 +680,38 @@ DankModal {
     }
     backgroundColor: Theme.withAlpha(Theme.surfaceContainer, Theme.popupTransparency)
 
-    readonly property bool textMonospace: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textMonospace !== undefined ? window.parentWidget.pluginData.textMonospace : false
+    readonly property var pluginData: (window.parentWidget && window.parentWidget.pluginData) ? window.parentWidget.pluginData : ({})
+
+    readonly property bool textMonospace: pluginData.textMonospace !== undefined ? pluginData.textMonospace : false
     
     // Rich Text Options
-    property bool textBold: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textBold !== undefined ? window.parentWidget.pluginData.textBold : false
+    property bool textBold: pluginData.textBold !== undefined ? pluginData.textBold : false
     onTextBoldChanged: {
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
-    property bool textItalic: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textItalic !== undefined ? window.parentWidget.pluginData.textItalic : false
+    property bool textItalic: pluginData.textItalic !== undefined ? pluginData.textItalic : false
     onTextItalicChanged: {
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
-    property bool textUnderline: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textUnderline !== undefined ? window.parentWidget.pluginData.textUnderline : false
+    property bool textUnderline: pluginData.textUnderline !== undefined ? pluginData.textUnderline : false
     onTextUnderlineChanged: {
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
-    property bool textBackground: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textBackground !== undefined ? window.parentWidget.pluginData.textBackground : false
+    property bool textBackground: pluginData.textBackground !== undefined ? pluginData.textBackground : false
     onTextBackgroundChanged: {
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
-    property int textCornerRadius: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textCornerRadius !== undefined ? window.parentWidget.pluginData.textCornerRadius : 8
+    property int textCornerRadius: pluginData.textCornerRadius !== undefined ? pluginData.textCornerRadius : 8
     onTextCornerRadiusChanged: {
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
-    property string textFontFamily: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textFontFamily !== undefined ? window.parentWidget.pluginData.textFontFamily : (textMonospace ? "monospace" : "sans-serif")
+    property string textFontFamily: pluginData.textFontFamily !== undefined ? pluginData.textFontFamily : (textMonospace ? "monospace" : "sans-serif")
     onTextFontFamilyChanged: {
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
-    readonly property string textInputMode: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textInputMode !== undefined ? window.parentWidget.pluginData.textInputMode : "inline"
-    readonly property string toolbarPosition: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.toolbarPosition !== undefined ? window.parentWidget.pluginData.toolbarPosition : "bottom"
-    readonly property bool configShowToolbar: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.showToolbar !== undefined ? window.parentWidget.pluginData.showToolbar : true
+    readonly property string textInputMode: pluginData.textInputMode !== undefined ? pluginData.textInputMode : "inline"
+    readonly property string toolbarPosition: pluginData.toolbarPosition !== undefined ? pluginData.toolbarPosition : "bottom"
+    readonly property bool configShowToolbar: pluginData.showToolbar !== undefined ? pluginData.showToolbar : true
     readonly property bool enableMagnifier: true
     property bool toolbarVisible: true
     onConfigShowToolbarChanged: {


### PR DESCRIPTION
## What
- Declared a central `readonly property var pluginData: (window.parentWidget && window.parentWidget.pluginData) ? window.parentWidget.pluginData : ({})` property helper in [QuickCaptureModal.qml](file:///home/loccun/Documents/GitHub/dms-quick-capture/QuickCaptureModal.qml).
- Simplified 10 repeated `textBold`, `textItalic`, `textUnderline`, `textBackground`, `textCornerRadius`, `textFontFamily`, `textInputMode`, `toolbarPosition`, `configShowToolbar`, `textMonospace` property bindings.
- Simplified `getPresetTool`, `getPresetColor`, and `getPresetThickness` functions to use the `pluginData` helper, removing 22 lines of duplicated lookup logic.

## Why
- Eliminates repetitive 100+ char binding chains.
- Reduces QML binding re-evaluation overhead and improves readability.

## How tested
- Verified via `dms restart` on desktop.