### PR TITLE
feat: add real-time pen smoothing with EMA filter

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -247,6 +247,7 @@ DankModal {
     property color autoBackdropSolidColor: Theme.primary
 
     // Intensity Management
+    property real penSmoothingAlpha: 0.4
     property int strokeWidth: 8
     property int pixelateIntensity: 8
     property bool pixelateRandomize: true

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ git checkout main && git pull
 | <kbd>B</kbd> | Backdrop Options |
 | <kbd>V</kbd> | Select |
 | <kbd>X</kbd> | Toggle Hide/Show Annotations |
-| <kbd>Tab</kbd> | Toggle between 2 latest radial presets |
+| <kbd>Tab</kbd> | Toggle between Select tool and last active tool (quickly move newly drawn strokes), or between 2 latest radial presets |
 
 ### Drawing & Editing
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ git checkout main && git pull
 | <kbd>B</kbd> | Backdrop Options |
 | <kbd>V</kbd> | Select |
 | <kbd>X</kbd> | Toggle Hide/Show Annotations |
-| <kbd>Tab</kbd> | Toggle between Select tool and last active tool (quickly move newly drawn strokes), or between 2 latest radial presets |
+| <kbd>Tab</kbd> | Toggle between Select tool and last active tool, or between 2 latest radial presets |
 
 ### Drawing & Editing
 

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -352,7 +352,7 @@ MouseArea {
                         window.currentStroke.points.push(absPt);
                     }
                 } else {
-                    const alpha = window.penSmoothingAlpha;
+                    const alpha = Math.min(1, Math.max(0, window.penSmoothingAlpha));
                     penSmoothX = alpha * absPt.x + (1 - alpha) * penSmoothX;
                     penSmoothY = alpha * absPt.y + (1 - alpha) * penSmoothY;
                     window.currentStroke.points.push(Qt.point(penSmoothX, penSmoothY));
@@ -964,7 +964,9 @@ MouseArea {
          }
          window.pushStroke(window.currentStroke);
          window.currentStroke = null;
-    }
+         penSmoothX = 0;
+         penSmoothY = 0;
+     }
 
      onWheel: (wheel) => {
          const step = wheel.angleDelta.y > 0 ? 1 : -1;
@@ -1029,5 +1031,13 @@ MouseArea {
           window.showSizePreview = true;
           previewTimer.restart();
          wheel.accepted = true;
+     }
+
+     Connections {
+         target: window
+         function onCurrentToolChanged() {
+             penSmoothX = 0;
+             penSmoothY = 0;
+         }
      }
 }

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -29,6 +29,10 @@ MouseArea {
     property string hoveredHandle: "none"
     property int hoveredStrokeIdx: -1
 
+    // Pen real-time smoothing state (exponential moving average)
+    property real penSmoothX: 0
+    property real penSmoothY: 0
+
     function getAbsolutePoint(mx, my) {
         let rx = mx / window.editScale;
         let ry = my / window.editScale;
@@ -348,7 +352,10 @@ MouseArea {
                         window.currentStroke.points.push(absPt);
                     }
                 } else {
-                    window.currentStroke.points.push(absPt);
+                    const alpha = window.penSmoothingAlpha;
+                    penSmoothX = alpha * absPt.x + (1 - alpha) * penSmoothX;
+                    penSmoothY = alpha * absPt.y + (1 - alpha) * penSmoothY;
+                    window.currentStroke.points.push(Qt.point(penSmoothX, penSmoothY));
                 }
                } else if (window.currentTool === "redact") {
                  let finalPt = absPt;
@@ -761,6 +768,13 @@ MouseArea {
                  drawingCanvas.requestPaint();
              }
             return;
+        }
+
+        // Initialize pen smoothing state for real-time EMA filtering
+        if (window.currentTool === "pen") {
+            const pt = getAbsolutePoint(mouse.x, mouse.y);
+            penSmoothX = pt.x;
+            penSmoothY = pt.y;
         }
 
          window.currentStroke = {

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -289,7 +289,7 @@ Rectangle {
             // Actions
             Row {
                 spacing: Theme.spacingXS; anchors.verticalCenter: parent.verticalCenter
-                DankActionButton { iconName: "undo"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; tooltipText: "Undo (Ctrl+Z)"; onClicked: root.undoRequested() }
+                DankActionButton { iconName: "undo"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; tooltipText: qsTr("Undo (Ctrl+Z)"); onClicked: root.undoRequested() }
                 DankActionButton { iconName: "push_pin"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Float Window (Ctrl+F)"; onClicked: root.floatRequested() }
                 DankActionButton { iconName: "save"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Save (Ctrl+S)"; onClicked: root.saveRequested() }
                 DankActionButton { iconName: "content_copy"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Copy (Ctrl+C)"; onClicked: root.copyRequested() }
@@ -298,7 +298,7 @@ Rectangle {
 
             Rectangle { width: Constants.separatorThickness; height: Constants.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
-            DankActionButton { iconName: "close"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; iconColor: Theme.error; tooltipText: "Discard & Close (Esc)"; anchors.verticalCenter: parent.verticalCenter; onClicked: root.closeRequested() }
+            DankActionButton { iconName: "close"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; iconColor: Theme.error; tooltipText: qsTr("Discard & Close (Esc)"); anchors.verticalCenter: parent.verticalCenter; onClicked: root.closeRequested() }
         }
     }
 

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -289,7 +289,7 @@ Rectangle {
             // Actions
             Row {
                 spacing: Theme.spacingXS; anchors.verticalCenter: parent.verticalCenter
-                DankActionButton { iconName: "undo"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; onClicked: root.undoRequested() }
+                DankActionButton { iconName: "undo"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; tooltipText: "Undo (Ctrl+Z)"; onClicked: root.undoRequested() }
                 DankActionButton { iconName: "push_pin"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Float Window (Ctrl+F)"; onClicked: root.floatRequested() }
                 DankActionButton { iconName: "save"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Save (Ctrl+S)"; onClicked: root.saveRequested() }
                 DankActionButton { iconName: "content_copy"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Copy (Ctrl+C)"; onClicked: root.copyRequested() }
@@ -298,7 +298,7 @@ Rectangle {
 
             Rectangle { width: Constants.separatorThickness; height: Constants.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
-            DankActionButton { iconName: "close"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; iconColor: Theme.error; anchors.verticalCenter: parent.verticalCenter; onClicked: root.closeRequested() }
+            DankActionButton { iconName: "close"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; iconColor: Theme.error; tooltipText: "Discard & Close (Esc)"; anchors.verticalCenter: parent.verticalCenter; onClicked: root.closeRequested() }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add real-time exponential moving average (EMA) filter for pen input points during drawing (alpha=0.4)
- Initialize EMA state on pen press, apply on position change for smoother live preview
- Post-draw 6-pass weighted moving average retained for final polish
- Add `penSmoothingAlpha` property (default 0.4, configurable)
- Add tooltips for Undo (Ctrl+Z) and Close (Esc) buttons
- Update Tab shortcut docs in README (toggle between Select/last tool vs radial presets)

## Summary by Sourcery

Introduce configurable real-time smoothing for pen strokes and improve toolbar shortcuts discoverability.

New Features:
- Add exponential moving average smoothing for live pen input during drawing with configurable alpha parameter.
- Expose a penSmoothingAlpha property to control pen stroke real-time smoothing intensity.

Enhancements:
- Initialize and track pen smoothing state per stroke to produce smoother pen previews while drawing.
- Add keyboard shortcut tooltips to Undo and Close toolbar buttons for better usability.

Documentation:
- Clarify Tab shortcut behavior in the README to describe toggling between Select/last tool and radial presets.