### PR TITLE
feat(backdrop): add backdrop and canvas ratio presets popover

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -245,6 +245,40 @@ DankModal {
     property color autoBackdropGradientStart: Theme.primary
     property color autoBackdropGradientEnd: Theme.secondary
     property color autoBackdropSolidColor: Theme.primary
+    property var customBackdropPresets: []
+    property var hiddenPresetIds: []
+    readonly property var backdropPresets: {
+        var customMap = {};
+        if (window.customBackdropPresets) {
+            for (var i = 0; i < window.customBackdropPresets.length; i++) {
+                var cp = window.customBackdropPresets[i];
+                customMap[cp.id] = cp;
+            }
+        }
+
+        var list = [];
+        if (Constants && Constants.defaultBackdropPresets) {
+            for (var j = 0; j < Constants.defaultBackdropPresets.length; j++) {
+                var dp = Constants.defaultBackdropPresets[j];
+                if (!window.hiddenPresetIds || window.hiddenPresetIds.indexOf(dp.id) === -1) {
+                    if (customMap[dp.id]) {
+                        list.push(customMap[dp.id]);
+                    } else {
+                        list.push(dp);
+                    }
+                }
+            }
+        }
+        if (window.customBackdropPresets) {
+            for (var k = 0; k < window.customBackdropPresets.length; k++) {
+                var up = window.customBackdropPresets[k];
+                if (up.isCustomUserCreated && (!window.hiddenPresetIds || window.hiddenPresetIds.indexOf(up.id) === -1)) {
+                    list.push(up);
+                }
+            }
+        }
+        return list;
+    }
 
     // Intensity Management
     property real penSmoothingAlpha: 0.4
@@ -1822,6 +1856,20 @@ DankModal {
                 window.autoBackdropGradientEnd = data.autoBackdropGradientEnd;
                 window.autoBackdropSolidColor = data.autoBackdropSolidColor;
             }
+            if (data.user_backdrop_presets) {
+                try {
+                    window.customBackdropPresets = JSON.parse(data.user_backdrop_presets);
+                } catch (e) {
+                    console.error("Failed to parse user_backdrop_presets:", e);
+                }
+            }
+            if (data.hidden_backdrop_presets) {
+                try {
+                    window.hiddenPresetIds = JSON.parse(data.hidden_backdrop_presets);
+                } catch (e) {
+                    console.error("Failed to parse hidden_backdrop_presets:", e);
+                }
+            }
             if (window.activeCanvas) window.activeCanvas.requestPaint();
             window.restoreState = null;
             window.restoreSource = "";
@@ -1830,6 +1878,105 @@ DankModal {
         Qt.callLater(() => {
             if (modalFocusScope) modalFocusScope.forceActiveFocus();
         });
+    }
+
+    function applyBackdropPreset(preset) {
+        if (!preset) return;
+        if (preset.mode !== undefined) window.backdropMode = preset.mode;
+        if (preset.solidColor !== undefined) window.backdropSolidColor = preset.solidColor;
+        if (preset.gradientStart !== undefined) window.backdropGradientStart = preset.gradientStart;
+        if (preset.gradientEnd !== undefined) window.backdropGradientEnd = preset.gradientEnd;
+        if (preset.gradientAngle !== undefined) window.backdropGradientAngle = preset.gradientAngle;
+        if (preset.padding !== undefined) window.backdropPadding = preset.padding;
+        if (preset.cornerRadius !== undefined) window.backdropCornerRadius = preset.cornerRadius;
+        if (preset.shadowStrength !== undefined) window.backdropShadowStrength = preset.shadowStrength;
+        if (preset.aspectRatio !== undefined) window.backdropAspectRatio = preset.aspectRatio;
+        if (preset.customAspectRatio !== undefined) window.customAspectRatio = preset.customAspectRatio;
+        window.hasUserCustomizedBackdrop = true;
+        window.requestPaintAll();
+    }
+
+    function saveCurrentBackdropAsPreset() {
+        const idx = window.customBackdropPresets.length + 1;
+        const newPreset = {
+            id: "custom_" + Date.now(),
+            name: "Custom " + idx,
+            mode: window.backdropMode,
+            solidColor: window.backdropSolidColor.toString(),
+            gradientStart: window.backdropGradientStart.toString(),
+            gradientEnd: window.backdropGradientEnd.toString(),
+            gradientAngle: window.backdropGradientAngle,
+            padding: window.backdropPadding,
+            cornerRadius: window.backdropCornerRadius,
+            shadowStrength: window.backdropShadowStrength,
+            aspectRatio: window.backdropAspectRatio,
+            customAspectRatio: window.customAspectRatio,
+            isCustomUserCreated: true
+        };
+        const newList = [...window.customBackdropPresets, newPreset];
+        window.customBackdropPresets = newList;
+        if (window.parentWidget && window.parentWidget.pluginService) {
+            window.parentWidget.pluginService.savePluginData("quickCapture", "user_backdrop_presets", JSON.stringify(newList));
+        }
+    }
+
+    function deletePreset(presetId) {
+        if (!presetId) return;
+        const newCustom = window.customBackdropPresets.filter(p => p.id !== presetId);
+        const newHidden = window.hiddenPresetIds.indexOf(presetId) === -1 ? [...window.hiddenPresetIds, presetId] : window.hiddenPresetIds;
+        window.customBackdropPresets = newCustom;
+        window.hiddenPresetIds = newHidden;
+        if (window.parentWidget && window.parentWidget.pluginService) {
+            window.parentWidget.pluginService.savePluginData("quickCapture", "user_backdrop_presets", JSON.stringify(newCustom));
+            window.parentWidget.pluginService.savePluginData("quickCapture", "hidden_backdrop_presets", JSON.stringify(newHidden));
+        }
+    }
+
+    function updatePresetWithCurrent(presetId) {
+        if (!presetId) return;
+        const currentData = {
+            mode: window.backdropMode,
+            solidColor: window.backdropSolidColor.toString(),
+            gradientStart: window.backdropGradientStart.toString(),
+            gradientEnd: window.backdropGradientEnd.toString(),
+            gradientAngle: window.backdropGradientAngle,
+            padding: window.backdropPadding,
+            cornerRadius: window.backdropCornerRadius,
+            shadowStrength: window.backdropShadowStrength,
+            aspectRatio: window.backdropAspectRatio,
+            customAspectRatio: window.customAspectRatio
+        };
+
+        const existingIdx = window.customBackdropPresets.findIndex(p => p.id === presetId);
+        let newList;
+        if (existingIdx !== -1) {
+            newList = window.customBackdropPresets.map(p => p.id === presetId ? Object.assign({}, p, currentData) : p);
+        } else {
+            const original = Constants.defaultBackdropPresets.find(p => p.id === presetId);
+            const updated = Object.assign({}, original, currentData);
+            newList = [...window.customBackdropPresets, updated];
+        }
+        window.customBackdropPresets = newList;
+        if (window.parentWidget && window.parentWidget.pluginService) {
+            window.parentWidget.pluginService.savePluginData("quickCapture", "user_backdrop_presets", JSON.stringify(newList));
+        }
+    }
+
+    function renamePreset(presetId, newName) {
+        if (!presetId || !newName) return;
+        const existingIdx = window.customBackdropPresets.findIndex(p => p.id === presetId);
+        let newList;
+        if (existingIdx !== -1) {
+            newList = window.customBackdropPresets.map(p => p.id === presetId ? Object.assign({}, p, { name: newName }) : p);
+        } else {
+            const original = Constants.defaultBackdropPresets.find(p => p.id === presetId);
+            const updated = Object.assign({}, original, { name: newName });
+            newList = [...window.customBackdropPresets, updated];
+        }
+        window.customBackdropPresets = newList;
+        if (window.parentWidget && window.parentWidget.pluginService) {
+            window.parentWidget.pluginService.savePluginData("quickCapture", "user_backdrop_presets", JSON.stringify(newList));
+        }
     }
 
     content: Component {
@@ -2096,6 +2243,7 @@ DankModal {
                         else if (type === "angle") popover = backdropAnglePopover;
                         else if (type === "aspectRatio") popover = backdropAspectRatioPopover;
                         else if (type === "alignment") popover = backdropAlignmentPopover;
+                        else if (type === "presets") popover = backdropPresetsPopover;
 
                         if (popover) {
                             if (toolbarCard.isVertical) {
@@ -2136,6 +2284,7 @@ DankModal {
                         else if (type === "angle") popover = backdropAnglePopover;
                         else if (type === "aspectRatio") popover = backdropAspectRatioPopover;
                         else if (type === "alignment") popover = backdropAlignmentPopover;
+                        else if (type === "presets") popover = backdropPresetsPopover;
 
                         if (popover) {
                             popover.startCloseTimer();
@@ -3082,6 +3231,16 @@ DankModal {
                         window.backdropAlignment = alignment;
                         window.requestPaintAll();
                     }
+                }
+
+                BackdropPresetsPopover {
+                    id: backdropPresetsPopover
+                    presetsList: window.backdropPresets
+                    onPresetSelected: (preset) => window.applyBackdropPreset(preset)
+                    onSaveCurrentAsPreset: window.saveCurrentBackdropAsPreset()
+                    onDeletePreset: (presetId) => window.deletePreset(presetId)
+                    onUpdatePresetWithCurrent: (presetId) => window.updatePresetWithCurrent(presetId)
+                    onRenamePreset: (presetId, newName) => window.renamePreset(presetId, newName)
                 }
 
                 Canvas {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -249,9 +249,9 @@ DankModal {
     property var hiddenPresetIds: []
     readonly property var backdropPresets: {
         var customMap = {};
-        if (window.customBackdropPresets) {
-            for (var i = 0; i < window.customBackdropPresets.length; i++) {
-                var cp = window.customBackdropPresets[i];
+        if (customBackdropPresets) {
+            for (var i = 0; i < customBackdropPresets.length; i++) {
+                var cp = customBackdropPresets[i];
                 customMap[cp.id] = cp;
             }
         }
@@ -260,7 +260,7 @@ DankModal {
         if (Constants && Constants.defaultBackdropPresets) {
             for (var j = 0; j < Constants.defaultBackdropPresets.length; j++) {
                 var dp = Constants.defaultBackdropPresets[j];
-                if (!window.hiddenPresetIds || window.hiddenPresetIds.indexOf(dp.id) === -1) {
+                if (!hiddenPresetIds || hiddenPresetIds.indexOf(dp.id) === -1) {
                     if (customMap[dp.id]) {
                         list.push(customMap[dp.id]);
                     } else {
@@ -269,10 +269,10 @@ DankModal {
                 }
             }
         }
-        if (window.customBackdropPresets) {
-            for (var k = 0; k < window.customBackdropPresets.length; k++) {
-                var up = window.customBackdropPresets[k];
-                if (up.isCustomUserCreated && (!window.hiddenPresetIds || window.hiddenPresetIds.indexOf(up.id) === -1)) {
+        if (customBackdropPresets) {
+            for (var k = 0; k < customBackdropPresets.length; k++) {
+                var up = customBackdropPresets[k];
+                if (up.isCustomUserCreated && (!hiddenPresetIds || hiddenPresetIds.indexOf(up.id) === -1)) {
                     list.push(up);
                 }
             }
@@ -1858,14 +1858,16 @@ DankModal {
             }
             if (data.user_backdrop_presets) {
                 try {
-                    window.customBackdropPresets = JSON.parse(data.user_backdrop_presets);
+                    const parsed = JSON.parse(data.user_backdrop_presets);
+                    if (Array.isArray(parsed)) window.customBackdropPresets = parsed;
                 } catch (e) {
                     console.error("Failed to parse user_backdrop_presets:", e);
                 }
             }
             if (data.hidden_backdrop_presets) {
                 try {
-                    window.hiddenPresetIds = JSON.parse(data.hidden_backdrop_presets);
+                    const parsed = JSON.parse(data.hidden_backdrop_presets);
+                    if (Array.isArray(parsed)) window.hiddenPresetIds = parsed;
                 } catch (e) {
                     console.error("Failed to parse hidden_backdrop_presets:", e);
                 }
@@ -1952,9 +1954,13 @@ DankModal {
         if (existingIdx !== -1) {
             newList = window.customBackdropPresets.map(p => p.id === presetId ? Object.assign({}, p, currentData) : p);
         } else {
-            const original = Constants.defaultBackdropPresets.find(p => p.id === presetId);
-            const updated = Object.assign({}, original, currentData);
-            newList = [...window.customBackdropPresets, updated];
+            const original = Constants.defaultBackdropPresets ? Constants.defaultBackdropPresets.find(p => p.id === presetId) : undefined;
+            if (original) {
+                const updated = Object.assign({}, original, currentData);
+                newList = [...window.customBackdropPresets, updated];
+            } else {
+                newList = window.customBackdropPresets;
+            }
         }
         window.customBackdropPresets = newList;
         if (window.parentWidget && window.parentWidget.pluginService) {
@@ -1969,9 +1975,13 @@ DankModal {
         if (existingIdx !== -1) {
             newList = window.customBackdropPresets.map(p => p.id === presetId ? Object.assign({}, p, { name: newName }) : p);
         } else {
-            const original = Constants.defaultBackdropPresets.find(p => p.id === presetId);
-            const updated = Object.assign({}, original, { name: newName });
-            newList = [...window.customBackdropPresets, updated];
+            const original = Constants.defaultBackdropPresets ? Constants.defaultBackdropPresets.find(p => p.id === presetId) : undefined;
+            if (original) {
+                const updated = Object.assign({}, original, { name: newName });
+                newList = [...window.customBackdropPresets, updated];
+            } else {
+                newList = window.customBackdropPresets;
+            }
         }
         window.customBackdropPresets = newList;
         if (window.parentWidget && window.parentWidget.pluginService) {

--- a/components/BackdropPresetsPopover.qml
+++ b/components/BackdropPresetsPopover.qml
@@ -1,0 +1,365 @@
+import QtQuick
+import QtQuick.Controls
+import qs.Common
+import qs.Widgets
+import "Constants.js" as Constants
+
+Rectangle {
+    id: popoverRoot
+
+    property var presetsList: []
+    property bool opened: false
+    property bool editMode: false
+
+    signal presetSelected(var preset)
+    signal saveCurrentAsPreset()
+    signal deletePreset(string presetId)
+    signal updatePresetWithCurrent(string presetId)
+    signal renamePreset(string presetId, string newName)
+
+    width: 260
+    height: Math.min(320, contentColumn.implicitHeight + Theme.spacingS * 2)
+    color: Theme.surfaceContainer
+    border.color: Theme.withAlpha(Theme.outline, 0.15)
+    border.width: 1
+    radius: Theme.cornerRadius
+    z: 10001
+
+    visible: opacity > 0
+    opacity: 0
+    scale: 0.9
+
+    states: [
+        State {
+            name: "visible"
+            when: popoverRoot.opened
+            PropertyChanges { target: popoverRoot; opacity: 1.0; scale: 1.0 }
+        }
+    ]
+
+    transitions: [
+        Transition {
+            NumberAnimation { properties: "opacity,scale"; duration: 120; easing.type: Easing.OutQuad }
+        }
+    ]
+
+    function open() {
+        closeTimer.stop();
+        popoverRoot.opened = true;
+    }
+
+    function close() {
+        popoverRoot.editMode = false;
+        popoverRoot.opened = false;
+    }
+
+    function startCloseTimer() {
+        closeTimer.start();
+    }
+
+    function stopCloseTimer() {
+        closeTimer.stop();
+    }
+
+    Timer {
+        id: closeTimer
+        interval: 300
+        onTriggered: popoverRoot.close()
+    }
+
+    HoverHandler {
+        id: popoverHoverHandler
+        onHoveredChanged: {
+            if (hovered) {
+                popoverRoot.stopCloseTimer();
+            } else {
+                popoverRoot.startCloseTimer();
+            }
+        }
+    }
+
+    Column {
+        id: contentColumn
+        width: parent.width - Theme.spacingS * 2
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.spacingS
+        spacing: Theme.spacingS
+
+        // Header Row
+        Item {
+            width: parent.width
+            height: 24
+
+            StyledText {
+                text: qsTr("Backdrop Presets")
+                font.pixelSize: Theme.fontSizeSmall
+                font.bold: true
+                color: Theme.surfaceText
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Row {
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Constants.spacingCompact
+
+                // Edit Mode Toggle Button
+                Rectangle {
+                    width: 24
+                    height: 22
+                    radius: Theme.cornerRadius / 2
+                    color: popoverRoot.editMode 
+                        ? Theme.withAlpha(Theme.error, 0.25) 
+                        : (editMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.1) : "transparent")
+                    border.color: popoverRoot.editMode ? Theme.error : "transparent"
+                    border.width: 1
+
+                    DankIcon {
+                        name: "edit"
+                        size: 13
+                        color: popoverRoot.editMode ? Theme.error : Theme.surfaceText
+                        anchors.centerIn: parent
+                    }
+
+                    MouseArea {
+                        id: editMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            popoverRoot.editMode = !popoverRoot.editMode;
+                        }
+                    }
+                }
+
+                // Save Current Preset Button
+                Rectangle {
+                    width: 60
+                    height: 22
+                    radius: Theme.cornerRadius / 2
+                    color: saveMouse.containsMouse ? Theme.withAlpha(Theme.primary, 0.2) : Theme.withAlpha(Theme.primary, 0.1)
+                    border.color: Theme.primary
+                    border.width: 1
+
+                    Row {
+                        anchors.centerIn: parent
+                        spacing: 2
+
+                        DankIcon {
+                            name: "add"
+                            size: 12
+                            color: Theme.primary
+                        }
+
+                        StyledText {
+                            text: qsTr("Save")
+                            font.pixelSize: Theme.fontSizeSmall - 2
+                            color: Theme.primary
+                            font.bold: true
+                        }
+                    }
+
+                    MouseArea {
+                        id: saveMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            popoverRoot.saveCurrentAsPreset();
+                        }
+                    }
+                }
+            }
+        }
+
+        // Scrollable list of preset cards
+        ScrollView {
+            width: parent.width
+            height: Math.min(240, presetsColumn.implicitHeight)
+            clip: true
+
+            Column {
+                id: presetsColumn
+                width: parent.width
+                spacing: Constants.spacingCompact
+
+                Repeater {
+                    model: popoverRoot.presetsList
+                    delegate: Rectangle {
+                        width: presetsColumn.width
+                        height: 38
+                        radius: Theme.cornerRadius - 2
+                        color: popoverRoot.editMode 
+                            ? Theme.withAlpha(Theme.error, 0.08) 
+                            : (cardMouse.containsMouse ? Theme.withAlpha(Theme.primary, 0.12) : Theme.withAlpha(Theme.surfaceText, 0.04))
+                        border.color: popoverRoot.editMode ? Theme.error : (cardMouse.containsMouse ? Theme.primary : "transparent")
+                        border.width: popoverRoot.editMode ? 1.5 : 1
+
+                        Item {
+                            anchors.fill: parent
+                            anchors.margins: 6
+
+                            Row {
+                                anchors.left: parent.left
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: Theme.spacingS
+
+                                // Dual Swatches (2 Color Circles)
+                                Item {
+                                    width: 30
+                                    height: 20
+                                    anchors.verticalCenter: parent.verticalCenter
+
+                                    // Color Slot 1 (Primary / Start / Solid)
+                                    Rectangle {
+                                        width: 18
+                                        height: 18
+                                        radius: 9
+                                        x: 0
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        color: modelData.mode === "solid" ? (modelData.solidColor || Theme.primary) : (modelData.gradientStart || Theme.primary)
+                                        border.color: Theme.withAlpha(Theme.outline, 0.3)
+                                        border.width: 1
+                                        z: 1
+                                    }
+
+                                    // Color Slot 2 (Secondary / End / Empty for Solid)
+                                    Rectangle {
+                                        width: 18
+                                        height: 18
+                                        radius: 9
+                                        x: 12
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        color: (modelData.mode === "gradient" || modelData.mode === "radial" || modelData.mode === "conic")
+                                               ? (modelData.gradientEnd || Theme.secondary)
+                                               : "transparent"
+                                        border.color: Theme.withAlpha(Theme.outline, 0.3)
+                                        border.width: 1
+                                        z: 0
+
+                                        DankIcon {
+                                            name: "close"
+                                            size: 10
+                                            color: Theme.withAlpha(Theme.surfaceText, 0.25)
+                                            anchors.centerIn: parent
+                                            visible: modelData.mode === "solid"
+                                        }
+                                    }
+                                }
+
+                                // Preset Name & Info
+                                Column {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    spacing: 1
+
+                                    TextInput {
+                                        visible: popoverRoot.editMode
+                                        text: modelData.name || "Preset"
+                                        font.pixelSize: Theme.fontSizeSmall - 1
+                                        font.bold: true
+                                        color: Theme.error
+                                        selectByMouse: true
+                                        onEditingFinished: {
+                                            popoverRoot.renamePreset(modelData.id, text);
+                                        }
+                                    }
+
+                                    StyledText {
+                                        visible: !popoverRoot.editMode
+                                        text: modelData.name || "Preset"
+                                        font.pixelSize: Theme.fontSizeSmall - 1
+                                        font.bold: true
+                                        color: Theme.surfaceText
+                                    }
+
+                                    StyledText {
+                                        text: (modelData.mode || "solid").toUpperCase() + " • " + (modelData.aspectRatio || "auto").toUpperCase()
+                                        font.pixelSize: Theme.fontSizeSmall - 3
+                                        color: Theme.withAlpha(Theme.surfaceText, 0.6)
+                                    }
+                                }
+                            }
+
+                            // Edit Actions Row (visible in Edit Mode)
+                            Row {
+                                visible: popoverRoot.editMode === true
+                                anchors.right: parent.right
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: 4
+                                z: 10
+
+                                // Overwrite / Update Button
+                                Rectangle {
+                                    width: 22
+                                    height: 22
+                                    radius: 4
+                                    color: updateMouse.containsMouse ? Theme.primary : Theme.withAlpha(Theme.primary, 0.2)
+                                    border.color: Theme.primary
+                                    border.width: 1
+
+                                    DankIcon {
+                                        name: "refresh"
+                                        size: 14
+                                        color: updateMouse.containsMouse ? "#ffffff" : Theme.primary
+                                        anchors.centerIn: parent
+                                    }
+
+                                    MouseArea {
+                                        id: updateMouse
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: {
+                                            popoverRoot.updatePresetWithCurrent(modelData.id);
+                                        }
+                                    }
+                                }
+
+                                // Delete Button
+                                Rectangle {
+                                    width: 22
+                                    height: 22
+                                    radius: 4
+                                    color: delMouse.containsMouse ? Theme.error : Theme.withAlpha(Theme.error, 0.2)
+                                    border.color: Theme.error
+                                    border.width: 1
+
+                                    DankIcon {
+                                        name: "delete"
+                                        size: 14
+                                        color: delMouse.containsMouse ? "#ffffff" : Theme.error
+                                        anchors.centerIn: parent
+                                    }
+
+                                    MouseArea {
+                                        id: delMouse
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: {
+                                            popoverRoot.deletePreset(modelData.id);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        MouseArea {
+                            id: cardMouse
+                            anchors.fill: parent
+                            enabled: !popoverRoot.editMode
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                popoverRoot.presetSelected(modelData);
+                                popoverRoot.close();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/BackdropPresetsPopover.qml
+++ b/components/BackdropPresetsPopover.qml
@@ -201,89 +201,97 @@ Rectangle {
                             anchors.fill: parent
                             anchors.margins: 6
 
-                            Row {
+                            // Dual Swatches (2 Color Circles)
+                            Item {
+                                id: swatchesItem
+                                width: 30
+                                height: 20
                                 anchors.left: parent.left
                                 anchors.verticalCenter: parent.verticalCenter
-                                spacing: Theme.spacingS
 
-                                // Dual Swatches (2 Color Circles)
-                                Item {
-                                    width: 30
-                                    height: 20
+                                // Color Slot 1 (Primary / Start / Solid)
+                                Rectangle {
+                                    width: 18
+                                    height: 18
+                                    radius: 9
+                                    x: 0
                                     anchors.verticalCenter: parent.verticalCenter
+                                    color: modelData.mode === "solid" ? (modelData.solidColor || Theme.primary) : (modelData.gradientStart || Theme.primary)
+                                    border.color: Theme.withAlpha(Theme.outline, 0.3)
+                                    border.width: 1
+                                    z: 1
+                                }
 
-                                    // Color Slot 1 (Primary / Start / Solid)
-                                    Rectangle {
-                                        width: 18
-                                        height: 18
-                                        radius: 9
-                                        x: 0
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        color: modelData.mode === "solid" ? (modelData.solidColor || Theme.primary) : (modelData.gradientStart || Theme.primary)
-                                        border.color: Theme.withAlpha(Theme.outline, 0.3)
-                                        border.width: 1
-                                        z: 1
+                                // Color Slot 2 (Secondary / End / Empty for Solid)
+                                Rectangle {
+                                    width: 18
+                                    height: 18
+                                    radius: 9
+                                    x: 12
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    color: (modelData.mode === "gradient" || modelData.mode === "radial" || modelData.mode === "conic")
+                                           ? (modelData.gradientEnd || Theme.secondary)
+                                           : "transparent"
+                                    border.color: Theme.withAlpha(Theme.outline, 0.3)
+                                    border.width: 1
+                                    z: 0
+
+                                    DankIcon {
+                                        name: "close"
+                                        size: 10
+                                        color: Theme.withAlpha(Theme.surfaceText, 0.25)
+                                        anchors.centerIn: parent
+                                        visible: modelData.mode === "solid"
                                     }
+                                }
+                            }
 
-                                    // Color Slot 2 (Secondary / End / Empty for Solid)
-                                    Rectangle {
-                                        width: 18
-                                        height: 18
-                                        radius: 9
-                                        x: 12
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        color: (modelData.mode === "gradient" || modelData.mode === "radial" || modelData.mode === "conic")
-                                               ? (modelData.gradientEnd || Theme.secondary)
-                                               : "transparent"
-                                        border.color: Theme.withAlpha(Theme.outline, 0.3)
-                                        border.width: 1
-                                        z: 0
+                            // Preset Name & Info
+                            Column {
+                                id: textColumn
+                                anchors.left: swatchesItem.right
+                                anchors.leftMargin: Theme.spacingS
+                                anchors.right: popoverRoot.editMode ? editActionsRow.left : parent.right
+                                anchors.rightMargin: Theme.spacingS
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: 1
 
-                                        DankIcon {
-                                            name: "close"
-                                            size: 10
-                                            color: Theme.withAlpha(Theme.surfaceText, 0.25)
-                                            anchors.centerIn: parent
-                                            visible: modelData.mode === "solid"
-                                        }
+                                TextInput {
+                                    visible: popoverRoot.editMode
+                                    width: parent.width
+                                    text: modelData.name || "Preset"
+                                    font.pixelSize: Theme.fontSizeSmall - 1
+                                    font.bold: true
+                                    color: Theme.error
+                                    selectByMouse: true
+                                    clip: true
+                                    onEditingFinished: {
+                                        popoverRoot.renamePreset(modelData.id, text);
                                     }
                                 }
 
-                                // Preset Name & Info
-                                Column {
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    spacing: 1
+                                StyledText {
+                                    visible: !popoverRoot.editMode
+                                    width: parent.width
+                                    text: modelData.name || "Preset"
+                                    font.pixelSize: Theme.fontSizeSmall - 1
+                                    font.bold: true
+                                    color: Theme.surfaceText
+                                    elide: Text.ElideRight
+                                }
 
-                                    TextInput {
-                                        visible: popoverRoot.editMode
-                                        text: modelData.name || "Preset"
-                                        font.pixelSize: Theme.fontSizeSmall - 1
-                                        font.bold: true
-                                        color: Theme.error
-                                        selectByMouse: true
-                                        onEditingFinished: {
-                                            popoverRoot.renamePreset(modelData.id, text);
-                                        }
-                                    }
-
-                                    StyledText {
-                                        visible: !popoverRoot.editMode
-                                        text: modelData.name || "Preset"
-                                        font.pixelSize: Theme.fontSizeSmall - 1
-                                        font.bold: true
-                                        color: Theme.surfaceText
-                                    }
-
-                                    StyledText {
-                                        text: (modelData.mode || "solid").toUpperCase() + " • " + (modelData.aspectRatio || "auto").toUpperCase()
-                                        font.pixelSize: Theme.fontSizeSmall - 3
-                                        color: Theme.withAlpha(Theme.surfaceText, 0.6)
-                                    }
+                                StyledText {
+                                    width: parent.width
+                                    text: (modelData.mode || "solid").toUpperCase() + " • " + (modelData.aspectRatio || "auto").toUpperCase()
+                                    font.pixelSize: Theme.fontSizeSmall - 3
+                                    color: Theme.withAlpha(Theme.surfaceText, 0.6)
+                                    elide: Text.ElideRight
                                 }
                             }
 
                             // Edit Actions Row (visible in Edit Mode)
                             Row {
+                                id: editActionsRow
                                 visible: popoverRoot.editMode === true
                                 anchors.right: parent.right
                                 anchors.verticalCenter: parent.verticalCenter

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -82,3 +82,21 @@ const compactControlHeight = 40;
 const customRatioPopoverHeight = 120;
 const verticalSelectorItemWidth = 32;
 
+// Default Backdrop Presets
+const defaultBackdropPresets = [
+    {
+        id: "studio_dark",
+        name: "Studio Dark",
+        mode: "solid",
+        solidColor: "#1e1e2e",
+        gradientStart: "#1e1e2e",
+        gradientEnd: "#181825",
+        gradientAngle: 45,
+        padding: 40,
+        cornerRadius: 16,
+        shadowStrength: 50,
+        aspectRatio: "auto",
+        customAspectRatio: 1.50
+    }
+];
+

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -428,6 +428,33 @@ Rectangle {
             
             Rectangle { width: Constants.separatorThickness; height: Constants.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
             
+            // Presets Control (Bookmarks)
+            Item {
+                id: presetsControl
+                width: Constants.btnSize
+                height: Constants.btnSize
+                anchors.verticalCenter: parent.verticalCenter
+
+                DankActionButton {
+                    iconName: "bookmarks"
+                    buttonSize: Constants.btnSize
+                    iconSize: Constants.iconSize
+                    tooltipText: qsTr("Backdrop Presets")
+                    anchors.centerIn: parent
+                    onClicked: root.backdropControlHovered("presets", presetsControl)
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: root.backdropControlHovered("presets", presetsControl)
+                    onExited: root.backdropControlExited("presets")
+                }
+            }
+
+            Rectangle { width: Constants.separatorThickness; height: Constants.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+
             BackdropModeSelectors {
                 backdropMode: root.backdropMode
                 isVertical: false
@@ -674,6 +701,33 @@ Rectangle {
             
             Rectangle { width: Constants.separatorLength; height: Constants.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
             
+            // Presets Control (Bookmarks)
+            Item {
+                id: presetsControlVert
+                width: Constants.btnSize
+                height: Constants.btnSize
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                DankActionButton {
+                    iconName: "bookmarks"
+                    buttonSize: Constants.btnSize
+                    iconSize: Constants.iconSize
+                    tooltipText: qsTr("Backdrop Presets")
+                    anchors.centerIn: parent
+                    onClicked: root.backdropControlHovered("presets", presetsControlVert)
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: root.backdropControlHovered("presets", presetsControlVert)
+                    onExited: root.backdropControlExited("presets")
+                }
+            }
+
+            Rectangle { width: Constants.separatorLength; height: Constants.separatorThickness; color: Theme.withAlpha(Theme.outline, 0.2); anchors.horizontalCenter: parent.horizontalCenter }
+
             BackdropModeSelectors {
                 backdropMode: root.backdropMode
                 isVertical: true


### PR DESCRIPTION
### What
This PR implements a full Backdrop & Canvas Aspect Ratio Presets feature, allowing users to save, apply, edit, and delete backdrop preset configurations with 1-click from the toolbar (closes #81).

### Why
Previously, customizing backdrops required manually re-configuring mode, gradient colors, padding, corner radius, and canvas aspect ratio every time. Presets allow rapid 1-click styling workflows.

### How
- **Preset Data Model**: Added `defaultBackdropPresets` in `Constants.js` (defaulting to Studio Dark).
- **Presets Popover UI (`components/BackdropPresetsPopover.qml`)**:
  - Integrated `bookmarks` icon button in `QuickCaptureToolbar.qml` positioned between the Back button and Backdrop Mode selectors.
  - Interactive Popover displaying dual-color swatches (2 circles for gradients/radials/conics, 1 circle + empty slot for solids), preset names, and ratio badges.
  - Hover stability using QtQuick `HoverHandler`.
- **Preset Customization & Edit Mode**:
  - `Save` button: Saves current canvas backdrop & ratio settings into custom user presets.
  - `Edit` toggle (pencil icon): Activates Edit Mode with warning theme borders.
  - **Inline Rename**: Click preset name to rename directly.
  - **In-place Overwrite**: Click `refresh` button to overwrite preset with current backdrop settings.
  - **Universal Deletion**: Click `delete` button to delete any preset (custom or default).
- **Persistence**: Saved to `pluginData` via `user_backdrop_presets` and `hidden_backdrop_presets`.

### How Tested
- Verified popover opening, closing, and hover stability via `dms restart`.
- Tested creating new presets, applying presets, in-place updating, inline renaming, deleting presets, and persistence across session restarts.