### PR TITLE
fix(input): reset inputMethod on modal open and dialog close to prevent IME shortcut interception (#154)

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -1813,6 +1813,9 @@ DankModal {
     }
 
     onOpened: {
+        Qt.inputMethod.commit();
+        Qt.inputMethod.reset();
+        Qt.inputMethod.hide();
         window.updateRadialPresets();
 
         let startTool = "pen";
@@ -1949,6 +1952,9 @@ DankModal {
         }
 
         Qt.callLater(() => {
+            Qt.inputMethod.commit();
+            Qt.inputMethod.reset();
+            Qt.inputMethod.hide();
             if (modalFocusScope) modalFocusScope.forceActiveFocus();
         });
     }

--- a/components/TextInputDialog.qml
+++ b/components/TextInputDialog.qml
@@ -40,6 +40,9 @@ Popup {
             window.editingStroke = null;
             if (window.activeCanvas) window.activeCanvas.requestPaint();
         }
+        Qt.inputMethod.commit();
+        Qt.inputMethod.reset();
+        Qt.inputMethod.hide();
         if (modalFocusScope) {
             modalFocusScope.forceActiveFocus();
         }


### PR DESCRIPTION
### What
Fixes #154 by resetting the Qt InputMethod state (`Qt.inputMethod.commit()`, `Qt.inputMethod.reset()`, `Qt.inputMethod.hide()`) when opening `QuickCaptureModal` and when closing `TextInputDialog`.

### Why
When Fcitx5 (or other Wayland IMEs) is active in the user session, Wayland's `zwp_text_input_v3` context remains enabled on the modal surface window even when focus moves from an input control (`TextArea`) to a non-editable QML `FocusScope`. Fcitx5 intercepts single-character shortcut keys (e.g. `S` for Highlighter, `A` for Arrow, `Z` for Undo), preventing Qt from delivering key events to `Keys.onPressed`.

### How
- Called `Qt.inputMethod.commit()`, `Qt.inputMethod.reset()`, and `Qt.inputMethod.hide()` in `QuickCaptureModal.qml` (`onOpened` and `Qt.callLater` focus restoration).
- Called `Qt.inputMethod.commit()`, `Qt.inputMethod.reset()`, and `Qt.inputMethod.hide()` in `TextInputDialog.qml` (`onClosed`).

### How Tested
- Verified modal lifecycle and focus restoration via `dms restart`.

Fixes #154.

## Summary by Sourcery

Reset Qt input method state when entering and leaving annotation modals to prevent IME interception of keyboard shortcuts.

Bug Fixes:
- Ensure opening QuickCaptureModal clears any active input method context so shortcut keys are delivered correctly.
- Ensure closing TextInputDialog clears any active input method context to restore normal shortcut handling across the modal lifecycle.