### PR TITLE
feat(redo): add Redo support with keyboard shortcuts, mouse forward button, and toolbar button

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -3498,6 +3498,15 @@ DankModal {
             window.undoneStrokes = [...window.undoneStrokes, popped];
             if (window.selectedStroke === popped) {
                 window.selectedStroke = null;
+                window.strokeWidth = window.preGrabStrokeWidth;
+                window.textFontSize = window.preGrabTextFontSize;
+                window.pixelateIntensity = window.preGrabPixelateIntensity;
+                window.spotlightIntensity = window.preGrabSpotlightIntensity;
+                window.calloutZoom = window.preGrabCalloutZoom;
+                window.currentColor = window.preGrabColor;
+                window.activeRedactMode = window.preGrabRedactMode;
+                window.activeRedactShape = window.preGrabRedactShape;
+                window.calloutLinkLines = window.preGrabCalloutLinkLines;
             }
             if (window.activeCanvas) window.activeCanvas.requestPaint();
         }
@@ -3509,6 +3518,36 @@ DankModal {
             const strokeToRedo = undoneList.pop();
             window.undoneStrokes = undoneList;
             window.strokes = [...window.strokes, strokeToRedo];
+
+            if (window.currentTool === "select") {
+                window.preGrabStrokeWidth = window.strokeWidth;
+                window.preGrabTextFontSize = window.textFontSize;
+                window.preGrabPixelateIntensity = window.pixelateIntensity;
+                window.preGrabSpotlightIntensity = window.spotlightIntensity;
+                window.preGrabCalloutZoom = window.calloutZoom;
+                window.preGrabColor = window.currentColor;
+                window.preGrabRedactMode = window.activeRedactMode;
+                window.preGrabRedactShape = window.activeRedactShape;
+                window.preGrabCalloutLinkLines = window.calloutLinkLines;
+
+                window.selectedStroke = strokeToRedo;
+                window.currentColor = strokeToRedo.color;
+                if (strokeToRedo.tool === "text") window.textFontSize = strokeToRedo.width;
+                else if (strokeToRedo.tool === "pixelate") window.pixelateIntensity = strokeToRedo.width;
+                else if (strokeToRedo.tool === "spotlight") window.spotlightIntensity = strokeToRedo.width;
+                else if (strokeToRedo.tool === "callout") window.calloutZoom = strokeToRedo.width;
+                else window.strokeWidth = strokeToRedo.width;
+
+                if (strokeToRedo.tool === "line" && strokeToRedo.lineStyle) window.activeLineStyle = strokeToRedo.lineStyle;
+                if (strokeToRedo.tool === "arrow") {
+                    if (strokeToRedo.arrowLineStyle) window.activeArrowLineStyle = strokeToRedo.arrowLineStyle;
+                    if (strokeToRedo.arrowHeadStyle) window.activeArrowHeadStyle = strokeToRedo.arrowHeadStyle;
+                }
+                if (strokeToRedo.tool === "redact" && strokeToRedo.redactMode) window.activeRedactMode = strokeToRedo.redactMode;
+                if (strokeToRedo.tool === "redact" && strokeToRedo.redactShape) window.activeRedactShape = strokeToRedo.redactShape;
+                if (strokeToRedo.tool === "callout") window.calloutLinkLines = strokeToRedo.calloutLinkLines !== undefined ? strokeToRedo.calloutLinkLines : 1;
+            }
+
             if (window.activeCanvas) window.activeCanvas.requestPaint();
         }
     }

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -310,6 +310,9 @@ DankModal {
         }
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
+    property var undoneStrokes: []
+    readonly property bool canUndo: strokes.length > 0
+    readonly property bool canRedo: undoneStrokes.length > 0
     property int textFontSize: window.parentWidget && window.parentWidget.pluginData && window.parentWidget.pluginData.textFontSize !== undefined ? window.parentWidget.pluginData.textFontSize : 36
     property int calloutZoom: 150
     property bool calloutDestDragging: false
@@ -1626,6 +1629,11 @@ DankModal {
             event.accepted = true;
             return;
         }
+        if (hasCtrl && (token === "Y" || (event.modifiers & Qt.ShiftModifier && token === "Z"))) {
+            window.performRedo();
+            event.accepted = true;
+            return;
+        }
         if (hasCtrl && token === "Z") {
             window.performUndo();
             event.accepted = true;
@@ -2141,7 +2149,8 @@ DankModal {
                     activeColorSlotIndex: window.activeColorSlotIndex
 
                     strokeWidth: window.activeIntensity
-                    canUndo: window.strokes.length > 0
+                    canUndo: window.canUndo
+                    canRedo: window.canRedo
 
                     backdropMode: window.backdropMode
                     backdropSolidColor: window.backdropSolidColor
@@ -2278,6 +2287,10 @@ DankModal {
                     onUndoRequested: {
                         moreToolsMenu.close();
                         window.performUndo();
+                    }
+                    onRedoRequested: {
+                        moreToolsMenu.close();
+                        window.performRedo();
                     }
                     onAnnotationsToggled: window.showAnnotations = !window.showAnnotations
 
@@ -3473,14 +3486,29 @@ DankModal {
         const list = [...window.strokes];
         list.push(stroke);
         window.strokes = list;
+        window.undoneStrokes = [];
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }
 
     function performUndo() {
         if (window.strokes.length > 0) {
             const list = [...window.strokes];
-            list.pop();
+            const popped = list.pop();
             window.strokes = list;
+            window.undoneStrokes = [...window.undoneStrokes, popped];
+            if (window.selectedStroke === popped) {
+                window.selectedStroke = null;
+            }
+            if (window.activeCanvas) window.activeCanvas.requestPaint();
+        }
+    }
+
+    function performRedo() {
+        if (window.undoneStrokes.length > 0) {
+            const undoneList = [...window.undoneStrokes];
+            const strokeToRedo = undoneList.pop();
+            window.undoneStrokes = undoneList;
+            window.strokes = [...window.strokes, strokeToRedo];
             if (window.activeCanvas) window.activeCanvas.requestPaint();
         }
     }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ git checkout main && git pull
 - **Thickness:** Scroll **Mouse Wheel** to scale brush / font size.
 - **Quick Erase:** **Middle-click** on any element to delete it.
 - **Copy / Duplicate:** Select a vector with the **Select** tool (<kbd>V</kbd>), then press **<kbd>C</kbd>** to duplicate. Pressing **<kbd>C</kbd>** without a selection pastes the last copied vector at the cursor.
-- **Undo:** <kbd>Ctrl</kbd> + <kbd>Z</kbd>.
+- **Undo:** <kbd>Ctrl</kbd> + <kbd>Z</kbd> or **Mouse Back Button**.
+- **Redo:** <kbd>Ctrl</kbd> + <kbd>Y</kbd> / <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> or **Mouse Forward Button**.
 - **Speech Bubble (Text Tool):** Click and drag to draw a speech bubble. The click location defines the tail target point, and the release location is the text bubble. A single click without dragging writes normal text.
 - **Leader Line (Stamp Tool):** Click and drag to create a stamp with a leader line. The click location points to the target, and the release location places the stamp body. A single click without dragging drops a normal stamp.
 - **Shift Constraint:** Hold **<kbd>Shift</kbd>** while drawing to constrain shapes:
@@ -129,7 +130,8 @@ git checkout main && git pull
 |-----|--------|
 | <kbd>Enter</kbd> | Done (save/copy per settings) |
 | <kbd>Esc</kbd> | Discard & Close |
-| <kbd>Ctrl</kbd> + <kbd>Z</kbd> | Undo last stroke |
+| <kbd>Ctrl</kbd> + <kbd>Z</kbd> | Undo last stroke (or Mouse Back Button) |
+| <kbd>Ctrl</kbd> + <kbd>Y</kbd> / <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> | Redo last undone stroke (or Mouse Forward Button) |
 | <kbd>Ctrl</kbd> + <kbd>S</kbd> | Save to file |
 | <kbd>Ctrl</kbd> + <kbd>C</kbd> | Copy to clipboard |
 | <kbd>Ctrl</kbd> + <kbd>A</kbd> | Copy & Save |

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -481,6 +481,11 @@ MouseArea {
             return;
         }
 
+        if (mouse.button === Qt.ForwardButton || mouse.button === Qt.XButton2) {
+            window.performRedo();
+            return;
+        }
+
         if (mouse.button === Qt.RightButton) {
             const mapped = drawMouseArea.mapToItem(radialMenu.parent, mouse.x, mouse.y);
             if (mouse.modifiers & Qt.ShiftModifier) {

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -17,6 +17,7 @@ Rectangle {
     property color currentColor: Theme.primary
     property int strokeWidth: 8
     property bool canUndo: false
+    property bool canRedo: false
     property bool isVertical: false
     property bool showAnnotations: true
     readonly property bool showShortcutHints: root.pluginData["show_shortcut_hints"] ?? false
@@ -78,6 +79,7 @@ Rectangle {
     property int activeColorSlotIndex: 0
     signal strokeWidthSelected(int width)
     signal undoRequested()
+    signal redoRequested()
     signal floatRequested()
     signal saveRequested()
     signal copyRequested()
@@ -290,10 +292,18 @@ Rectangle {
 
             Rectangle { width: Constants.separatorThickness; height: Constants.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
 
-            // Actions
+            // History Actions (Undo & Redo)
             Row {
                 spacing: Theme.spacingXS; anchors.verticalCenter: parent.verticalCenter
                 DankActionButton { iconName: "undo"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; enabled: root.canUndo; opacity: enabled ? 1.0 : 0.4; tooltipText: I18n.tr("Undo (Ctrl+Z)"); onClicked: root.undoRequested() }
+                DankActionButton { iconName: "redo"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; enabled: root.canRedo; opacity: enabled ? 1.0 : 0.4; tooltipText: I18n.tr("Redo (Ctrl+Y / Ctrl+Shift+Z)"); onClicked: root.redoRequested() }
+            }
+
+            Rectangle { width: Constants.separatorThickness; height: Constants.separatorLength; color: Theme.withAlpha(Theme.outline, 0.2); anchors.verticalCenter: parent.verticalCenter }
+
+            // Export Actions
+            Row {
+                spacing: Theme.spacingXS; anchors.verticalCenter: parent.verticalCenter
                 DankActionButton { iconName: "push_pin"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Float Window (Ctrl+F)"; onClicked: root.floatRequested() }
                 DankActionButton { iconName: "save"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Save (Ctrl+S)"; onClicked: root.saveRequested() }
                 DankActionButton { iconName: "content_copy"; buttonSize: Constants.btnSize; iconSize: Constants.iconSize; tooltipText: "Copy (Ctrl+C)"; onClicked: root.copyRequested() }

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -58,7 +58,8 @@ Key events are intercepted at the root Modal level via `modalFocusScope.Keys.onP
 | `Tab` | Presets Toggle | Swaps between 2 latest presets |
 | `Esc` | Discard & Close | Closes modal editor |
 | `Enter` / `Return` | Done | Triggers save/copy pipeline |
-| `Ctrl+Z` | Undo | Reverts last vector stroke |
+| `Ctrl+Z` / Mouse Back | Undo | Reverts last vector stroke |
+| `Ctrl+Y` / `Ctrl+Shift+Z` / Mouse Forward | Redo | Restores last undone vector stroke |
 | `Ctrl+C` | Copy | Copies canvas to clipboard |
 | `Ctrl+S` | Save | Saves canvas as file |
 | `Ctrl+A` | Copy & Save | Copy and save concurrently |

--- a/docs/ipc-and-settings.md
+++ b/docs/ipc-and-settings.md
@@ -79,7 +79,8 @@ Pressing these keys changes the active tool:
 ### Action Controls
 - `Enter`: Complete and save/copy (depends on preferences).
 - `Esc`: Cancel, discard changes, and close.
-- `Ctrl + Z`: Undo the latest vector stroke.
+- `Ctrl + Z` / **Mouse Back Button**: Undo the latest vector stroke.
+- `Ctrl + Y` / `Ctrl + Shift + Z` / **Mouse Forward Button**: Redo the latest undone vector stroke.
 - `Ctrl + C`: Copy the current canvas to the clipboard.
 - `Ctrl + S`: Save the canvas directly as a file.
 - `Ctrl + A`: Copy to clipboard and save as file simultaneously.


### PR DESCRIPTION
### What
Added complete Redo support across the application:
- Stack-based Redo system (`undoneStrokes`).
- Keyboard shortcuts: `Ctrl+Y` and `Ctrl+Shift+Z`.
- Mouse input: Mouse Forward Button (`Qt.ForwardButton` / `Qt.XButton2`).
- Toolbar UI: Redo action button in a dedicated History group separated by vertical lines.

### Why
Users need the ability to restore accidentally undone annotations quickly via keyboard, mouse, or toolbar UI.

### How tested
Tested locally on DMS shell. Drawing annotations, undoing via `Ctrl+Z` / Mouse Back, redoing via `Ctrl+Y` / `Ctrl+Shift+Z` / Mouse Forward / Toolbar Redo button, and verifying Redo stack resets when new annotations are drawn.

## Summary by Sourcery

Add redo support to drawing annotations across keyboard, mouse, and toolbar inputs.

New Features:
- Introduce redo functionality via a stack of undone strokes in the quick capture modal.
- Expose redo capability and state to the drawing toolbar with a dedicated redo button in a history group.
- Support redo through keyboard shortcuts Ctrl+Y and Ctrl+Shift+Z and mouse forward buttons.

Enhancements:
- Reset redo history when new strokes are drawn to maintain consistent undo/redo behavior.