### PR TITLE
fix(backdrop): fix backdrop presets persistence on restart

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -21,6 +21,7 @@ DankModal {
     CaptureConfig { 
         id: config 
         pluginData: (window.parentWidget && window.parentWidget.pluginData) ? window.parentWidget.pluginData : ({})
+        onPluginDataChanged: window.loadPresetsFromPluginData()
     }
 
     Image {
@@ -2085,6 +2086,42 @@ DankModal {
         }
     }
 
+    function loadPresetsFromPluginData() {
+        if (!config || !config.pluginData) return;
+        
+        const userPresetsRaw = config.pluginData["user_backdrop_presets"];
+        if (userPresetsRaw !== undefined) {
+            if (userPresetsRaw) {
+                try {
+                    const parsed = JSON.parse(userPresetsRaw);
+                    if (Array.isArray(parsed)) {
+                        window.customBackdropPresets = parsed;
+                    }
+                } catch (e) {
+                    console.error("Failed to parse user_backdrop_presets:", e);
+                }
+            } else {
+                window.customBackdropPresets = [];
+            }
+        }
+
+        const hiddenPresetsRaw = config.pluginData["hidden_backdrop_presets"];
+        if (hiddenPresetsRaw !== undefined) {
+            if (hiddenPresetsRaw) {
+                try {
+                    const parsed = JSON.parse(hiddenPresetsRaw);
+                    if (Array.isArray(parsed)) {
+                        window.hiddenPresetIds = parsed;
+                    }
+                } catch (e) {
+                    console.error("Failed to parse hidden_backdrop_presets:", e);
+                }
+            } else {
+                window.hiddenPresetIds = [];
+            }
+        }
+    }
+
     content: Component {
         FocusScope {
             id: contentRoot
@@ -3574,5 +3611,9 @@ DankModal {
         window.restoreSource = "";
         window.bgImageSource = "";
         window.exportCallback = null;
+    }
+
+    Component.onCompleted: {
+        window.loadPresetsFromPluginData();
     }
 }


### PR DESCRIPTION
Fixes an issue where custom and hidden backdrop presets are lost when restarting DankMaterialShell (DMS).

### Why
The custom backdrop presets (`user_backdrop_presets`) and hidden preset IDs (`hidden_backdrop_presets`) were successfully saved to the persistent `pluginData` store, but were never loaded back into the modal on fresh launches (only during state restoration when returning from float windows).

### How
- Added a `loadPresetsFromPluginData()` helper function in `QuickCaptureModal.qml` to parse and load these settings.
- Bound `loadPresetsFromPluginData()` to the `onPluginDataChanged` event of `CaptureConfig` to reactively load new presets.
- Called `loadPresetsFromPluginData()` in `Component.onCompleted` to initialize presets upon modal instantiation.

### How Tested
- Simulated settings changes and verified presets load.
- Reloaded the plugin using `dms ipc plugin-scan reload quickCapture` and verified custom presets persist.

## Summary by Sourcery

Ensure backdrop presets are loaded from persistent plugin data when the quick capture modal initializes and when plugin data changes.

Bug Fixes:
- Preserve custom and hidden backdrop presets across DankMaterialShell restarts by reloading them from pluginData.

Enhancements:
- Add a helper to parse backdrop preset settings from pluginData and keep modal state in sync with configuration changes.