### PR TITLE
feat(callout): add ellipse shape option

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -167,6 +167,7 @@ DankModal {
             window.activeRedactMode = window.preGrabRedactMode;
             window.activeRedactShape = window.preGrabRedactShape;
             window.calloutLinkLines = window.preGrabCalloutLinkLines;
+            window.calloutShape = window.preGrabCalloutShape;
             if (window.activeCanvas) window.activeCanvas.requestPaint();
         }
         if (currentTool === "colorpicker") {
@@ -191,6 +192,7 @@ DankModal {
             window.preGrabRedactMode = window.activeRedactMode;
             window.preGrabRedactShape = window.activeRedactShape;
             window.preGrabCalloutLinkLines = window.calloutLinkLines;
+            window.preGrabCalloutShape = window.calloutShape;
             window.selectedStroke = s;
             window.currentColor = s.color;
             if (s.tool === "text") window.textFontSize = s.width;
@@ -205,7 +207,10 @@ DankModal {
             }
             if (s.tool === "redact" && s.redactMode) window.activeRedactMode = s.redactMode;
             if (s.tool === "redact" && s.redactShape) window.activeRedactShape = s.redactShape;
-            if (s.tool === "callout") window.calloutLinkLines = s.calloutLinkLines !== undefined ? s.calloutLinkLines : 1;
+            if (s.tool === "callout") {
+                window.calloutLinkLines = s.calloutLinkLines !== undefined ? s.calloutLinkLines : 1;
+                window.calloutShape = s.calloutShape !== undefined ? s.calloutShape : "rect";
+            }
             const reorder = [...window.strokes];
             const idx = reorder.indexOf(s);
             if (idx !== -1) {
@@ -376,6 +381,20 @@ DankModal {
     onStampCounterFormatChanged: {
         window.reindexStamps();
         window.requestPaintAll();
+    }
+    property string calloutShape: "rect" // rect, ellipse
+    onCalloutShapeChanged: {
+        if (selectedStroke && selectedStroke.tool === "callout") {
+            if (selectedStroke.calloutShape !== calloutShape) {
+                selectedStroke.calloutShape = calloutShape;
+                const idx = window.strokes.indexOf(selectedStroke);
+                if (idx !== -1) {
+                    window.strokes[idx] = selectedStroke;
+                    window.strokes = [...window.strokes];
+                }
+                if (window.activeCanvas) window.activeCanvas.requestPaint();
+            }
+        }
     }
     property int calloutLinkLines: 1 // 1, 2
     onCalloutLinkLinesChanged: {
@@ -711,6 +730,7 @@ DankModal {
     property string preGrabRedactMode: "solid"
     property string preGrabRedactShape: "rect"
     property int preGrabCalloutLinkLines: 1
+    property string preGrabCalloutShape: "rect"
     property point pressCoords: Qt.point(0, 0)
     property var originalPoints: []
 
@@ -1190,10 +1210,12 @@ DankModal {
             window.preGrabRedactMode = window.activeRedactMode;
             window.preGrabRedactShape = window.activeRedactShape;
             window.preGrabCalloutLinkLines = window.calloutLinkLines;
+            window.preGrabCalloutShape = window.calloutShape;
             window.strokeWidth = pasted.width;
             window.currentColor = pasted.color;
             if (pasted.tool === "redact" && pasted.redactMode) window.activeRedactMode = pasted.redactMode;
             if (pasted.tool === "redact" && pasted.redactShape) window.activeRedactShape = pasted.redactShape;
+            if (pasted.tool === "callout") window.calloutShape = pasted.calloutShape !== undefined ? pasted.calloutShape : "rect";
             window.selectedStroke = pasted;
             window.pressCoords = absPt;
             window.originalPoints = newPoints;
@@ -3279,7 +3301,9 @@ DankModal {
                     id: calloutOptionsToolbar
                     toolbarPosition: window.toolbarPosition
                     currentLinkLines: window.calloutLinkLines
+                    currentShape: window.calloutShape
                     onLinkLinesSelected: (count) => window.calloutLinkLines = count
+                    onShapeSelected: (shape) => window.calloutShape = shape
                 }
 
                 PixelateOptionsToolbar {
@@ -3560,6 +3584,7 @@ DankModal {
                 window.activeRedactMode = window.preGrabRedactMode;
                 window.activeRedactShape = window.preGrabRedactShape;
                 window.calloutLinkLines = window.preGrabCalloutLinkLines;
+                window.calloutShape = window.preGrabCalloutShape;
             }
             if (window.activeCanvas) window.activeCanvas.requestPaint();
         }
@@ -3582,6 +3607,7 @@ DankModal {
                 window.preGrabRedactMode = window.activeRedactMode;
                 window.preGrabRedactShape = window.activeRedactShape;
                 window.preGrabCalloutLinkLines = window.calloutLinkLines;
+                window.preGrabCalloutShape = window.calloutShape;
 
                 window.selectedStroke = strokeToRedo;
                 window.currentColor = strokeToRedo.color;
@@ -3598,7 +3624,10 @@ DankModal {
                 }
                 if (strokeToRedo.tool === "redact" && strokeToRedo.redactMode) window.activeRedactMode = strokeToRedo.redactMode;
                 if (strokeToRedo.tool === "redact" && strokeToRedo.redactShape) window.activeRedactShape = strokeToRedo.redactShape;
-                if (strokeToRedo.tool === "callout") window.calloutLinkLines = strokeToRedo.calloutLinkLines !== undefined ? strokeToRedo.calloutLinkLines : 1;
+                if (strokeToRedo.tool === "callout") {
+                    window.calloutLinkLines = strokeToRedo.calloutLinkLines !== undefined ? strokeToRedo.calloutLinkLines : 1;
+                    window.calloutShape = strokeToRedo.calloutShape !== undefined ? strokeToRedo.calloutShape : "rect";
+                }
             }
 
             if (window.activeCanvas) window.activeCanvas.requestPaint();

--- a/components/CalloutOptionsToolbar.qml
+++ b/components/CalloutOptionsToolbar.qml
@@ -16,9 +16,11 @@ Item {
     property real menuY: 0
 
     property int currentLinkLines: 1
+    property string currentShape: "rect"
     property string toolbarPosition: "top"
 
     signal linkLinesSelected(int count)
+    signal shapeSelected(string shape)
 
     states: [
         State {
@@ -58,8 +60,8 @@ Item {
 
     Rectangle {
         id: menuContent
-        width: contentRow.implicitWidth + Theme.spacingM * 2
-        height: Constants.subToolbarHeight
+        width: contentColumn.implicitWidth + Theme.spacingM * 2
+        height: contentColumn.implicitHeight + Theme.spacingM * 2
         x: Math.max(10, Math.min(root.width - width - 10, root.menuX - width / 2))
         y: root.toolbarPosition === "bottom"
             ? Math.max(10, Math.min(root.height - height - 10, root.menuY - height - 20))
@@ -71,14 +73,52 @@ Item {
         border.width: 1
         radius: Theme.cornerRadius
 
-        Row {
-            id: contentRow
+        Column {
+            id: contentColumn
             anchors.centerIn: parent
             spacing: Theme.spacingS
 
-            // Group: Connecting Lines (1 Line, 2 Lines)
+            // Row 1: Shape (Rectangle, Ellipse)
             Row {
-                spacing: Theme.spacingXS
+                id: shapeRow
+                spacing: Theme.spacingS
+                Repeater {
+                    model: [
+                        { icon: "crop_square", shape: "rect", tooltip: I18n.tr("Rectangle") },
+                        { icon: "circle", shape: "ellipse", tooltip: I18n.tr("Ellipse") }
+                    ]
+                    delegate: Rectangle {
+                        width: Constants.subToolbarBtnSize; height: Constants.subToolbarBtnSize
+                        radius: Theme.cornerRadius - 2
+                        color: root.currentShape === modelData.shape
+                            ? Theme.withAlpha(Theme.primary, 0.15)
+                            : (shapeMouse.containsMouse ? Theme.withAlpha(Theme.surfaceText, 0.08) : "transparent")
+                        border.color: root.currentShape === modelData.shape ? Theme.primary : "transparent"
+                        border.width: 1
+
+                        DankIcon {
+                            anchors.centerIn: parent
+                            name: modelData.icon
+                            size: Constants.subToolbarIconSize
+                            color: root.currentShape === modelData.shape ? Theme.primary : Theme.surfaceText
+                        }
+
+                        MouseArea {
+                            id: shapeMouse
+                            anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.shapeSelected(modelData.shape);
+                                root.close();
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Row 2: Connecting Lines (1 Line, 2 Lines)
+            Row {
+                id: linesRow
+                spacing: Theme.spacingS
                 Repeater {
                     model: [
                         { icon: "remove", count: 1, tooltip: I18n.tr("1 Connecting Line") },

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -573,6 +573,7 @@ MouseArea {
                     window.activeRedactMode = window.preGrabRedactMode;
                     window.activeRedactShape = window.preGrabRedactShape;
                     window.calloutLinkLines = window.preGrabCalloutLinkLines;
+                    window.calloutShape = window.preGrabCalloutShape;
                 }
                 window.originalPoints = [];
                 window.activeHandle = "none";
@@ -595,6 +596,7 @@ MouseArea {
                     window.preGrabRedactMode = window.activeRedactMode;
                     window.preGrabRedactShape = window.activeRedactShape;
                     window.preGrabCalloutLinkLines = window.calloutLinkLines;
+                    window.preGrabCalloutShape = window.calloutShape;
                 }
                 
                 window.selectedStroke = stroke;
@@ -614,6 +616,7 @@ MouseArea {
                 }
                 if (stroke.tool === "callout") {
                     window.calloutLinkLines = stroke.calloutLinkLines !== undefined ? stroke.calloutLinkLines : 1;
+                    window.calloutShape = stroke.calloutShape !== undefined ? stroke.calloutShape : "rect";
                 }
 
                 // Detection for callout destination dragging
@@ -798,6 +801,7 @@ MouseArea {
               redactMode: window.currentTool === "redact" ? window.activeRedactMode : "solid",
               redactShape: window.currentTool === "redact" ? window.activeRedactShape : "rect",
               calloutLinkLines: window.currentTool === "callout" ? window.calloutLinkLines : 1,
+              calloutShape: window.currentTool === "callout" ? window.calloutShape : "rect",
               randomize: window.currentTool === "pixelate" ? window.pixelateRandomize : false,
               randomSeed: window.currentTool === "pixelate" ? Math.floor(Math.random() * 2147483647) : 0
           };

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -564,8 +564,10 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                     if (linkLines === 2) {
                         const e1 = ellipseEdgePoint(srcCx, srcCy, srcRx, srcRy, dstP0.x, dstP0.y);
                         const e2 = ellipseEdgePoint(srcCx, srcCy, srcRx, srcRy, dstP1.x, dstP1.y);
-                        ctx.moveTo(e1.x, e1.y); ctx.lineTo(dstP0.x, dstP0.y);
-                        ctx.moveTo(e2.x, e2.y); ctx.lineTo(dstP1.x, dstP1.y);
+                        const d1 = ellipseEdgePoint(dstCx, dstCy, dstRx, dstRy, srcP0.x, srcP0.y);
+                        const d2 = ellipseEdgePoint(dstCx, dstCy, dstRx, dstRy, srcP1.x, srcP1.y);
+                        ctx.moveTo(e1.x, e1.y); ctx.lineTo(d1.x, d1.y);
+                        ctx.moveTo(e2.x, e2.y); ctx.lineTo(d2.x, d2.y);
                     } else {
                         const e1 = ellipseEdgePoint(srcCx, srcCy, srcRx, srcRy, dstCx, dstCy);
                         const d1 = ellipseEdgePoint(dstCx, dstCy, dstRx, dstRy, srcCx, srcCy);

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -1,6 +1,23 @@
 .pragma library
 .import "Constants.js" as Constants
 
+function ellipseEdgePoint(cx, cy, rx, ry, tx, ty) {
+    const dx = tx - cx;
+    const dy = ty - cy;
+    if (dx === 0 && dy === 0) return { x: cx + rx, y: cy };
+    const angle = Math.atan2(dy, dx);
+    return { x: cx + rx * Math.cos(angle), y: cy + ry * Math.sin(angle) };
+}
+
+function drawEllipsePath(ctx, cx, cy, rx, ry) {
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.scale(rx, ry);
+    ctx.beginPath();
+    ctx.arc(0, 0, 1, 0, 2 * Math.PI);
+    ctx.restore();
+}
+
 /**
  * DrawingRenderer.js
  * Encapsulates all drawing logic for the Quick Capture plugin.
@@ -508,46 +525,75 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
 
             if (sw > 0 && sh > 0 && dw > 0 && dh > 0) {
                 const bW = stroke.borderWidth !== undefined ? stroke.borderWidth : 2;
+                const isEllipse = stroke.calloutShape === "ellipse";
+                const srcCx = sx + sw / 2;
+                const srcCy = sy + sh / 2;
+                const dstCx = dx + dw / 2;
+                const dstCy = dy + dh / 2;
 
-                // 1. Draw orig rect border (background source box)
+                // 1. Draw source border
                 ctx.strokeStyle = stroke.color;
                 ctx.lineWidth = bW;
-                ctx.strokeRect(sx, sy, sw, sh);
-                
+                if (isEllipse) {
+                    drawEllipsePath(ctx, srcCx, srcCy, sw / 2, sh / 2);
+                    ctx.stroke();
+                    drawEllipsePath(ctx, srcCx, srcCy, sw / 2 + 1, sh / 2 + 1);
+                } else {
+                    ctx.strokeRect(sx, sy, sw, sh);
+                }
+
                 ctx.strokeStyle = "rgba(0,0,0,0.4)";
                 ctx.lineWidth = 1;
-                ctx.strokeRect(sx - bW/2 - 0.5, sy - bW/2 - 0.5, sw + bW + 1, sh + bW + 1);
+                if (isEllipse) {
+                    ctx.stroke();
+                } else {
+                    ctx.strokeRect(sx - bW/2 - 0.5, sy - bW/2 - 0.5, sw + bW + 1, sh + bW + 1);
+                }
 
-                // 2. Draw connecting lines (dynamic corners) using semi-transparent stroke color
+                // 2. Draw connecting lines using semi-transparent stroke color
                 const linkLines = stroke.calloutLinkLines !== undefined ? stroke.calloutLinkLines : 2;
                 ctx.strokeStyle = Qt.rgba(rgb.r, rgb.g, rgb.b, 0.6);
                 ctx.lineWidth = bW;
                 ctx.beginPath();
-                
-                if (linkLines === 2) {
-                    // Simple logic: connect closest horizontal corners
-                    if (dx > sx + sw) { // Dest is to the right
+
+                if (isEllipse) {
+                    const srcRx = sw / 2;
+                    const srcRy = sh / 2;
+                    const dstRx = dw / 2;
+                    const dstRy = dh / 2;
+                    if (linkLines === 2) {
+                        const e1 = ellipseEdgePoint(srcCx, srcCy, srcRx, srcRy, dstP0.x, dstP0.y);
+                        const e2 = ellipseEdgePoint(srcCx, srcCy, srcRx, srcRy, dstP1.x, dstP1.y);
+                        ctx.moveTo(e1.x, e1.y); ctx.lineTo(dstP0.x, dstP0.y);
+                        ctx.moveTo(e2.x, e2.y); ctx.lineTo(dstP1.x, dstP1.y);
+                    } else {
+                        const e1 = ellipseEdgePoint(srcCx, srcCy, srcRx, srcRy, dstCx, dstCy);
+                        const d1 = ellipseEdgePoint(dstCx, dstCy, dstRx, dstRy, srcCx, srcCy);
+                        ctx.moveTo(e1.x, e1.y); ctx.lineTo(d1.x, d1.y);
+                    }
+                } else if (linkLines === 2) {
+                    if (dx > sx + sw) {
                         ctx.moveTo(srcP1.x, srcP0.y); ctx.lineTo(dstP0.x, dstP0.y);
                         ctx.moveTo(srcP1.x, srcP1.y); ctx.lineTo(dstP0.x, dstP1.y);
-                    } else if (dx + dw < sx) { // Dest is to the left
+                    } else if (dx + dw < sx) {
                         ctx.moveTo(srcP0.x, srcP0.y); ctx.lineTo(dstP1.x, dstP0.y);
                         ctx.moveTo(srcP0.x, srcP1.y); ctx.lineTo(dstP1.x, dstP1.y);
-                    } else { // Dest is above/below
+                    } else {
                         ctx.moveTo(srcP0.x, srcP1.y); ctx.lineTo(dstP0.x, dstP0.y);
                         ctx.moveTo(srcP1.x, srcP1.y); ctx.lineTo(dstP1.x, dstP0.y);
                     }
-                } else { // 1 Line
-                    if (dx > sx + sw) { // Dest is to the right
+                } else {
+                    if (dx > sx + sw) {
                         ctx.moveTo(sx + sw, sy + sh / 2);
                         ctx.lineTo(dx, dy + dh / 2);
-                    } else if (dx + dw < sx) { // Dest is to the left
+                    } else if (dx + dw < sx) {
                         ctx.moveTo(sx, sy + sh / 2);
                         ctx.lineTo(dx + dw, dy + dh / 2);
-                    } else { // Dest is above/below
-                        if (dy > sy + sh) { // Dest is below
+                    } else {
+                        if (dy > sy + sh) {
                             ctx.moveTo(sx + sw / 2, sy + sh);
                             ctx.lineTo(dx + dw / 2, dy);
-                        } else { // Dest is above
+                        } else {
                             ctx.moveTo(sx + sw / 2, sy);
                             ctx.lineTo(dx + dw / 2, dy + dh);
                         }
@@ -571,7 +617,11 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                         if (clampSW > 0 && clampSH > 0) {
                             ctx.save();
                             ctx.beginPath();
-                            ctx.rect(dx, dy, dw, dh);
+                            if (isEllipse) {
+                                drawEllipsePath(ctx, dstCx, dstCy, dw / 2, dh / 2);
+                            } else {
+                                ctx.rect(dx, dy, dw, dh);
+                            }
                             ctx.clip();
                             ctx.drawImage(config.bgImageItem, clampSX, clampSY, clampSW, clampSH, dx, dy, dw, dh);
                             ctx.restore();
@@ -582,11 +632,23 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 // 4. Draw destination border and shadow (foreground)
                 ctx.strokeStyle = stroke.color;
                 ctx.lineWidth = bW;
-                ctx.strokeRect(dx, dy, dw, dh);
-                
+                if (isEllipse) {
+                    ctx.beginPath();
+                    drawEllipsePath(ctx, dstCx, dstCy, dw / 2, dh / 2);
+                    ctx.stroke();
+                } else {
+                    ctx.strokeRect(dx, dy, dw, dh);
+                }
+
                 ctx.strokeStyle = "rgba(0,0,0,0.4)";
                 ctx.lineWidth = 1;
-                ctx.strokeRect(dx - bW/2 - 0.5, dy - bW/2 - 0.5, dw + bW + 1, dh + bW + 1);
+                if (isEllipse) {
+                    ctx.beginPath();
+                    drawEllipsePath(ctx, dstCx, dstCy, dw / 2 + 1, dh / 2 + 1);
+                    ctx.stroke();
+                } else {
+                    ctx.strokeRect(dx - bW/2 - 0.5, dy - bW/2 - 0.5, dw + bW + 1, dh + bW + 1);
+                }
             }
         }
 
@@ -1009,7 +1071,13 @@ function drawSelectionHandles(ctx, stroke, Theme, estimateTextWidthFn, Qt, Helpe
 
         ctx.save();
         setDashedSelectionStyle(ctx, stroke, Helpers, Qt);
-        ctx.strokeRect(x1, y1, sw, sh);
+        if (stroke.calloutShape === "ellipse") {
+            ctx.beginPath();
+            drawEllipsePath(ctx, cx, cy, sw / 2, sh / 2);
+        } else {
+            ctx.rect(x1, y1, sw, sh);
+        }
+        ctx.stroke();
         ctx.restore();
 
         drawHandlePoints(ctx, [

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -706,8 +706,19 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
             const srcP1 = stroke.points[1];
             const dstP0 = stroke.points[2];
             const dstP1 = stroke.points[3];
-            if ((mx >= srcP0.x - Constants.calloutSelectionPadding && mx <= srcP1.x + Constants.calloutSelectionPadding && my >= srcP0.y - Constants.calloutSelectionPadding && my <= srcP1.y + Constants.calloutSelectionPadding) ||
-                (mx >= dstP0.x - Constants.calloutSelectionPadding && mx <= dstP1.x + Constants.calloutSelectionPadding && my >= dstP0.y - Constants.calloutSelectionPadding && my <= dstP1.y + Constants.calloutSelectionPadding)) {
+            const pad = Constants.calloutSelectionPadding;
+            if (stroke.calloutShape === "ellipse") {
+                const srcCx = (srcP0.x + srcP1.x) / 2;
+                const srcCy = (srcP0.y + srcP1.y) / 2;
+                const srcRx = (srcP1.x - srcP0.x) / 2 + pad;
+                const srcRy = (srcP1.y - srcP0.y) / 2 + pad;
+                const dx = mx - srcCx;
+                const dy = my - srcCy;
+                if (srcRx > 0 && srcRy > 0 && (dx * dx) / (srcRx * srcRx) + (dy * dy) / (srcRy * srcRy) <= 1) return i;
+            } else if (mx >= srcP0.x - pad && mx <= srcP1.x + pad && my >= srcP0.y - pad && my <= srcP1.y + pad) {
+                return i;
+            }
+            if (mx >= dstP0.x - pad && mx <= dstP1.x + pad && my >= dstP0.y - pad && my <= dstP1.y + pad) {
                 return i;
             }
         }
@@ -995,6 +1006,7 @@ function copyStrokeProperties(source, target) {
     if (source.hasLeaderLine !== undefined) target.hasLeaderLine = source.hasLeaderLine;
     if (source.isSpeechBubble !== undefined) target.isSpeechBubble = source.isSpeechBubble;
     if (source.calloutLinkLines !== undefined) target.calloutLinkLines = source.calloutLinkLines;
+    if (source.calloutShape !== undefined) target.calloutShape = source.calloutShape;
     if (source.id !== undefined) target.id = source.id;
 }
 

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -712,14 +712,19 @@ function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
                 const srcCy = (srcP0.y + srcP1.y) / 2;
                 const srcRx = (srcP1.x - srcP0.x) / 2 + pad;
                 const srcRy = (srcP1.y - srcP0.y) / 2 + pad;
-                const dx = mx - srcCx;
-                const dy = my - srcCy;
+                let dx = mx - srcCx;
+                let dy = my - srcCy;
                 if (srcRx > 0 && srcRy > 0 && (dx * dx) / (srcRx * srcRx) + (dy * dy) / (srcRy * srcRy) <= 1) return i;
-            } else if (mx >= srcP0.x - pad && mx <= srcP1.x + pad && my >= srcP0.y - pad && my <= srcP1.y + pad) {
-                return i;
-            }
-            if (mx >= dstP0.x - pad && mx <= dstP1.x + pad && my >= dstP0.y - pad && my <= dstP1.y + pad) {
-                return i;
+                const dstCx = (dstP0.x + dstP1.x) / 2;
+                const dstCy = (dstP0.y + dstP1.y) / 2;
+                const dstRx = (dstP1.x - dstP0.x) / 2 + pad;
+                const dstRy = (dstP1.y - dstP0.y) / 2 + pad;
+                dx = mx - dstCx;
+                dy = my - dstCy;
+                if (dstRx > 0 && dstRy > 0 && (dx * dx) / (dstRx * dstRx) + (dy * dy) / (dstRy * dstRy) <= 1) return i;
+            } else {
+                if (mx >= srcP0.x - pad && mx <= srcP1.x + pad && my >= srcP0.y - pad && my <= srcP1.y + pad) return i;
+                if (mx >= dstP0.x - pad && mx <= dstP1.x + pad && my >= dstP0.y - pad && my <= dstP1.y + pad) return i;
             }
         }
     }


### PR DESCRIPTION
Add ellipse shape toggle for callout tool. Source, destination, connecting lines,
and selection handles all render as ellipse when shape is set to "ellipse".

**Changes:**
- `CalloutOptionsToolbar.qml`: new shape row (Rectangle ↔ Ellipse), follows convention of `ArrowOptionsToolbar`/`RedactOptionsToolbar`
- `QuickCaptureModal.qml`: `calloutShape` property + save/restore across preGrab, undo, redo, paste, tool switch
- `DrawMouseArea.qml`: store `calloutShape` on stroke creation; sync on select
- `DrawingRenderer.js`: ellipse rendering via `translate+scale+arc`, ellipse edge intersection for connecting lines, ellipse clip for destination image
- `Helpers.js`: ellipse hit-test `(dx/rx)² + (dy/ry)² ≤ 1`, `calloutShape` in `copyStrokeProperties`

## Summary by Sourcery

Add support for an ellipse shape variant for the callout tool, including rendering, hit-testing, selection, and state management.

New Features:
- Introduce a shape toggle in the callout options toolbar to switch between rectangular and elliptical callouts.
- Add a calloutShape property to the capture modal and strokes so callouts can be created, edited, and pasted as ellipses.

Enhancements:
- Extend drawing logic to render callout sources, destinations, connecting lines, and selection handles as ellipses when configured.
- Update hit-testing and stroke property copying to respect the new calloutShape, ensuring correct selection and behavior across interactions.