### PR TITLE
refactor: extract tool intensity metadata to ToolMetadata constant

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -319,14 +319,17 @@ DankModal {
     }
 
     function updateActiveIntensity(val) {
-        if (effectiveTool === "text") textFontSize = val;
-        else if (effectiveTool === "pixelate") pixelateIntensity = Math.max(2, Math.min(12, val));
+        const meta = Constants.getToolMeta(effectiveTool);
+        const clamped = Math.max(meta.min, Math.min(meta.max, val));
+
+        if (effectiveTool === "text") textFontSize = clamped;
+        else if (effectiveTool === "pixelate") pixelateIntensity = clamped;
         else if (effectiveTool === "spotlight") {
-            spotlightIntensity = Math.max(10, Math.min(100, val));
-            preGrabSpotlightIntensity = spotlightIntensity;
+            spotlightIntensity = clamped;
+            preGrabSpotlightIntensity = clamped;
         }
-        else if (effectiveTool === "callout") calloutZoom = Math.max(100, Math.min(500, val));
-        else strokeWidth = Math.max(1, Math.min(50, val));
+        else if (effectiveTool === "callout") calloutZoom = clamped;
+        else strokeWidth = clamped;
 
         if (selectedStroke) {
             selectedStroke.width = val;
@@ -1229,7 +1232,7 @@ DankModal {
 
     function getPresetThickness(index) {
         const val = window.pluginData["preset_" + index + "_thickness"];
-        return val !== undefined ? (parseInt(val, 10) || 6) : 6;
+        return val !== undefined ? (parseInt(val, 10) || Constants.getToolMeta("pen").defaultValue) : Constants.getToolMeta("pen").defaultValue;
     }
 
     function updateRadialPresets() {
@@ -1936,7 +1939,7 @@ DankModal {
         window.updateRadialPresets();
 
         let startTool = "pen";
-        let startThickness = 6;
+        let startThickness = Constants.getToolMeta("pen").defaultValue;
         let startColor = Theme.primary;
 
         const defaultToolMode = config.pluginData.defaultToolMode || "preset";
@@ -1951,11 +1954,11 @@ DankModal {
                 startThickness = window.getPresetThickness(presetIdx);
             } else {
                 startTool = config.pluginData.defaultTool || "pen";
-                startThickness = config.pluginData.defaultThickness || 6;
+                startThickness = config.pluginData.defaultThickness || Constants.getToolMeta("pen").defaultValue;
             }
         } else {
             startTool = config.pluginData.defaultTool || "pen";
-            startThickness = config.pluginData.defaultThickness || 6;
+            startThickness = config.pluginData.defaultThickness || Constants.getToolMeta("pen").defaultValue;
         }
 
         window.currentTool = startTool;
@@ -3357,11 +3360,13 @@ DankModal {
                     onPresetSelected: (preset) => {
                         window.currentTool = preset.tool;
                         window.currentColor = preset.color;
-                        if (preset.tool === "text") window.textFontSize = preset.thickness;
-                        else if (preset.tool === "pixelate") window.pixelateIntensity = Math.max(2, Math.min(12, preset.thickness));
-                        else if (preset.tool === "spotlight") window.spotlightIntensity = Math.max(10, Math.min(100, preset.thickness));
-                        else if (preset.tool === "callout") window.calloutZoom = Math.max(100, Math.min(500, preset.thickness));
-                        else window.strokeWidth = preset.thickness;
+                        const meta = Constants.getToolMeta(preset.tool);
+                        const clamped = Math.max(meta.min, Math.min(meta.max, preset.thickness));
+                        if (preset.tool === "text") window.textFontSize = clamped;
+                        else if (preset.tool === "pixelate") window.pixelateIntensity = clamped;
+                        else if (preset.tool === "spotlight") window.spotlightIntensity = clamped;
+                        else if (preset.tool === "callout") window.calloutZoom = clamped;
+                        else window.strokeWidth = clamped;
                         window.recordPresetUsage(preset);
                     }
                     onCenterClicked: {

--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -332,14 +332,14 @@ DankModal {
         else strokeWidth = clamped;
 
         if (selectedStroke) {
-            selectedStroke.width = val;
+            selectedStroke.width = clamped;
             if (selectedStroke.tool === "callout" && selectedStroke.points && selectedStroke.points.length === 4) {
                 const srcP0 = selectedStroke.points[0];
                 const srcP1 = selectedStroke.points[1];
                 const dstP0 = selectedStroke.points[2];
                 const rw = srcP1.x - srcP0.x;
                 const rh = srcP1.y - srcP0.y;
-                const zoom = val / 100.0;
+                const zoom = clamped / 100.0;
                 const dw = rw * zoom;
                 const dh = rh * zoom;
                 const newPoints = [...selectedStroke.points];
@@ -353,7 +353,7 @@ DankModal {
             }
         }
         if (currentStroke) {
-            currentStroke.width = val;
+            currentStroke.width = clamped;
         }
         if (window.activeCanvas) window.activeCanvas.requestPaint();
     }

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -2963,6 +2963,8 @@ PluginSettings {
                 function refreshThicknessConstraints() {
                     const t = presetToolSetting.value;
                     const meta = Constants.getToolMeta(t);
+                    // Localized labels map - required because I18n.tr() needs string literals for extraction tools.
+                    // Keys must match ToolMetadata.label values for consistency.
                     const toolLabels = {
                         pen: I18n.tr("Thickness"), line: I18n.tr("Thickness"),
                         arrow: I18n.tr("Thickness"), rect: I18n.tr("Thickness"),

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -1407,11 +1407,11 @@ PluginSettings {
             id: defaultThickness
             label: I18n.tr("Default Stroke Thickness")
             settingKey: "defaultThickness"
-            defaultValue: 6
-            minimum: 1
-            maximum: 20
-            leftLabel: "1"
-            rightLabel: "20"
+            defaultValue: Constants.getToolMeta("pen").defaultValue
+            minimum: Constants.getToolMeta("pen").min
+            maximum: Constants.getToolMeta("pen").max
+            leftLabel: Constants.getToolMeta("pen").min.toString()
+            rightLabel: Constants.getToolMeta("pen").max.toString()
             previewType: "thickness"
             visible: defaultToolMode.value === "custom"
         }
@@ -1463,11 +1463,11 @@ PluginSettings {
             id: textFontSize
             label: I18n.tr("Default Text Font Size")
             settingKey: "textFontSize"
-            defaultValue: 36
-            minimum: 8
-            maximum: 72
-            leftLabel: "8"
-            rightLabel: "72"
+            defaultValue: Constants.getToolMeta("text").defaultValue
+            minimum: Constants.getToolMeta("text").min
+            maximum: Constants.getToolMeta("text").max
+            leftLabel: Constants.getToolMeta("text").min.toString()
+            rightLabel: Constants.getToolMeta("text").max.toString()
             previewType: "fontSize"
         }
 
@@ -2443,7 +2443,7 @@ PluginSettings {
             for (let i = 0; i < 8; i++) {
                 const tool = radialMenuCard.activePresetTools[i] || "none";
                 const color = radialMenuCard.activePresetColors[i] || "primary";
-                const thickness = radialMenuCard.activePresetThicknesses[i] ?? 6;
+                const thickness = radialMenuCard.activePresetThicknesses[i] ?? Constants.getToolMeta("pen").defaultValue;
                 list.push({ tool: tool, color: color, thickness: thickness });
             }
             return list;
@@ -2950,9 +2950,9 @@ PluginSettings {
                     id: presetThicknessSetting
                     settingKey: "preset_" + index + "_thickness"
                     label: I18n.tr("Preset Thickness")
-                    defaultValue: 6
-                    minimum: 1
-                    maximum: 50
+                    defaultValue: Constants.getToolMeta("pen").defaultValue
+                    minimum: Constants.getToolMeta("pen").min
+                    maximum: Constants.getToolMeta("pen").max
                     unit: "px"
                     leftLabel: String(minimum)
                     rightLabel: String(maximum)
@@ -2962,50 +2962,21 @@ PluginSettings {
 
                 function refreshThicknessConstraints() {
                     const t = presetToolSetting.value;
-                    let defVal = 6;
-                    if (t === "text") {
-                        presetThicknessSetting.label = I18n.tr("Font Size");
-                        presetThicknessSetting.minimum = 12;
-                        presetThicknessSetting.maximum = 120;
-                        presetThicknessSetting.unit = "px";
-                        presetThicknessSetting.previewType = "none";
-                        defVal = 36;
-                    } else if (t === "pixelate") {
-                        presetThicknessSetting.label = I18n.tr("Pixel Intensity");
-                        presetThicknessSetting.minimum = 2;
-                        presetThicknessSetting.maximum = 12;
-                        presetThicknessSetting.unit = "px";
-                        presetThicknessSetting.previewType = "none";
-                        defVal = 8;
-                    } else if (t === "spotlight") {
-                        presetThicknessSetting.label = I18n.tr("Dimming Opacity");
-                        presetThicknessSetting.minimum = 10;
-                        presetThicknessSetting.maximum = 95;
-                        presetThicknessSetting.unit = "%";
-                        presetThicknessSetting.previewType = "none";
-                        defVal = 50;
-                    } else if (t === "callout") {
-                        presetThicknessSetting.label = I18n.tr("Zoom Level");
-                        presetThicknessSetting.minimum = 100;
-                        presetThicknessSetting.maximum = 500;
-                        presetThicknessSetting.unit = "%";
-                        presetThicknessSetting.previewType = "none";
-                        defVal = 150;
-                    } else if (t === "stamp") {
-                        presetThicknessSetting.label = I18n.tr("Stamp Size");
-                        presetThicknessSetting.minimum = 1;
-                        presetThicknessSetting.maximum = 50;
-                        presetThicknessSetting.unit = "px";
-                        presetThicknessSetting.previewType = "thickness";
-                        defVal = 6;
-                    } else {
-                        presetThicknessSetting.label = I18n.tr("Preset Thickness");
-                        presetThicknessSetting.minimum = 1;
-                        presetThicknessSetting.maximum = 50;
-                        presetThicknessSetting.unit = "px";
-                        presetThicknessSetting.previewType = "thickness";
-                        defVal = 6;
-                    }
+                    const meta = Constants.getToolMeta(t);
+                    const toolLabels = {
+                        pen: I18n.tr("Thickness"), line: I18n.tr("Thickness"),
+                        arrow: I18n.tr("Thickness"), rect: I18n.tr("Thickness"),
+                        ellipse: I18n.tr("Thickness"), highlighter: I18n.tr("Thickness"),
+                        redact: I18n.tr("Thickness"), stamp: I18n.tr("Stamp Size"),
+                        text: I18n.tr("Font Size"), pixelate: I18n.tr("Pixel Intensity"),
+                        spotlight: I18n.tr("Dimming Opacity"), callout: I18n.tr("Zoom Level")
+                    };
+                    presetThicknessSetting.label = toolLabels[t] || I18n.tr("Preset Thickness");
+                    presetThicknessSetting.minimum = meta.min;
+                    presetThicknessSetting.maximum = meta.max;
+                    presetThicknessSetting.unit = meta.unit;
+                    presetThicknessSetting.previewType = meta.previewType;
+                    const defVal = meta.defaultValue;
                     
                     const oldDefVal = presetThicknessSetting.defaultValue;
                     presetThicknessSetting.defaultValue = defVal;

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -42,8 +42,8 @@ const ToolMetadata = {
     stamp:       { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Stamp Size", previewType: "thickness", previewMultiplier: 10 },
     text:        { min: 12, max: 120, step: 1,  unit: "px", defaultValue: 36, label: "Font Size", previewType: "none" },
     pixelate:    { min: 2,  max: 12,  step: 1,  unit: "px", defaultValue: 8,  label: "Pixel Intensity", previewType: "none", previewMultiplier: 3, previewClampMin: 8, previewClampMax: 36 },
-    spotlight:   { min: 10, max: 100, step: 1,  unit: "%",  defaultValue: 50, label: "Dimming Opacity", previewType: "none" },
-    callout:     { min: 100,max: 500, step: 10, unit: "%",  defaultValue: 150, label: "Zoom Level", previewType: "none", borderWidthMin: 1, borderWidthMax: 10 },
+    spotlight:   { min: 10, max: 100, step: 1,  unit: "%",  defaultValue: 50, label: "Dimming Opacity", previewType: "none", previewFixedWidth: 100 },
+    callout:     { min: 100,max: 500, step: 10, unit: "%",  defaultValue: 150, label: "Zoom Level", previewType: "none", previewFixedWidth: 40, borderWidthMin: 1, borderWidthMax: 10 },
 };
 
 function getToolMeta(tool) {

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -29,6 +29,27 @@ const stampTextOffsetMultiplier = 0.1;
 const textPaddingMultiplierX = 0.3;
 const textPaddingMultiplierY = 0.15;
 
+// Tool intensity metadata
+// Each tool defines: min, max, step, unit, default, and optional multipliers
+const ToolMetadata = {
+    pen:         { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Thickness", previewType: "thickness" },
+    line:        { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Thickness", previewType: "thickness" },
+    arrow:       { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Thickness", previewType: "thickness" },
+    rect:        { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Thickness", previewType: "thickness" },
+    ellipse:     { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Thickness", previewType: "thickness" },
+    highlighter: { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Thickness", previewType: "thickness", previewMultiplier: 4 },
+    redact:      { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Thickness", previewType: "thickness" },
+    stamp:       { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  label: "Stamp Size", previewType: "thickness", previewMultiplier: 10 },
+    text:        { min: 12, max: 120, step: 1,  unit: "px", defaultValue: 36, label: "Font Size", previewType: "none" },
+    pixelate:    { min: 2,  max: 12,  step: 1,  unit: "px", defaultValue: 8,  label: "Pixel Intensity", previewType: "none", previewMultiplier: 3, previewClampMin: 8, previewClampMax: 36 },
+    spotlight:   { min: 10, max: 100, step: 1,  unit: "%",  defaultValue: 50, label: "Dimming Opacity", previewType: "none" },
+    callout:     { min: 100,max: 500, step: 10, unit: "%",  defaultValue: 150, label: "Zoom Level", previewType: "none", borderWidthMin: 1, borderWidthMax: 10 },
+};
+
+function getToolMeta(tool) {
+    return ToolMetadata[tool] || ToolMetadata.pen;
+}
+
 // Default radial menu preset tools
 const defaultRadialTools = ["pen", "arrow", "rect", "highlighter", "ellipse", "stamp", "redact", "pixelate"];
 

--- a/components/DrawMouseArea.qml
+++ b/components/DrawMouseArea.qml
@@ -1014,10 +1014,11 @@ MouseArea {
              return;
          }
 
-         if (window.currentTool === "select" && window.selectedStroke && window.selectedStroke.tool === "callout") {
-             if (window.calloutDestDragging) {
-                 const currentZoom = window.selectedStroke.width;
-                 const nextZoom = Math.max(100, Math.min(500, currentZoom + step * 10));
+          if (window.currentTool === "select" && window.selectedStroke && window.selectedStroke.tool === "callout") {
+              if (window.calloutDestDragging) {
+                  const calloutMeta = Constants.getToolMeta("callout");
+                  const currentZoom = window.selectedStroke.width;
+                  const nextZoom = Math.max(calloutMeta.min, Math.min(calloutMeta.max, currentZoom + step * calloutMeta.step));
                  window.selectedStroke.width = nextZoom;
                  window.calloutZoom = nextZoom;
                  
@@ -1039,8 +1040,9 @@ MouseArea {
                      window.originalPoints[3] = Qt.point(window.originalPoints[2].x + dw, window.originalPoints[2].y + dh);
                  }
              } else {
-                 const currentBorderWidth = window.selectedStroke.borderWidth !== undefined ? window.selectedStroke.borderWidth : 2;
-                 const nextBorderWidth = Math.max(1, Math.min(10, currentBorderWidth + step));
+                  const calloutMeta = Constants.getToolMeta("callout");
+                  const currentBorderWidth = window.selectedStroke.borderWidth !== undefined ? window.selectedStroke.borderWidth : 2;
+                  const nextBorderWidth = Math.max(calloutMeta.borderWidthMin, Math.min(calloutMeta.borderWidthMax, currentBorderWidth + step));
                  window.selectedStroke.borderWidth = nextBorderWidth;
                  window.strokeWidth = nextBorderWidth;
              }

--- a/components/DrawingRenderer.js
+++ b/components/DrawingRenderer.js
@@ -380,7 +380,8 @@ function drawStroke(ctx, stroke, Helpers, Qt, Theme, config) {
                 ctx.imageSmoothingEnabled = false;
 
                 if (config.bgImageItem && config.bgImageItem.status === 1 /* Image.Ready */) {
-                    const blockSize = Math.max(8, Math.min(36, stroke.width * 3));
+                    const pixelateMeta = Constants.getToolMeta("pixelate");
+                    const blockSize = Math.max(pixelateMeta.previewClampMin, Math.min(pixelateMeta.previewClampMax, stroke.width * 3));
                     const imgW = config.bgImageItem.sourceSize.width;
                     const imgH = config.bgImageItem.sourceSize.height;
                     for (let y = ry; y < ry + rh; y += blockSize) {

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -265,7 +265,7 @@ Rectangle {
                 spacing: Theme.spacingS; anchors.verticalCenter: parent.verticalCenter
                 readonly property var toolMeta: Constants.getToolMeta(root.activeToolType)
                 Text {
-                    text: root.strokeWidth + root.toolMeta.unit
+                    text: root.strokeWidth + parent.toolMeta.unit
                     width: Constants.btnSize; horizontalAlignment: Text.AlignRight
                     color: Theme.surfaceText; font.pixelSize: 11; font.bold: true; anchors.verticalCenter: parent.verticalCenter
                 }

--- a/components/QuickCaptureToolbar.qml
+++ b/components/QuickCaptureToolbar.qml
@@ -263,21 +263,17 @@ Rectangle {
             // Thickness Section
             Row {
                 spacing: Theme.spacingS; anchors.verticalCenter: parent.verticalCenter
+                readonly property var toolMeta: Constants.getToolMeta(root.activeToolType)
                 Text {
-                    text: {
-                        if (root.activeToolType === "spotlight" || root.activeToolType === "callout") {
-                            return root.strokeWidth + "%";
-                        }
-                        return root.strokeWidth + "px";
-                    }
+                    text: root.strokeWidth + root.toolMeta.unit
                     width: Constants.btnSize; horizontalAlignment: Text.AlignRight
                     color: Theme.surfaceText; font.pixelSize: 11; font.bold: true; anchors.verticalCenter: parent.verticalCenter
                 }
                 DankSlider {
                     id: hSlider
-                    minimum: root.activeToolType === "pixelate" ? 2 : (root.activeToolType === "spotlight" ? 10 : (root.activeToolType === "callout" ? 100 : 1))
-                    maximum: root.activeToolType === "pixelate" ? 12 : (root.activeToolType === "text" ? 120 : (root.activeToolType === "spotlight" ? 95 : (root.activeToolType === "callout" ? 500 : 50)))
-                    step: root.activeToolType === "callout" ? 10 : 1
+                    minimum: parent.toolMeta.min
+                    maximum: parent.toolMeta.max
+                    step: parent.toolMeta.step
                     width: Constants.sliderWidth
                     height: Constants.btnSize
                     showValue: false

--- a/components/SizePreviewCard.qml
+++ b/components/SizePreviewCard.qml
@@ -31,21 +31,19 @@ Rectangle {
         const tool = window.effectiveTool;
         const meta = Constants.getToolMeta(tool);
 
-        if (meta.previewMultiplier) {
+        if (meta.previewFixedWidth !== undefined) {
+            base = meta.previewFixedWidth;
+        } else if (meta.previewMultiplier) {
             base = window.activeIntensity * meta.previewMultiplier;
         }
         if (meta.previewClampMin !== undefined) {
             base = Math.max(meta.previewClampMin, Math.min(meta.previewClampMax, base));
         }
 
-        if (tool === "spotlight") {
-            base = 100;
-        } else if (tool === "callout") {
+        if (tool === "callout") {
             if (window.currentTool === "select" && !window.calloutDestDragging && window.selectedStroke) {
                 const bw = window.selectedStroke.borderWidth !== undefined ? window.selectedStroke.borderWidth : 2;
                 base = bw * 2;
-            } else {
-                base = 40;
             }
         }
         return base * window.editScale;

--- a/components/SizePreviewCard.qml
+++ b/components/SizePreviewCard.qml
@@ -4,6 +4,7 @@ import qs.Widgets
 import qs.Modals.Common
 import qs.Services
 import "../dms-common"
+import "Constants.js" as Constants
 
 Rectangle {
     id: sizePreviewItem
@@ -28,13 +29,16 @@ Rectangle {
     readonly property real shapeWidth: {
         let base = window.activeIntensity;
         const tool = window.effectiveTool;
-        if (tool === "highlighter") {
-            base = window.activeIntensity * 4;
-        } else if (tool === "stamp") {
-            base = window.activeIntensity * 10;
-        } else if (tool === "pixelate") {
-            base = Math.max(8, Math.min(36, window.activeIntensity * 3));
-        } else if (tool === "spotlight") {
+        const meta = Constants.getToolMeta(tool);
+
+        if (meta.previewMultiplier) {
+            base = window.activeIntensity * meta.previewMultiplier;
+        }
+        if (meta.previewClampMin !== undefined) {
+            base = Math.max(meta.previewClampMin, Math.min(meta.previewClampMax, base));
+        }
+
+        if (tool === "spotlight") {
             base = 100;
         } else if (tool === "callout") {
             if (window.currentTool === "select" && !window.calloutDestDragging && window.selectedStroke) {
@@ -87,10 +91,8 @@ Rectangle {
                 }
             }
             const tool = window.effectiveTool;
-            if (tool === "spotlight" || tool === "callout") {
-                return window.activeIntensity + "%";
-            }
-            return window.activeIntensity + "px";
+            const meta = Constants.getToolMeta(tool);
+            return window.activeIntensity + meta.unit;
         }
 
         color: Theme.primary


### PR DESCRIPTION
## Summary

Centralize all tool intensity/thickness metadata (min, max, step, default, unit, label) into a single `ToolMetadata` constant in `Constants.js`, eliminating hardcoded values scattered across 7 files.

## Changes

### New: `ToolMetadata` constant
```javascript
const ToolMetadata = {
    pen:         { min: 1,  max: 50,  step: 1,  unit: "px", defaultValue: 8,  ... },
    text:        { min: 12, max: 120, step: 1,  unit: "px", defaultValue: 36, ... },
    pixelate:    { min: 2,  max: 12,  step: 1,  unit: "px", defaultValue: 8,  ... },
    spotlight:   { min: 10, max: 100, step: 1,  unit: "%",  defaultValue: 50, ... },
    callout:     { min: 100,max: 500, step: 10, unit: "%",  defaultValue: 150, ... },
    // ... all tools
};
```

### Refactored files
- `QuickCaptureModal.qml` - `updateActiveIntensity()` and fallback defaults
- `QuickCaptureToolbar.qml` - Slider min/max/step
- `SizePreviewCard.qml` - Preview width and unit display
- `QuickCaptureSettings.qml` - Settings sliders
- `DrawMouseArea.qml` - Callout zoom wheel and border width
- `DrawingRenderer.js` - Pixelate blockSize clamp

### Bug fixes
- Spotlight max: 95 → 100 (consistent across all files)
- Default thickness fallback: 6 → 8 (matches `pen.defaultValue`)
- textFontSize slider: min 8→12, max 72→120 (matches ToolMetadata)
- defaultThickness slider: max 20→50 (matches `pen.max`)

## Summary by Sourcery

Centralize drawing tool intensity and size configuration in a shared ToolMetadata registry and update capture UI and rendering logic to consume it for consistent ranges, defaults, units, and clamping.

New Features:
- Introduce a ToolMetadata constant and getToolMeta helper to define per-tool intensity/size ranges, defaults, units, and preview behavior in one place.

Bug Fixes:
- Align spotlight intensity maximum to 100% across the UI and presets.
- Update default stroke thickness fallbacks from 6px to the pen tool default of 8px.
- Align text font size slider and preset ranges with the defined text tool metadata.
- Ensure pixelate block size and intensity clamping use the shared pixelate tool metadata.
- Use callout tool metadata for zoom and border width adjustments to avoid out-of-range values.

Enhancements:
- Refactor capture settings, modal, toolbar, size preview, and drawing mouse handling to derive slider constraints, labels, units, and previews from ToolMetadata instead of hardcoded values.
- Simplify preset thickness configuration to use tool metadata-driven labels, ranges, and preview types for all tools.