### PR TITLE
Fix stroke interaction regression

### DIFF
--- a/QuickCaptureModal.qml
+++ b/QuickCaptureModal.qml
@@ -176,6 +176,11 @@ DankModal {
             window.savePreGrabState();
             window.selectedStroke = s;
             window.currentColor = s.color;
+            const orig = [];
+            for (let p of s.points) {
+                orig.push(Qt.point(p.x, p.y));
+            }
+            window.originalPoints = orig;
             if (s.tool === "text") window.textFontSize = s.width;
             else if (s.tool === "pixelate") window.pixelateIntensity = s.width;
             else if (s.tool === "spotlight") window.spotlightIntensity = s.width;

--- a/components/Helpers.js
+++ b/components/Helpers.js
@@ -457,7 +457,12 @@ function estimateTextWidth(text, fontSize, isBold, isMonospace) {
 // ─── 6. Stroke geometry & hit-testing ────────────────────────────────────────
 
 /**
- * Finds the index of the stroke under coordinate (mx, my).
+ * Calculates the bounding box of a stroke.
+ * @param {object} stroke - The stroke object.
+ * @param {function} estimateTextWidthFn - Text width estimation function.
+ * @returns {object} { minX, minY, maxX, maxY }
+ */
+function getStrokeBBox(stroke, estimateTextWidthFn) {
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
     const pts = stroke.points;
     const len = pts.length;
@@ -527,6 +532,14 @@ function estimateTextWidth(text, fontSize, isBold, isMonospace) {
     return { minX: minX, minY: minY, maxX: maxX, maxY: maxY };
 }
 
+/**
+ * Finds the index of the stroke under coordinate (mx, my).
+ * @param {number} mx - X coordinate.
+ * @param {number} my - Y coordinate.
+ * @param {array} strokes - List of strokes.
+ * @param {function} estimateTextWidthFn - Text width estimation function.
+ * @returns {number} Stroke index or -1.
+ */
 function findStrokeAt(mx, my, strokes, estimateTextWidthFn) {
     for (let i = strokes.length - 1; i >= 0; i--) {
         const stroke = strokes[i];


### PR DESCRIPTION
This PR fixes the issue where strokes could not be grabbed or moved after commit 9e70566.

The root cause was a corruption in `components/Helpers.js` where the `getStrokeBBox` function declaration was accidentally deleted during a refactor, and `findStrokeAt` was partially broken as a result.

Additionally, this PR ensures that `originalPoints` are correctly initialized when a stroke is automatically selected upon switching to the Select tool, improving the UX for keyboard-based selection.

## Summary by Sourcery

Restore stroke hit-testing and selection behavior and improve initialization of stroke state when automatically selecting a stroke in the Quick Capture modal.

Bug Fixes:
- Reintroduce stroke bounding box calculation used by hit-testing to fix broken stroke grabbing and movement.
- Ensure originalPoints is initialized when a stroke is auto-selected after switching to the Select tool, preventing inconsistent behavior with keyboard-based stroke manipulation.

Enhancements:
- Capture the original geometry of an auto-selected stroke in the Quick Capture modal to provide a smoother selection and editing UX.