### PR TITLE
feat(capture): add control center hide toggle

### DIFF
--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -24,6 +24,7 @@ PluginComponent {
     property bool isDownloading: false
     property string currentCapturePath: ""
     property string captureOutputName: ""
+    property bool hideControlCenter: pluginData.defaultHideControlCenter !== false
     readonly property int captureTimeoutMs: 60000
     readonly property int scrollCaptureTimeoutMs: 120000
     readonly property bool isAnnotating: modal.shouldBeVisible
@@ -78,12 +79,16 @@ PluginComponent {
         root.pendingCaptureAction = finalAction;
         root.pendingCaptureMode = finalMode;
 
-        if (pluginData.hideControlCenter === true) {
+        if (root.hideControlCenter) {
             root.closeControlCenter();
             captureDelayTimer.start();
         } else {
             root.startActualCapture();
         }
+    }
+
+    function toggleHideControlCenter() {
+        root.hideControlCenter = !root.hideControlCenter;
     }
 
     function closeControlCenter() {
@@ -226,6 +231,7 @@ PluginComponent {
                     root.toastError(I18n.tr("Failed to save screenshot"));
             });
         } else {
+            root.closeControlCenter();
             modal.currentCapturePath = path;
             modal.shouldBeVisible = true;
             modal.open();

--- a/QuickCaptureDaemon.qml
+++ b/QuickCaptureDaemon.qml
@@ -77,8 +77,13 @@ PluginComponent {
         root.isCapturing = true;
         root.pendingCaptureAction = finalAction;
         root.pendingCaptureMode = finalMode;
-        root.closeControlCenter();
-        captureDelayTimer.start();
+
+        if (pluginData.hideControlCenter === true) {
+            root.closeControlCenter();
+            captureDelayTimer.start();
+        } else {
+            root.startActualCapture();
+        }
     }
 
     function closeControlCenter() {

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -507,10 +507,10 @@ PluginSettings {
         SectionTitle {
             text: I18n.tr("Capture Options")
             icon: "settings"
-            showReset: outputTargetName.isDirty || hideControlCenter.isDirty || skipConfirm.isDirty || includeCursor.isDirty || resetLastRegion.isDirty
+            showReset: outputTargetName.isDirty || defaultHideControlCenter.isDirty || skipConfirm.isDirty || includeCursor.isDirty || resetLastRegion.isDirty
             onResetClicked: {
                 outputTargetName.resetToDefault();
-                hideControlCenter.resetToDefault();
+                defaultHideControlCenter.resetToDefault();
                 skipConfirm.resetToDefault();
                 includeCursor.resetToDefault();
                 resetLastRegion.resetToDefault();
@@ -546,10 +546,10 @@ PluginSettings {
         Separator {}
 
         ToggleSettingPlus {
-            id: hideControlCenter
-            settingKey: "hideControlCenter"
-            label: I18n.tr("Hide Control Center")
-            description: I18n.tr("Close Control Center before capture.")
+            id: defaultHideControlCenter
+            settingKey: "defaultHideControlCenter"
+            label: I18n.tr("Hide Control Center by Default")
+            description: I18n.tr("Initial state for the Control Center toggle.")
             defaultValue: true
         }
 

--- a/QuickCaptureSettings.qml
+++ b/QuickCaptureSettings.qml
@@ -507,9 +507,10 @@ PluginSettings {
         SectionTitle {
             text: I18n.tr("Capture Options")
             icon: "settings"
-            showReset: outputTargetName.isDirty || skipConfirm.isDirty || includeCursor.isDirty || resetLastRegion.isDirty
+            showReset: outputTargetName.isDirty || hideControlCenter.isDirty || skipConfirm.isDirty || includeCursor.isDirty || resetLastRegion.isDirty
             onResetClicked: {
                 outputTargetName.resetToDefault();
+                hideControlCenter.resetToDefault();
                 skipConfirm.resetToDefault();
                 includeCursor.resetToDefault();
                 resetLastRegion.resetToDefault();
@@ -540,6 +541,16 @@ PluginSettings {
             settingKey: "includeCursor"
             label: I18n.tr("Include Cursor")
             defaultValue: false
+        }
+
+        Separator {}
+
+        ToggleSettingPlus {
+            id: hideControlCenter
+            settingKey: "hideControlCenter"
+            label: I18n.tr("Hide Control Center")
+            description: I18n.tr("Close Control Center before capture.")
+            defaultValue: true
         }
 
         Separator {}

--- a/QuickCaptureWidget.qml
+++ b/QuickCaptureWidget.qml
@@ -644,6 +644,20 @@ PluginComponent {
                             if (root.daemon) root.daemon.showHistoryCarousel();
                         }
                     }
+
+                    DankActionButton {
+                        iconName: root.daemon && root.daemon.hideControlCenter ? "visibility_off" : "visibility"
+                        buttonSize: 28
+                        iconSize: 16
+                        iconColor: root.daemon && root.daemon.hideControlCenter ? Theme.surfaceVariantText : Theme.primary
+                        tooltipText: root.daemon && root.daemon.hideControlCenter
+                            ? I18n.tr("Hide Control Center")
+                            : I18n.tr("Show Control Center")
+                        tooltipSide: "bottom"
+                        onClicked: {
+                            if (root.daemon) root.daemon.toggleHideControlCenter();
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Adds option don't close Control Center before starting a screenshot capture.

## Use Case

Some users want screenshots to include the current shell UI, such as Control Center/quick settings, without waiting for the popout close animation before capture begins.

## Changes

- QuickCaptureSettings.qml: add a `Hide Control Center` toggle under Capture Options, enabled by default to preserve existing behavior
- QuickCaptureDaemon.qml: only close Control Center and wait for the capture delay when `hideControlCenter` is enabled
- When the toggle is disabled, capture starts immediately without closing Control Center first

## Checklist

- [x] I have tested these changes on my setup
- [ ] I have updated the documentation (README, IPC/settings docs) if needed
- [x] I have verified the plugin loads without errors