### PR TITLE
fix(region-selector): render first frame synchronously to avoid frame-callback deadlock

### DIFF
--- a/dms-screenshot-rs/src/region_selector/backend.rs
+++ b/dms-screenshot-rs/src/region_selector/backend.rs
@@ -711,6 +711,9 @@ fn setup_layer_surfaces(
         layer_surface.set_exclusive_zone(-1);
         surface.commit();
 
+        // A freshly created surface has never committed a buffer, so its first
+        // frame must be drawn synchronously (see request_render).
+        output.initial_render_done = false;
         output.surface = Some(surface);
         output.layer_surface = Some(layer_surface);
     }
@@ -2276,23 +2279,21 @@ fn request_render_pending(state: &mut SelectorState, qh: &QueueHandle<SelectorSt
 }
 
 fn request_render(state: &mut SelectorState, qh: &QueueHandle<SelectorState>, output_idx: usize) {
-    let Some(output) = state.outputs.get(output_idx) else {
-        return;
+    // Decide whether this output still needs a synchronous first render. The
+    // borrow ends here so render_output can take &mut state below.
+    let needs_direct_render = {
+        let Some(output) = state.outputs.get_mut(output_idx) else {
+            return;
+        };
+        if !output.configured || output.closed {
+            return;
+        }
+        output.dirty = true;
+        if output.frame_callback.is_some() || output.surface.is_none() {
+            return;
+        }
+        !output.initial_render_done
     };
-    if !output.configured || output.closed {
-        return;
-    }
-    let has_frame_callback = output.frame_callback.is_some();
-    let needs_direct_render = !output.initial_render_done;
-    let has_surface = output.surface.is_some();
-
-    let Some(output) = state.outputs.get_mut(output_idx) else {
-        return;
-    };
-    output.dirty = true;
-    if has_frame_callback || !has_surface {
-        return;
-    }
 
     if needs_direct_render {
         // Some compositors (e.g. Hyprland >= 0.56) never fire wl_surface.frame

--- a/dms-screenshot-rs/src/region_selector/backend.rs
+++ b/dms-screenshot-rs/src/region_selector/backend.rs
@@ -182,6 +182,7 @@ struct OutputEntry {
     cursor_buffer: Option<CursorBuffer>,
     frame_callback: Option<WlCallback>,
     dirty: bool,
+    initial_render_done: bool,
 }
 
 struct ShmBuffer {
@@ -2232,6 +2233,7 @@ fn render_output(state: &mut SelectorState, qh: &QueueHandle<SelectorState>, out
     surface.set_buffer_scale(scale);
     surface.commit();
     output.dirty = false;
+    output.initial_render_done = true;
 }
 
 fn pointer_is_over_scroll_preview(state: &SelectorState, seat_idx: usize) -> bool {
@@ -2274,16 +2276,36 @@ fn request_render_pending(state: &mut SelectorState, qh: &QueueHandle<SelectorSt
 }
 
 fn request_render(state: &mut SelectorState, qh: &QueueHandle<SelectorState>, output_idx: usize) {
-    let Some(output) = state.outputs.get_mut(output_idx) else {
+    let Some(output) = state.outputs.get(output_idx) else {
         return;
     };
     if !output.configured || output.closed {
         return;
     }
+    let has_frame_callback = output.frame_callback.is_some();
+    let needs_direct_render = !output.initial_render_done;
+    let has_surface = output.surface.is_some();
+
+    let Some(output) = state.outputs.get_mut(output_idx) else {
+        return;
+    };
     output.dirty = true;
-    if output.frame_callback.is_some() {
+    if has_frame_callback || !has_surface {
         return;
     }
+
+    if needs_direct_render {
+        // Some compositors (e.g. Hyprland >= 0.56) never fire wl_surface.frame
+        // callbacks for a layer surface that has not committed a buffer yet,
+        // which deadlocks the selector before its first frame. Draw the first
+        // frame synchronously instead of waiting for a callback.
+        render_output(state, qh, output_idx);
+        return;
+    }
+
+    let Some(output) = state.outputs.get_mut(output_idx) else {
+        return;
+    };
     let Some(surface) = output.surface.as_ref().cloned() else {
         return;
     };


### PR DESCRIPTION
## Summary

Render the region selector's first frame synchronously instead of waiting for a `wl_surface.frame` callback, fixing a deadlock that leaves the selection overlay invisible (and input-less) on Hyprland 0.56 and similar compositors.

## Use Case

Region/scroll capture is completely unusable on affected compositors: the overlay never appears, and after the plugin's 60s timeout the user gets a misleading "Rust screenshot backend is not installed" toast even though the backend is installed and working. See #219.

## Changes

- `dms-screenshot-rs/src/region_selector/backend.rs`:
  - `request_render()`: if the output has not committed its initial buffer yet, call `render_output()` directly instead of waiting for a frame callback (which some compositors never fire for buffer-less surfaces).
  - Track this with a new `initial_render_done` flag per output, set after the first successful commit.
  - All subsequent redraws still go through the existing frame-callback path, unchanged.

## Related Issues

Closes #219

## Testing

- Tested on Hyprland 0.56.2, x86_64, dual 1920x1080 monitors, DMS 1.5.3, plugin 5.0.0-beta.3:
  - **Before:** added trace logging shows `zwlr_layer_surface_v1.configure` arriving for both outputs, but `render_output()` never runs — no buffer committed, `hyprctl layers` shows the `selection` layers at alpha 0, capture killed at 60s (`exitCode=124`), "backend not installed" toast.
  - **After:** buffers commit immediately after configure, overlay appears, a drawn region completes with `{"status":"success",...}` and opens the annotation modal.
- `full` mode unaffected (still works as before).
- Plugin loads without errors; rebuilt binary installed to `backend/<arch>/` per the README flow.

## Screenshots / Screen Recordings

Not available (Wayland screen content from the affected overlay was, by definition, not rendered).

## Checklist

- [x] I have tested these changes on my setup
- [ ] I have updated the documentation (README, IPC/settings docs) if needed
- [x] I have verified the plugin loads without errors

## Summary by Sourcery

Ensure the region selector displays and accepts input reliably on compositors that do not issue frame callbacks before the first buffer commit.

Bug Fixes:
- Render the region selector's initial frame synchronously when needed, preventing compositor frame-callback deadlocks that leave the overlay invisible and unusable.

Enhancements:
- Preserve the existing frame-callback rendering path for subsequent redraws while tracking whether each output has completed its initial render.