### PR TITLE
refactor: remove Qt5Compat dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Screenshot annotation plugin for DankMaterialShell.
 | **img2pdf** | PDF export |
 | **tesseract** | OCR text scanner |
 | **zbar** (`zbarimg`) | QR scanner |
-| **Qt5Compat GraphicalEffects** (`qt6-qt5compat`) | Floating images |
 | **Rust screenshot backend** | Installed separately when the New Backend is selected |
 | **curl** and **sha256sum** | Verify and install the Rust backend release asset |
 

--- a/components/floating/FloatWindow.qml
+++ b/components/floating/FloatWindow.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects as GE
+import QtQuick.Effects
 import Quickshell
 import Quickshell.Wayland
 import qs.Common
@@ -382,14 +381,9 @@ PanelWindow {
             visible: opacity > 0
 
             layer.enabled: true
-            layer.effect: GE.OpacityMask {
-                maskSource: Rectangle {
-                    width: img.width
-                    height: img.height
-                    radius: Math.max(0, Theme.cornerRadius - window.borderWidth)
-                    visible: false
-                    antialiasing: true
-                }
+            layer.effect: MultiEffect {
+                maskEnabled: true
+                maskSource: imgMask
             }
 
             onStatusChanged: {
@@ -402,6 +396,15 @@ PanelWindow {
                     window.destroy();
                 }
             }
+        }
+
+        Rectangle {
+            id: imgMask
+            anchors.fill: img
+            radius: Math.max(0, Theme.cornerRadius - window.borderWidth)
+            visible: false
+            antialiasing: true
+            layer.enabled: true
         }
 
         // Minimized Icon


### PR DESCRIPTION
## Summary

Use qt6 MultiEffect to clip the floating image corners instead of Qt5 OpacityMask

## Use Case

Removes the Qt5Compat dependency, which DMS users may not have installed by default

## Changes

<!-- Bullet list of what changed and why. -->

## Related Issues

<!-- Link to any related issues, e.g. Closes #123, Related to #456. -->

## Testing

<!-- Describe how you tested these changes. Include steps, OS info, DMS version. -->

## Screenshots / Screen Recordings

<!-- If applicable, add screenshots or recordings showing the before/after. -->

## Checklist

- [ ] I have tested these changes on my setup
- [ ] I have updated the documentation (README, IPC/settings docs) if needed
- [ ] I have verified the plugin loads without errors

## Summary by Sourcery

Remove the Qt5Compat dependency from floating image rendering.

Enhancements:
- Replace the Qt5Compat opacity mask with Qt 6 MultiEffect masking for rounded floating images.

Build:
- Remove the Qt5Compat GraphicalEffects dependency from the documented requirements.