### PR TITLE
i18n: sync translations from POEditor

### DIFF
--- a/translations/ar.json
+++ b/translations/ar.json
@@ -1,0 +1,1457 @@
+{
+  "%1 — %2": {
+    "%1 — %2": ""
+  },
+  "1 Connecting Line": {
+    "1 Connecting Line": "خط اتصال واحد"
+  },
+  "2 Connecting Lines": {
+    "2 Connecting Lines": "خطا اتصال"
+  },
+  "AUTO": {
+    "AUTO": "تلقائي"
+  },
+  "Action": {
+    "Action": "إجراء"
+  },
+  "Action when Enter": {
+    "Action when Enter": "الإجراء عند الضغط على Enter"
+  },
+  "Active Window": {
+    "Active Window": "النافذة النشطة"
+  },
+  "Adaptive": {
+    "Adaptive": "تكيفي"
+  },
+  "Adaptive (DMS Theme)": {
+    "Adaptive (DMS Theme)": "تكييفي (سمة DMS)"
+  },
+  "Add": {
+    "Add": "إضافة"
+  },
+  "Add Text Note": {
+    "Add Text Note": "إضافة ملاحظة نصية"
+  },
+  "All Combined Outputs": {
+    "All Combined Outputs": "جميع المخرجات مجتمعة"
+  },
+  "All Outputs": {
+    "All Outputs": "جميع المخرجات"
+  },
+  "Annotating": {
+    "Annotating": "التعليق التوضيحي"
+  },
+  "Annotation Tools": {
+    "Annotation Tools": "أدوات التعليق التوضيحي"
+  },
+  "Anonymous Copy (stripped metadata)": {
+    "Anonymous Copy (stripped metadata)": "نسخ مجهول (تم إزالة البيانات الوصفية)"
+  },
+  "Arrow (3)": {
+    "Arrow (3)": "سهم (3)"
+  },
+  "Arrow Color": {
+    "Arrow Color": "لون السهم"
+  },
+  "Arrow Thickness": {
+    "Arrow Thickness": "سمك السهم"
+  },
+  "Arrow Vector": {
+    "Arrow Vector": "سهم متجه"
+  },
+  "Audio & Overlay": {
+    "Audio & Overlay": "الصوت والتراكب"
+  },
+  "Audio Codec": {
+    "Audio Codec": "برنامج ترميز الصوت"
+  },
+  "Auto": {
+    "Auto": "تلقائي"
+  },
+  "Auto Balance": {
+    "Auto Balance": "موازنة تلقائية"
+  },
+  "Auto Detect": {
+    "Auto Detect": "كشف تلقائي"
+  },
+  "Auto-apply background defaults": {
+    "Auto-apply background defaults": "تطبيق إعدادات الخلفية الافتراضية تلقائياً"
+  },
+  "Auto-close the loop when ending near the start point.": {
+    "Auto-close the loop when ending near the start point.": "إغلاق الحلقة تلقائياً عند الانتهاء بالقرب من نقطة البداية."
+  },
+  "Auto-minimize": {
+    "Auto-minimize": "تصغير تلقائي"
+  },
+  "Auto-select a tool preset on hover, without releasing the mouse.": {
+    "Auto-select a tool preset on hover, without releasing the mouse.": "تحديد مسبق للأداة تلقائياً عند التمرير، دون تحرير الماوس."
+  },
+  "Auto-tiling": {
+    "Auto-tiling": "تجانب تلقائي"
+  },
+  "Automatically minimize the float window after a delay": {
+    "Automatically minimize the float window after a delay": "تصغير النافذة العائمة تلقائياً بعد تأخير"
+  },
+  "Automatically stack windows to avoid overlap": {
+    "Automatically stack windows to avoid overlap": "ترتيب النوافذ تلقائياً لتجنب التداخل"
+  },
+  "Back to Annotation (B)": {
+    "Back to Annotation (B)": "العودة إلى التعليق التوضيحي (B)"
+  },
+  "Background": {
+    "Background": "الخلفية"
+  },
+  "Background (B)": {
+    "Background (B)": "الخلفية (B)"
+  },
+  "Background Defaults": {
+    "Background Defaults": "إعدادات الخلفية الافتراضية"
+  },
+  "Background Image Folder": {
+    "Background Image Folder": "مجلد صور الخلفية"
+  },
+  "Background Images": {
+    "Background Images": "صور الخلفية"
+  },
+  "Background Presets": {
+    "Background Presets": "إعدادات الخلفية المسبقة"
+  },
+  "Balanced": {
+    "Balanced": "متوازن"
+  },
+  "Bar Interactions": {
+    "Bar Interactions": "تفاعلات الشريط"
+  },
+  "Blink Recording Dot": {
+    "Blink Recording Dot": "وميض نقطة التسجيل"
+  },
+  "Blur Background Image": {
+    "Blur Background Image": "تمويه صورة الخلفية"
+  },
+  "Border Color": {
+    "Border Color": "لون الحد"
+  },
+  "Border Width": {
+    "Border Width": "عرض الحدود"
+  },
+  "Both": {
+    "Both": "كلاهما"
+  },
+  "Bottom": {
+    "Bottom": "أسفل"
+  },
+  "Bottom Center": {
+    "Bottom Center": "أسفل المنتصف"
+  },
+  "Bottom Left": {
+    "Bottom Left": "أسفل اليسار"
+  },
+  "Bottom Right": {
+    "Bottom Right": "أسفل اليمين"
+  },
+  "CUST": {
+    "CUST": "مخصص"
+  },
+  "Callout": {
+    "Callout": "وسيلة إيضاح"
+  },
+  "Callout (Z) | Hold G for Loupe": {
+    "Callout (Z) | Hold G for Loupe": "وسيلة إيضاح (Z) | اضغط باستمرار على G للعدسة المكبرة"
+  },
+  "Callout Zoom": {
+    "Callout Zoom": "تكبير وسيلة الإيضاح"
+  },
+  "Callout, Background (Z, B)": {
+    "Callout, Background (Z, B)": "وسيلة إيضاح، خلفية (Z, B)"
+  },
+  "Capture": {
+    "Capture": "التقاط"
+  },
+  "Capture Actions": {
+    "Capture Actions": "إجراءات الالتقاط"
+  },
+  "Capture Options": {
+    "Capture Options": "خيارات الالتقاط"
+  },
+  "Capturing...": {
+    "Capturing...": "جاري الالتقاط..."
+  },
+  "Catppuccin": {
+    "Catppuccin": "Catppuccin"
+  },
+  "Center": {
+    "Center": "المنتصف"
+  },
+  "Center Left": {
+    "Center Left": "منتصف اليسار"
+  },
+  "Center Right": {
+    "Center Right": "منتصف اليمين"
+  },
+  "Choose Color": {
+    "Choose Color": "اختيار اللون"
+  },
+  "Choose notifications shown after copy or save.": {
+    "Choose notifications shown after copy or save.": "اختر الإشعارات التي تظهر بعد النسخ أو الحفظ."
+  },
+  "Choose the editor shape for portrait or landscape screens.": {
+    "Choose the editor shape for portrait or landscape screens.": "اختر شكل المحرر للشاشات العمودية أو الأفقية."
+  },
+  "Choose whether the editor opens as a modal overlay or a movable floating window.": {
+    "Choose whether the editor opens as a modal overlay or a movable floating window.": "اختر ما إذا كان المحرر يفتح كطبقة تراكب مشروطة أو نافذة عائمة قابلة للتحريك."
+  },
+  "Choose which monitor to capture during full screen recording.": {
+    "Choose which monitor to capture during full screen recording.": "اختر الشاشة المراد التقاطها أثناء تسجيل ملء الشاشة."
+  },
+  "Classic (Tailwind)": {
+    "Classic (Tailwind)": "كلاسيكي (Tailwind)"
+  },
+  "Clean Text Eraser": {
+    "Clean Text Eraser": "ممساحة النصوص النظيفة"
+  },
+  "Clear saved region selection before each capture": {
+    "Clear saved region selection before each capture": "مسح تحديد المنطقة المحفوظة قبل كل التقاط"
+  },
+  "Clipboard": {
+    "Clipboard": "الحافظة"
+  },
+  "Close": {
+    "Close": "اغلاق"
+  },
+  "Close Annotator": {
+    "Close Annotator": "إغلاق أداة التعليقات التوضيحية"
+  },
+  "Color Palette": {
+    "Color Palette": "لوحة الألوان"
+  },
+  "Color Picker (F for RGB | Eyedropper)": {
+    "Color Picker (F for RGB | Eyedropper)": "منتقي الألوان (F للـ RGB | القطارة)"
+  },
+  "Color Picker, Eraser (F, T)": {
+    "Color Picker, Eraser (F, T)": "منتقي الألوان، ممساحة (F, T)"
+  },
+  "Color copied to clipboard: %1": {
+    "Color copied to clipboard: %1": "تم نسخ اللون إلى الحافظة: %1"
+  },
+  "Configure up to 8 quick-access tool presets. Right-click during capture to open the radial menu.": {
+    "Configure up to 8 quick-access tool presets. Right-click during capture to open the radial menu.": "قم بتهيئة ما يصل إلى 8 إعدادات مسبقة لأدوات الوصول السريع. انقر بزر الماوس الأيمن أثناء الالتقاط لفتح القائمة الشعاعية."
+  },
+  "Conic Gradient": {
+    "Conic Gradient": "تدرج مخروطي"
+  },
+  "Container Format": {
+    "Container Format": "تنسيق الحاوية"
+  },
+  "Contributors": {
+    "Contributors": "المساهمون"
+  },
+  "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
+    "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": "يتحكم في ميزانية بكسل المعاينة أثناء التحرير. قللها إذا واجهت بطئًا. لا يؤثر ذلك على جودة الصورة النهائية المحفوظة."
+  },
+  "Converting recording to GIF...": {
+    "Converting recording to GIF...": "جاري تحويل التسجيل إلى GIF..."
+  },
+  "Copied": {
+    "Copied": "تم النسخ"
+  },
+  "Copied & saved": {
+    "Copied & saved": "تم النسخ والحفظ"
+  },
+  "Copied Anonymously": {
+    "Copied Anonymously": "تم النسخ بشكل مجهول"
+  },
+  "Copied to clipboard": {
+    "Copied to clipboard": "تم النسخ إلى الحافظة"
+  },
+  "Copied:": {
+    "Copied:": "تم النسخ:"
+  },
+  "Copy": {
+    "Copy": "نسخ"
+  },
+  "Copy & Save": {
+    "Copy & Save": "نسخ وحفظ"
+  },
+  "Copy (Ctrl+C) | Anonymous Copy (Ctrl+Shift+C)": {
+    "Copy (Ctrl+C) | Anonymous Copy (Ctrl+Shift+C)": "نسخ (Ctrl+C) | نسخ مجهول (Ctrl+Shift+C)"
+  },
+  "Copy Color": {
+    "Copy Color": "نسخ اللون"
+  },
+  "Copy Current Palette": {
+    "Copy Current Palette": "نسخ اللوحة الحالية"
+  },
+  "Copy and customize this preset": {
+    "Copy and customize this preset": "نسخ وتخصيص هذا الإعداد المسبق"
+  },
+  "Copy vector / Paste / Duplicate": {
+    "Copy vector / Paste / Duplicate": "نسخ المتجه / لصق / تكرار"
+  },
+  "Crop / Resize": {
+    "Crop / Resize": "قص / تغيير الحجم"
+  },
+  "Crop / Resize Area": {
+    "Crop / Resize Area": "منطقة القص / تغيير الحجم"
+  },
+  "Custom": {
+    "Custom": "خيار مخصص"
+  },
+  "Custom Colors": {
+    "Custom Colors": "ألوان مخصصة"
+  },
+  "Custom Tool": {
+    "Custom Tool": "أداة مخصصة"
+  },
+  "Dank Violet": {
+    "Dank Violet": "Dank Violet"
+  },
+  "Dark": {
+    "Dark": "داكن"
+  },
+  "Darken the image to improve foreground contrast": {
+    "Darken the image to improve foreground contrast": "تغميق الصورة لتحسين تباين المقدمة"
+  },
+  "Dashed Line": {
+    "Dashed Line": "خط متقطع"
+  },
+  "Default Alignment": {
+    "Default Alignment": "المحاذاة الافتراضية"
+  },
+  "Default Aspect Ratio": {
+    "Default Aspect Ratio": "نسبة العرض إلى الارتفاع الافتراضية"
+  },
+  "Default Background Image": {
+    "Default Background Image": "صورة الخلفية الافتراضية"
+  },
+  "Default Background Mode": {
+    "Default Background Mode": "وضع الخلفية الافتراضي"
+  },
+  "Default Bold Text": {
+    "Default Bold Text": "نص عريض افتراضي"
+  },
+  "Default Corner Radius": {
+    "Default Corner Radius": "نصف قطر الزاوية الافتراضي"
+  },
+  "Default Gradient Angle": {
+    "Default Gradient Angle": "زاوية التدرج الافتراضية"
+  },
+  "Default Gradient End": {
+    "Default Gradient End": "نهاية التدرج الافتراضية"
+  },
+  "Default Gradient Start": {
+    "Default Gradient Start": "بداية التدرج الافتراضية"
+  },
+  "Default Italic Text": {
+    "Default Italic Text": "نص مائل افتراضي"
+  },
+  "Default Microphone": {
+    "Default Microphone": "الميكروفون الافتراضي"
+  },
+  "Default Output": {
+    "Default Output": "المخرج الافتراضي"
+  },
+  "Default Padding": {
+    "Default Padding": "الهامش الافتراضي"
+  },
+  "Default Shadow Strength": {
+    "Default Shadow Strength": "قوة الظل الافتراضية"
+  },
+  "Default Solid Color": {
+    "Default Solid Color": "لون صلب افتراضي"
+  },
+  "Default Text Background": {
+    "Default Text Background": "خلفية النص الافتراضية"
+  },
+  "Default Text Font Size": {
+    "Default Text Font Size": "حجم خط النص الافتراضي"
+  },
+  "Default Underline Text": {
+    "Default Underline Text": "نص مسطر افتراضي"
+  },
+  "Default Watermark": {
+    "Default Watermark": "العلامة المائية الافتراضية"
+  },
+  "Delete": {
+    "Delete": "حذف"
+  },
+  "Dim Background Image": {
+    "Dim Background Image": "تعتيم صورة الخلفية"
+  },
+  "Dim Intensity": {
+    "Dim Intensity": "شدة التعتيم"
+  },
+  "Dimming Opacity": {
+    "Dimming Opacity": "عتامة التعتيم"
+  },
+  "Direct": {
+    "Direct": "مباشر"
+  },
+  "Discard & Close": {
+    "Discard & Close": "تجاهل وإغلاق"
+  },
+  "Discard & Close (Esc)": {
+    "Discard & Close (Esc)": "تجاهل وإغلاق (Esc)"
+  },
+  "Done": {
+    "Done": "تم"
+  },
+  "Done (Action based on settings)": {
+    "Done (Action based on settings)": "تم (إجراء يعتمد على الإعدادات)"
+  },
+  "Dotted Line": {
+    "Dotted Line": "خط منقط"
+  },
+  "Dracula": {
+    "Dracula": "Dracula"
+  },
+  "Drag Image": {
+    "Drag Image": "سحب الصورة"
+  },
+  "Draw an outer ring using the stamp number color": {
+    "Draw an outer ring using the stamp number color": "ارسم حلقة خارجية باستخدام لون رقم الطابع"
+  },
+  "Drop image onto bar icon to annotate it": {
+    "Drop image onto bar icon to annotate it": "أفلت الصورة على أيقونة الشريط للتعليق عليها"
+  },
+  "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": {
+    "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": "يقبل كل أمر إجراء: <b>edit</b> (فتح المحرر) أو <b>float</b> (نافذة تبقى في المقدمة دائماً)."
+  },
+  "Edge Spacing": {
+    "Edge Spacing": "تباعد الحواف"
+  },
+  "Edit": {
+    "Edit": "تعديل"
+  },
+  "Edit Color Palette": {
+    "Edit Color Palette": "تعديل لوحة الألوان"
+  },
+  "Edit Image from Clipboard": {
+    "Edit Image from Clipboard": ""
+  },
+  "Edit Text Note": {
+    "Edit Text Note": "تعديل ملاحظة نصية"
+  },
+  "Editor": {
+    "Editor": "المحرر"
+  },
+  "Editor Aspect Ratio": {
+    "Editor Aspect Ratio": "نسبة عرض المحرر"
+  },
+  "Editor Display Mode": {
+    "Editor Display Mode": "وضع عرض المحرر"
+  },
+  "Editor Display Screen": {
+    "Editor Display Screen": "شاشة عرض المحرر"
+  },
+  "Editor Preview Quality": {
+    "Editor Preview Quality": "جودة معاينة المحرر"
+  },
+  "Ellipse": {
+    "Ellipse": "شكل بيضاوي"
+  },
+  "Ellipse / Circle": {
+    "Ellipse / Circle": "شكل بيضاوي / دائرة"
+  },
+  "Ellipse / Circle (Q)": {
+    "Ellipse / Circle (Q)": "شكل بيضاوي / دائرة (Q)"
+  },
+  "Ellipse Color": {
+    "Ellipse Color": "لون الشكل البيضاوي"
+  },
+  "Ellipse Thickness": {
+    "Ellipse Thickness": "سُمك الشكل البيضاوي"
+  },
+  "Ellipse, Text, Pixelate, Redact (Q, W, E, R)": {
+    "Ellipse, Text, Pixelate, Redact (Q, W, E, R)": "شكل بيضاوي، نص، بكسلة، حجب (Q, W, E, R)"
+  },
+  "Enable background automatically when opening the editor": {
+    "Enable background automatically when opening the editor": "تمكين الخلفية تلقائياً عند فتح المحرر"
+  },
+  "Eraser": {
+    "Eraser": "الممحاة"
+  },
+  "Everforest": {
+    "Everforest": "Everforest"
+  },
+  "Failed to convert recording to GIF.": {
+    "Failed to convert recording to GIF.": "فشل تحويل التسجيل إلى GIF."
+  },
+  "Failed to copy screenshot to clipboard.": {
+    "Failed to copy screenshot to clipboard.": "فشل نسخ لقطة الشاشة إلى الحافظة."
+  },
+  "Failed to generate blurred background image": {
+    "Failed to generate blurred background image": "فشل توليد صورة الخلفية الضبابية"
+  },
+  "Failed to save screenshot": {
+    "Failed to save screenshot": "فشل حفظ لقطة الشاشة"
+  },
+  "Failed to save screenshot file.": {
+    "Failed to save screenshot file.": "فشل حفظ ملف لقطة الشاشة."
+  },
+  "Flip Horiz": {
+    "Flip Horiz": "انعكاس أفقي"
+  },
+  "Flip Vert": {
+    "Flip Vert": "انعكاس عمودي"
+  },
+  "Float": {
+    "Float": "عائم"
+  },
+  "Float Image": {
+    "Float Image": "صورة عائمة"
+  },
+  "Float Window": {
+    "Float Window": "نافذة عائمة"
+  },
+  "Floating": {
+    "Floating": "عائم"
+  },
+  "Focused Screen": {
+    "Focused Screen": "الشاشة المركزة"
+  },
+  "Focused Window": {
+    "Focused Window": "النافذة النشطة"
+  },
+  "Font Size": {
+    "Font Size": "حجم الخط"
+  },
+  "Font family used for number stamp labels": {
+    "Font family used for number stamp labels": "عائلة الخط المستخدمة لملصقات أرقام الطوابع"
+  },
+  "Force Copy & Save": {
+    "Force Copy & Save": "فرض النسخ والحفظ"
+  },
+  "Force Copy to Clipboard": {
+    "Force Copy to Clipboard": "فرض النسخ إلى الحافظة"
+  },
+  "Force Save to File": {
+    "Force Save to File": "فرض الحفظ إلى ملف"
+  },
+  "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
+    "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": "رموز التنسيق: %Y (السنة)، %y (السنة برقمين)، %m (الشهر)، %d (اليوم)، %H (الساعة)، %M (الدقيقة)، %S (الثانية)، {zzz} (جزء من الثانية)"
+  },
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": "رموز التنسيق: {user} (اسم المستخدم)، \\n (سطر جديد)، %Y (السنة)، %y (السنة برقمين)، %m (الشهر)، %d (اليوم)، %H (الساعة)، %M (الدقيقة)، %S (الثانية)"
+  },
+  "Framerate": {
+    "Framerate": "معدل الإطارات"
+  },
+  "Free": {
+    "Free": "حر"
+  },
+  "Freehand Pen": {
+    "Freehand Pen": "قلم رسم حر"
+  },
+  "Freehand Pen (1)": {
+    "Freehand Pen (1)": "قلم رسم حر (1)"
+  },
+  "From Clipboard": {
+    "From Clipboard": "من الحافظة"
+  },
+  "From File": {
+    "From File": "من ملف"
+  },
+  "Full Screen": {
+    "Full Screen": "ملء الشاشة"
+  },
+  "Full Screen Target": {
+    "Full Screen Target": "هدف ملء الشاشة"
+  },
+  "GIF Framerate": {
+    "GIF Framerate": "معدل إطارات GIF"
+  },
+  "General Shortcuts": {
+    "General Shortcuts": "اختصارات عامة"
+  },
+  "Gruvbox Material": {
+    "Gruvbox Material": "Gruvbox Material"
+  },
+  "Help": {
+    "Help": "مساعدة"
+  },
+  "Hide Control Center": {
+    "Hide Control Center": "إخفاء مركز التحكم"
+  },
+  "Hide Control Center by Default": {
+    "Hide Control Center by Default": "إخفاء مركز التحكم افتراضياً"
+  },
+  "High": {
+    "High": "عالي"
+  },
+  "Highlighter": {
+    "Highlighter": "أداة التمييز"
+  },
+  "Highlighter (S)": {
+    "Highlighter (S)": "أداة التمييز (S)"
+  },
+  "Highlighter Color": {
+    "Highlighter Color": "لون أداة التمييز"
+  },
+  "Highlighter Thickness": {
+    "Highlighter Thickness": "سُمك أداة التمييز"
+  },
+  "History": {
+    "History": "السجل"
+  },
+  "Hover Trigger Delay": {
+    "Hover Trigger Delay": "تأخير تفعيل التحويم"
+  },
+  "IPC Commands": {
+    "IPC Commands": "أوامر IPC"
+  },
+  "Image": {
+    "Image": "صورة"
+  },
+  "Image + Text": {
+    "Image + Text": "صورة + نص"
+  },
+  "Image Background": {
+    "Image Background": "خلفية الصورة"
+  },
+  "Image Error": {
+    "Image Error": "خطأ في الصورة"
+  },
+  "Image Size": {
+    "Image Size": "حجم الصورة"
+  },
+  "Image copied to clipboard": {
+    "Image copied to clipboard": "تم نسخ الصورة إلى الحافظة"
+  },
+  "Image selected automatically when using Image Background mode": {
+    "Image selected automatically when using Image Background mode": "يتم اختيار الصورة تلقائياً عند استخدام وضع خلفية الصورة"
+  },
+  "Include Cursor": {
+    "Include Cursor": "تضمين المؤشر"
+  },
+  "Initial Width": {
+    "Initial Width": "العرض الأولي"
+  },
+  "Initial state for the Control Center toggle.": {
+    "Initial state for the Control Center toggle.": "الحالة الأولية لتبديل مركز التحكم."
+  },
+  "Input Mode": {
+    "Input Mode": "وضع الإدخال"
+  },
+  "Insert Image": {
+    "Insert Image": "إدراج صورة"
+  },
+  "Interaction / Result": {
+    "Interaction / Result": "التفاعل / النتيجة"
+  },
+  "Interactive Region": {
+    "Interactive Region": "المنطقة التفاعلية"
+  },
+  "JPEG Quality": {
+    "JPEG Quality": "جودة JPEG"
+  },
+  "Kanagawa": {
+    "Kanagawa": "Kanagawa"
+  },
+  "Key": {
+    "Key": "مفتاح"
+  },
+  "Landscape": {
+    "Landscape": "أفقي (عرضي)"
+  },
+  "Last Reg": {
+    "Last Reg": "آخر منطقة"
+  },
+  "Last Region": {
+    "Last Region": "آخر منطقة"
+  },
+  "Last Selected Region": {
+    "Last Selected Region": "آخر منطقة محددة"
+  },
+  "Left": {
+    "Left": "اليسار"
+  },
+  "Left Click": {
+    "Left Click": "النقر الأيسر"
+  },
+  "Light": {
+    "Light": "خفيف"
+  },
+  "Line Color": {
+    "Line Color": "لون الخط"
+  },
+  "Line Thickness": {
+    "Line Thickness": "سُمك الخط"
+  },
+  "Linear Gradient": {
+    "Linear Gradient": "تدرج خطي"
+  },
+  "Live Preview": {
+    "Live Preview": "معاينة مباشرة"
+  },
+  "Loading contributors...": {
+    "Loading contributors...": "جاري تحميل المساهمين..."
+  },
+  "Low": {
+    "Low": "منخفض"
+  },
+  "Magnifier Loupe": {
+    "Magnifier Loupe": "عدسة مكبرة"
+  },
+  "Max Height (0 = no limit)": {
+    "Max Height (0 = no limit)": "الحد الأقصى للارتفاع (0 = بلا حد)"
+  },
+  "Medium": {
+    "Medium": "متوسط"
+  },
+  "Menu Item Right Click": {
+    "Menu Item Right Click": "النقر بزر الفأرة الأيمن على عنصر القائمة"
+  },
+  "Merging audio tracks...": {
+    "Merging audio tracks...": "جاري دمج المسارات الصوتية..."
+  },
+  "Microphone Device": {
+    "Microphone Device": "جهاز الميكروفون"
+  },
+  "Middle Click": {
+    "Middle Click": "النقر بزر الفأرة الأوسط"
+  },
+  "Middle Click Action": {
+    "Middle Click Action": "إجراء النقر بزر الفأرة الأوسط"
+  },
+  "Minimize Delay": {
+    "Minimize Delay": "تقليل التأخير"
+  },
+  "Modal": {
+    "Modal": "مشروط (Modal)"
+  },
+  "More Tools": {
+    "More Tools": "المزيد من الأدوات"
+  },
+  "Niri Binding Example": {
+    "Niri Binding Example": "مثال ربط Niri"
+  },
+  "No Background": {
+    "No Background": "إخفاء خلفية الشريط"
+  },
+  "No Image Specified": {
+    "No Image Specified": "لم يتم تحديد صورة"
+  },
+  "No output available": {
+    "No output available": "لا يوجد مخرج متاح"
+  },
+  "No saved images yet": {
+    "No saved images yet": "لا توجد صور محفوظة بعد"
+  },
+  "No supported images found": {
+    "No supported images found": "لم يتم العثور على صور مدعومة"
+  },
+  "None": {
+    "None": "لا شيء"
+  },
+  "None / Disabled": {
+    "None / Disabled": "لا شيء / معطل"
+  },
+  "Nord": {
+    "Nord": "نورد (Nord)"
+  },
+  "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": {
+    "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": "ملاحظة: يؤدي بدء وضع الأداة إلى تجاوز إعدادات سمك الأداة واللون الافتراضية إذا كانت الأداة الأولية تطابقها."
+  },
+  "Notification": {
+    "Notification": "إشعار"
+  },
+  "Notifications": {
+    "Notifications": "الإشعارات"
+  },
+  "Number Stamp": {
+    "Number Stamp": "ختم رقمي"
+  },
+  "OCR": {
+    "OCR": "التعرف الضوئي على الحروف (OCR)"
+  },
+  "OCR Result": {
+    "OCR Result": "نتيجة التعرف الضوئي على الحروف"
+  },
+  "OCR Text Recognition": {
+    "OCR Text Recognition": "التعرف على نصوص OCR"
+  },
+  "Opacity": {
+    "Opacity": "الشفافية"
+  },
+  "Open": {
+    "Open": "فتح"
+  },
+  "Open Folder": {
+    "Open Folder": "فتح المجلد"
+  },
+  "Open Quick Capture menu (Popout)": {
+    "Open Quick Capture menu (Popout)": "فتح قائمة الالتقاط السريع (منبثقة)"
+  },
+  "Open Specific Image Path": {
+    "Open Specific Image Path": ""
+  },
+  "Outline Variant": {
+    "Outline Variant": "تباين المخطط التفصيلي"
+  },
+  "Output Format": {
+    "Output Format": "تنسيق الإخراج"
+  },
+  "Output format applies only to disk saves. Clipboard copies are always PNG.": {
+    "Output format applies only to disk saves. Clipboard copies are always PNG.": "ينطبق تنسيق الإخراج على الحفظ على القرص فقط. نسخ الحافظة تكون دائماً بتنسيق PNG."
+  },
+  "Outputs": {
+    "Outputs": "المخرجات"
+  },
+  "Overlay Opacity": {
+    "Overlay Opacity": "عتامة التراكب"
+  },
+  "PAUSED": {
+    "PAUSED": "مُتوقف مؤقتاً"
+  },
+  "PRIMARY": {
+    "PRIMARY": "أساسي"
+  },
+  "Palette Preset": {
+    "Palette Preset": "إعدادات اللوحة المسبقة"
+  },
+  "Pause": {
+    "Pause": "إيقاف مؤقت"
+  },
+  "Pause / Resume": {
+    "Pause / Resume": ""
+  },
+  "Pen Auto-Close": {
+    "Pen Auto-Close": "إغلاق القلم تلقائياً"
+  },
+  "Pen Color": {
+    "Pen Color": "لون القلم"
+  },
+  "Pen Thickness": {
+    "Pen Thickness": "سُمك القلم"
+  },
+  "Pen, Line, Arrow, Rect": {
+    "Pen, Line, Arrow, Rect": "قلم، خط، سهم، مستطيل"
+  },
+  "Pick Color": {
+    "Pick Color": "اختيار اللون"
+  },
+  "Pick a palette preset or customize individual color slots.": {
+    "Pick a palette preset or customize individual color slots.": "اختر إعداداً مسبقاً للوحة أو قم بتخصيص فتحات الألوان الفردية."
+  },
+  "Pixel Intensity": {
+    "Pixel Intensity": "كثافة البكسل"
+  },
+  "Pixelate": {
+    "Pixelate": "بكسلة"
+  },
+  "Pixelate (E)": {
+    "Pixelate (E)": "تنميط (Pixelate) (E)"
+  },
+  "Pixelate Intensity": {
+    "Pixelate Intensity": "كثافة التنميط"
+  },
+  "Popup Input": {
+    "Popup Input": "إدخال منبثق"
+  },
+  "Portrait": {
+    "Portrait": "عمودي"
+  },
+  "Position": {
+    "Position": "الموقع"
+  },
+  "Post-Capture Notification": {
+    "Post-Capture Notification": "إشعار ما بعد الالتقاط"
+  },
+  "Preset %1": {
+    "Preset %1": "إعداد مسبق %1"
+  },
+  "Preset 1": {
+    "Preset 1": "إعداد مسبق 1"
+  },
+  "Preset 2": {
+    "Preset 2": "إعداد مسبق 2"
+  },
+  "Preset 3": {
+    "Preset 3": "إعداد مسبق 3"
+  },
+  "Preset 4": {
+    "Preset 4": "إعداد مسبق 4"
+  },
+  "Preset 5": {
+    "Preset 5": "إعداد مسبق 5"
+  },
+  "Preset 6": {
+    "Preset 6": "إعداد مسبق 6"
+  },
+  "Preset 7": {
+    "Preset 7": "إعداد مسبق 7"
+  },
+  "Preset 8": {
+    "Preset 8": "إعداد مسبق 8"
+  },
+  "Preset Color": {
+    "Preset Color": "لون الإعداد المسبق"
+  },
+  "Preset Thickness": {
+    "Preset Thickness": "سُمك الإعداد المسبق"
+  },
+  "Preset Tool": {
+    "Preset Tool": "أداة الإعداد المسبق"
+  },
+  "Preview": {
+    "Preview": "معاينة"
+  },
+  "Primary": {
+    "Primary": "رئيسي"
+  },
+  "Primary Screen": {
+    "Primary Screen": "الشاشة الأساسية"
+  },
+  "QR Result": {
+    "QR Result": "نتيجة رمز الاستجابة السريعة (QR)"
+  },
+  "Quick Capture": {
+    "Quick Capture": "التقاط سريع"
+  },
+  "Quick Capture Error": {
+    "Quick Capture Error": "خطأ في الالتقاط السريع"
+  },
+  "RECORDING": {
+    "RECORDING": "جاري التسجيل"
+  },
+  "Radial Gradient": {
+    "Radial Gradient": "تدرج شعاعي"
+  },
+  "Radial Menu": {
+    "Radial Menu": "قائمة شعاعية"
+  },
+  "Radial Menu Opacity": {
+    "Radial Menu Opacity": "عتامة القائمة الشعاعية"
+  },
+  "Radial Menu Settings": {
+    "Radial Menu Settings": "إعدادات القائمة الشعاعية"
+  },
+  "Radial Preset": {
+    "Radial Preset": "إعداد شعاعي مسبق"
+  },
+  "Ratio": {
+    "Ratio": "نسبة"
+  },
+  "Ready": {
+    "Ready": "مستعد"
+  },
+  "Recent Edits": {
+    "Recent Edits": "التعديلات الأخيرة"
+  },
+  "Record Microphone": {
+    "Record Microphone": "تسجيل الميكروفون"
+  },
+  "Record Mouse Cursor": {
+    "Record Mouse Cursor": "تسجيل مؤشر الفأرة"
+  },
+  "Record System Audio": {
+    "Record System Audio": "تسجيل صوت النظام"
+  },
+  "Recording": {
+    "Recording": "تسجيل"
+  },
+  "Recording Folder": {
+    "Recording Folder": "مجلد التسجيل"
+  },
+  "Recording ended with error code %1.": {
+    "Recording ended with error code %1.": "انتهى التسجيل برمز خطأ %1."
+  },
+  "Recording...": {
+    "Recording...": "جارٍ التسجيل..."
+  },
+  "Recordings Directory": {
+    "Recordings Directory": "دليل التسجيلات"
+  },
+  "Rectangle": {
+    "Rectangle": "مستطيل"
+  },
+  "Rectangle Color": {
+    "Rectangle Color": "لون المستطيل"
+  },
+  "Rectangle Outline": {
+    "Rectangle Outline": "مخطط المستطيل"
+  },
+  "Rectangle Outline (4)": {
+    "Rectangle Outline (4)": "مخطط المستطيل (4)"
+  },
+  "Rectangle Thickness": {
+    "Rectangle Thickness": "سُمك المستطيل"
+  },
+  "Redact": {
+    "Redact": "تنقيح"
+  },
+  "Redact (R)": {
+    "Redact (R)": "تنقيح (R)"
+  },
+  "Redact Thickness": {
+    "Redact Thickness": "سُمك التنقيح"
+  },
+  "Redo (Ctrl+Y / Ctrl+Shift+Z)": {
+    "Redo (Ctrl+Y / Ctrl+Shift+Z)": "إعادة (Ctrl+Y / Ctrl+Shift+Z)"
+  },
+  "Redo last undone stroke": {
+    "Redo last undone stroke": "إعادة آخر إجراء تم التراجع عنه"
+  },
+  "Refresh": {
+    "Refresh": "إعادة تحميل"
+  },
+  "Region": {
+    "Region": "منطقة"
+  },
+  "Reset": {
+    "Reset": "إعادة تعيين"
+  },
+  "Reset Last Region": {
+    "Reset Last Region": "إعادة ضبط آخر منطقة"
+  },
+  "Resume": {
+    "Resume": "استئناف"
+  },
+  "Right": {
+    "Right": "يمين"
+  },
+  "Right Click": {
+    "Right Click": "نقرة يمين"
+  },
+  "Right Click Action": {
+    "Right Click Action": "إجراء النقر بالزر الأيمن"
+  },
+  "Rosé Pine": {
+    "Rosé Pine": "روز باين"
+  },
+  "Rotate L": {
+    "Rotate L": "تدوير لليسار"
+  },
+  "Rotate R": {
+    "Rotate R": "تدوير لليمين"
+  },
+  "Round Highlighter Tips": {
+    "Round Highlighter Tips": "رؤوس تمييز مستديرة"
+  },
+  "Round Rectangle Corners": {
+    "Round Rectangle Corners": "زوايا مستطيل مستديرة"
+  },
+  "Rounded Rectangle": {
+    "Rounded Rectangle": "مستطيل مستدير الزوايا"
+  },
+  "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
+    "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": "حفظ (Ctrl+S) | حفظ باسم (Ctrl+Shift+S)"
+  },
+  "Save Directory": {
+    "Save Directory": "دليل الحفظ"
+  },
+  "Save Filename Pattern": {
+    "Save Filename Pattern": "نمط اسم ملف الحفظ"
+  },
+  "Save Screenshot As": {
+    "Save Screenshot As": "حفظ لقطة الشاشة باسم"
+  },
+  "Saved %1 (%2)": {
+    "Saved %1 (%2)": "تم الحفظ %1 (%2)"
+  },
+  "Saving": {
+    "Saving": "جارٍ الحفظ"
+  },
+  "Scale Editor to Screenshot Size": {
+    "Scale Editor to Screenshot Size": "ملاءمة المحرر لحجم لقطة الشاشة"
+  },
+  "Scan QR": {
+    "Scan QR": "مسح رمز الاستجابة السريعة"
+  },
+  "Screen": {
+    "Screen": "شاشة"
+  },
+  "Screen Recorder": {
+    "Screen Recorder": "مسجل الشاشة"
+  },
+  "Screen Recording (%1)": {
+    "Screen Recording (%1)": ""
+  },
+  "Screen Recording Error": {
+    "Screen Recording Error": "خطأ في تسجيل الشاشة"
+  },
+  "Screen Recording Saved": {
+    "Screen Recording Saved": "تم حفظ تسجيل الشاشة"
+  },
+  "Screen recording timed out or was cancelled.": {
+    "Screen recording timed out or was cancelled.": "انتهت مهلة تسجيل الشاشة أو تم إلغاؤه."
+  },
+  "Screen: %1 (%2x%3)": {
+    "Screen: %1 (%2x%3)": "الشاشة: %1 (%2x%3)"
+  },
+  "Screenshot (%1) — %2": {
+    "Screenshot (%1) — %2": ""
+  },
+  "Screenshot Copied": {
+    "Screenshot Copied": "تم نسخ لقطة الشاشة"
+  },
+  "Screenshot Folder": {
+    "Screenshot Folder": "مجلد لقطات الشاشة"
+  },
+  "Screenshot Saved": {
+    "Screenshot Saved": "تم حفظ لقطة الشاشة"
+  },
+  "Screenshot copied anonymously with randomized name and stripped metadata.": {
+    "Screenshot copied anonymously with randomized name and stripped metadata.": "تم نسخ لقطة الشاشة بشكل مجهول مع اسم عشوائي وإزالة البيانات الوصفية."
+  },
+  "Screenshot copied to clipboard and saved to %1": {
+    "Screenshot copied to clipboard and saved to %1": "تم نسخ لقطة الشاشة إلى الحافظة وحفظها في %1"
+  },
+  "Screenshot copied to clipboard but failed to save file: %1": {
+    "Screenshot copied to clipboard but failed to save file: %1": "تم نسخ لقطة الشاشة إلى الحافظة ولكن فشل حفظ الملف: %1"
+  },
+  "Screenshot copied to clipboard.": {
+    "Screenshot copied to clipboard.": "تم نسخ لقطة الشاشة إلى الحافظة."
+  },
+  "Screenshot copied with randomized name.": {
+    "Screenshot copied with randomized name.": "تم نسخ لقطة الشاشة باسم عشوائي."
+  },
+  "Screenshot failed (mode: %1).": {
+    "Screenshot failed (mode: %1).": "فشلت لقطة الشاشة (الوضع: %1)."
+  },
+  "Screenshot saved": {
+    "Screenshot saved": "تم حفظ لقطة الشاشة"
+  },
+  "Screenshot saved to %1": {
+    "Screenshot saved to %1": "تم حفظ لقطة الشاشة في %1"
+  },
+  "Screenshot saved to %1/%2": {
+    "Screenshot saved to %1/%2": "تم حفظ لقطة الشاشة في %1/%2"
+  },
+  "Scroll": {
+    "Scroll": "تمرير"
+  },
+  "Scroll Interval": {
+    "Scroll Interval": "فاصل التمرير"
+  },
+  "Scroll capture: select a region, scroll content, then press Enter to finish.": {
+    "Scroll capture: select a region, scroll content, then press Enter to finish.": "التقاط التمرير: حدد منطقة، وقم بتمرير المحتوى، ثم اضغط Enter للإنهاء."
+  },
+  "Scrolling": {
+    "Scrolling": "شريطي"
+  },
+  "Scrolling Capture": {
+    "Scrolling Capture": "التقاط التمرير"
+  },
+  "Select": {
+    "Select": "تحديد"
+  },
+  "Select / Move stroke": {
+    "Select / Move stroke": "تحديد / تحريك الخط"
+  },
+  "Select Color Slots 1 - 4": {
+    "Select Color Slots 1 - 4": "تحديد خانات الألوان 1 - 4"
+  },
+  "Select Color Slots 5 - 8 (Q, W, E, R)": {
+    "Select Color Slots 5 - 8 (Q, W, E, R)": "تحديد خانات الألوان 5 - 8 (Q, W, E, R)"
+  },
+  "Select Directory": {
+    "Select Directory": "تحديد المجلد"
+  },
+  "Select Image File": {
+    "Select Image File": ""
+  },
+  "Select Image to Annotate": {
+    "Select Image to Annotate": "تحديد صورة للتعليق عليها"
+  },
+  "Selected Tool / Action": {
+    "Selected Tool / Action": "الأداة / الإجراء المحدد"
+  },
+  "Settings": {
+    "Settings": "الإعدادات"
+  },
+  "Shapes": {
+    "Shapes": "الأشكال"
+  },
+  "Shortcut Action": {
+    "Shortcut Action": "إجراء الاختصار"
+  },
+  "Shortcuts": {
+    "Shortcuts": "اختصارات"
+  },
+  "Show Control Center": {
+    "Show Control Center": "إظهار مركز التحكم"
+  },
+  "Show Keyboard Shortcut Hints": {
+    "Show Keyboard Shortcut Hints": "إظهار تلميحات اختصارات لوحة المفاتيح"
+  },
+  "Show Pill Border": {
+    "Show Pill Border": "إظهار حدود الحبة"
+  },
+  "Show Recent Edits History": {
+    "Show Recent Edits History": "إظهار سجل التعديلات الأخيرة"
+  },
+  "Show Region Border": {
+    "Show Region Border": "إظهار حدود المنطقة"
+  },
+  "Show Screenshot Border": {
+    "Show Screenshot Border": "إظهار حدود لقطة الشاشة"
+  },
+  "Show Toolbar": {
+    "Show Toolbar": "إظهار شريط الأدوات"
+  },
+  "Show Toolbar Border": {
+    "Show Toolbar Border": "إظهار حدود شريط الأدوات"
+  },
+  "Show only the image on a transparent background": {
+    "Show only the image on a transparent background": "إظهار الصورة فقط على خلفية شفافة"
+  },
+  "Skip Confirmation": {
+    "Skip Confirmation": "تخطي التأكيد"
+  },
+  "Slot 1": {
+    "Slot 1": "الخانة 1"
+  },
+  "Slot 2": {
+    "Slot 2": "الخانة 2"
+  },
+  "Slot 3": {
+    "Slot 3": "الخانة 3"
+  },
+  "Slot 4": {
+    "Slot 4": "الخانة 4"
+  },
+  "Slot 5": {
+    "Slot 5": "الخانة 5"
+  },
+  "Slot 6": {
+    "Slot 6": "الخانة 6"
+  },
+  "Slot 7": {
+    "Slot 7": "الخانة 7"
+  },
+  "Slot 8": {
+    "Slot 8": "الخانة 8"
+  },
+  "Soften image details so screenshot content stands out": {
+    "Soften image details so screenshot content stands out": "تنعيم تفاصيل الصورة ليبرز محتوى لقطة الشاشة"
+  },
+  "Solid Color": {
+    "Solid Color": "لون مصمت"
+  },
+  "Solid Fill": {
+    "Solid Fill": "تعبئة مصمتة"
+  },
+  "Solid Line": {
+    "Solid Line": "خط مستقيم"
+  },
+  "Spawn Position": {
+    "Spawn Position": "موقع الظهور"
+  },
+  "Specific Output": {
+    "Specific Output": "مخرج محدد"
+  },
+  "Spotlight": {
+    "Spotlight": "Spotlight"
+  },
+  "Spotlight (D)": {
+    "Spotlight (D)": "تسليط الضوء (Spotlight) (D)"
+  },
+  "Spotlight Opacity": {
+    "Spotlight Opacity": "عتامة تسليط الضوء"
+  },
+  "Stamp (A)": {
+    "Stamp (A)": "الختم (Stamp) (A)"
+  },
+  "Stamp Color": {
+    "Stamp Color": "لون الختم"
+  },
+  "Stamp Contrast Ring": {
+    "Stamp Contrast Ring": "حلقة تباين الختم"
+  },
+  "Stamp Number Font": {
+    "Stamp Number Font": "خط رقم الختم"
+  },
+  "Stamp Size": {
+    "Stamp Size": "حجم الختم"
+  },
+  "Stamp, Highlighter, Spotlight (A, S, D)": {
+    "Stamp, Highlighter, Spotlight (A, S, D)": "الختم، قلم التمييز، تسليط الضوء (A, S, D)"
+  },
+  "Starting Preset": {
+    "Starting Preset": "الإعداد المسبق للبدء"
+  },
+  "Starting Tool": {
+    "Starting Tool": "أداة البدء"
+  },
+  "Starting Tool Mode": {
+    "Starting Tool Mode": "وضع أداة البدء"
+  },
+  "Stop & Save": {
+    "Stop & Save": "إيقاف وحفظ"
+  },
+  "Straight Line": {
+    "Straight Line": "خط مستقيم"
+  },
+  "Straight Line (2)": {
+    "Straight Line (2)": "خط مستقيم (2)"
+  },
+  "Surface Container Highest": {
+    "Surface Container Highest": "حاوية السطح الأعلى"
+  },
+  "Switch to Select Tool": {
+    "Switch to Select Tool": "التبديل إلى أداة التحديد"
+  },
+  "Switch to your custom preset": {
+    "Switch to your custom preset": "التبديل إلى إعدادك المسبق المخصص"
+  },
+  "Synthwave Electric": {
+    "Synthwave Electric": "Synthwave Electric"
+  },
+  "System Audio Device": {
+    "System Audio Device": "جهاز صوت النظام"
+  },
+  "System Default": {
+    "System Default": "افتراضي النظام"
+  },
+  "Target Output Name": {
+    "Target Output Name": "اسم المخرج المستهدف"
+  },
+  "Text": {
+    "Text": "نص"
+  },
+  "Text (W)": {
+    "Text (W)": "النص (W)"
+  },
+  "Text Background Roundness": {
+    "Text Background Roundness": "استدارة خلفية النص"
+  },
+  "Text Color": {
+    "Text Color": "لون النص"
+  },
+  "Text Font": {
+    "Text Font": "خط النص"
+  },
+  "Text Note": {
+    "Text Note": "ملاحظة نصية"
+  },
+  "Text Size": {
+    "Text Size": "حجم النص"
+  },
+  "Theme Primary Color": {
+    "Theme Primary Color": "اللون الأساسي للسمة"
+  },
+  "Thickness": {
+    "Thickness": "السُمك"
+  },
+  "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
+    "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": "إعداد اللوحة المسبق هذا للقراءة فقط. اختر أحد الخيارات أدناه للتبديل إلى اللوحة المخصصة وتحرير الألوان:"
+  },
+  "Toast": {
+    "Toast": "تنبيه منبثق"
+  },
+  "Toggle Hide/Show Annotations": {
+    "Toggle Hide/Show Annotations": "تبديل إخفاء/إظهار التعليقات التوضيحية"
+  },
+  "Toggle Start / Stop": {
+    "Toggle Start / Stop": ""
+  },
+  "Toggle between 2 latest presets": {
+    "Toggle between 2 latest presets": "التبديل بين آخر إعدادين مسبقين"
+  },
+  "Tokyo Night": {
+    "Tokyo Night": "Tokyo Night"
+  },
+  "Tool Defaults": {
+    "Tool Defaults": "إعدادات الأداة الافتراضية"
+  },
+  "Toolbar": {
+    "Toolbar": "شريط الأدوات"
+  },
+  "Toolbar Palette": {
+    "Toolbar Palette": "لوحة شريط الأدوات"
+  },
+  "Toolbar Position": {
+    "Toolbar Position": "موقع شريط الأدوات"
+  },
+  "Top": {
+    "Top": "أعلى"
+  },
+  "Top Center": {
+    "Top Center": "أعلى المنتصف"
+  },
+  "Top Left": {
+    "Top Left": "أعلى اليسار"
+  },
+  "Top Right": {
+    "Top Right": "أعلى اليمين"
+  },
+  "Transparent": {
+    "Transparent": "شفاف"
+  },
+  "Transparent Background": {
+    "Transparent Background": "خلفية شفافة"
+  },
+  "Trigger Middle-Click Action (Default: Interactive Region)": {
+    "Trigger Middle-Click Action (Default: Interactive Region)": "تشغيل إجراء النقر الأوسط (الافتراضي: منطقة تفاعلية)"
+  },
+  "Trigger Right-Click Action (Default: Clipboard Annotate)": {
+    "Trigger Right-Click Action (Default: Clipboard Annotate)": "تشغيل إجراء النقر الأيمن (الافتراضي: تعليق الحافظة)"
+  },
+  "Trigger on Hover": {
+    "Trigger on Hover": "التشغيل عند التحويم"
+  },
+  "Type note...": {
+    "Type note...": "اكتب ملاحظة..."
+  },
+  "Undo (Ctrl+Z)": {
+    "Undo (Ctrl+Z)": "تراجع (Ctrl+Z)"
+  },
+  "Undo last stroke": {
+    "Undo last stroke": "تراجع عن آخر ضربة"
+  },
+  "Usage Guide": {
+    "Usage Guide": "دليل الاستخدام"
+  },
+  "Use Existing Custom": {
+    "Use Existing Custom": "استخدم مخصص موجود"
+  },
+  "Use Floating Editor": {
+    "Use Floating Editor": "استخدام المحرر العائم"
+  },
+  "Use Modal Editor": {
+    "Use Modal Editor": "استخدام المحرر النمطي"
+  },
+  "Very High": {
+    "Very High": "عالية جداً"
+  },
+  "Video Codec": {
+    "Video Codec": "ترميز الفيديو"
+  },
+  "Video Quality": {
+    "Video Quality": "جودة الفيديو"
+  },
+  "Video Settings": {
+    "Video Settings": "إعدادات الفيديو"
+  },
+  "Watermark": {
+    "Watermark": "علامة مائية"
+  },
+  "Watermark Image": {
+    "Watermark Image": "صورة العلامة المائية"
+  },
+  "Watermark Text": {
+    "Watermark Text": "نص العلامة المائية"
+  },
+  "Watermark Type": {
+    "Watermark Type": "نوع العلامة المائية"
+  },
+  "WebP Quality": {
+    "WebP Quality": "جودة WebP"
+  },
+  "When enabled, the editor shrinks to match the captured region instead of filling 90% of the screen.": {
+    "When enabled, the editor shrinks to match the captured region instead of filling 90% of the screen.": "عند التفعيل، يتقلص المحرر ليتناسب مع المنطقة الملتقطة بدلاً من ملء 90% من الشاشة."
+  },
+  "Window": {
+    "Window": "نافذة"
+  },
+  "Window / Portal": {
+    "Window / Portal": ""
+  },
+  "Zoom Level": {
+    "Zoom Level": "مستوى التكبير"
+  },
+  "gpu-screen-recorder is not installed. Please install it first.": {
+    "gpu-screen-recorder is not installed. Please install it first.": "gpu-screen-recorder غير مثبت. يرجى تثبيته أولاً."
+  }
+}

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Действие"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": "Адаптивен"
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Добавяне"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Аудиокодек"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "Автоматично"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "Фон"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "Балансирано"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Цвят на рамката"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "Ширина на рамката"
   },
   "Both": {
-    "Both": ""
+    "Both": "И двете"
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Отдолу"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "Долу центрирано"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Долу вляво"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Долу вдясно"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Избор на цвят"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Буфер за обмен"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Затваряне"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Копирано в буфера за обмен"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "Копиране"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Персонализирано"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Изтриване"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Отстояние от ръбовете"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": "Редактиране"
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "Плаващ"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": "Плаващ"
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Фокусиран прозорец"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Размер на шрифта"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Помощ"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": "Високо"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "История"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Изображение"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Изображението е копирано в буфера за обмен"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "Клавиш"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Отляво"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": "Тънък (Light)"
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "Ниско"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Средно"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Няма фон"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Няма"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": "Известие"
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Известия"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Непрозрачност"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Отваряне"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "Пауза"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "Пикселизиране"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Позиция"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "Преглед"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Основен"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": "Готово"
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Опресняване"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Възстановяване"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Продължаване"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Отдясно"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "Превъртане"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Превъртане"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "Избор"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Настройки"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Преки пътища"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "Системни настройки"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "Текст"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "Цвят на текста"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Дебелина"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": "Кратко съобщение"
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Отгоре"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "Горе центрирано"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Горе вляво"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Горе вдясно"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "Много високо"
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/de.json
+++ b/translations/de.json
@@ -135,7 +135,7 @@
     "Border Width": "Randbreite"
   },
   "Both": {
-    "Both": ""
+    "Both": "Beide"
   },
   "Bottom": {
     "Bottom": "Unten"
@@ -163,9 +163,6 @@
   },
   "Callout, Background (Z, B)": {
     "Callout, Background (Z, B)": ""
-  },
-  "Cancel": {
-    "Cancel": ""
   },
   "Capture": {
     "Capture": ""
@@ -244,6 +241,9 @@
   },
   "Container Format": {
     "Container Format": ""
+  },
+  "Contributors": {
+    "Contributors": ""
   },
   "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
     "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": ""
@@ -530,8 +530,8 @@
   "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
     "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": ""
   },
-  "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
-    "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
   },
   "Framerate": {
     "Framerate": ""
@@ -682,6 +682,9 @@
   },
   "Live Preview": {
     "Live Preview": ""
+  },
+  "Loading contributors...": {
+    "Loading contributors...": ""
   },
   "Low": {
     "Low": "Niedrig"
@@ -834,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelieren"
+    "Pixelate": "Verpixeln"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -1031,9 +1034,6 @@
   "Rounded Rectangle": {
     "Rounded Rectangle": ""
   },
-  "Save": {
-    "Save": ""
-  },
   "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
@@ -1144,6 +1144,9 @@
   },
   "Select Color Slots 5 - 8 (Q, W, E, R)": {
     "Select Color Slots 5 - 8 (Q, W, E, R)": ""
+  },
+  "Select Directory": {
+    "Select Directory": ""
   },
   "Select Image File": {
     "Select Image File": ""
@@ -1298,6 +1301,9 @@
   "System Audio Device": {
     "System Audio Device": ""
   },
+  "System Default": {
+    "System Default": "Systemstandard"
+  },
   "Target Output Name": {
     "Target Output Name": ""
   },
@@ -1326,7 +1332,7 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Dicke"
+    "Thickness": "Stärke"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""

--- a/translations/eo.json
+++ b/translations/eo.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Ago"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": ""
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Aldoni"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Sona kodeko"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "Aŭtomata"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "Fono"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "Ekvilibrita"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Bordkoloro"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "Borda larĝo"
   },
   "Both": {
     "Both": ""
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Malsupre"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "Malsupre centre"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Malsupre maldekstre"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Malsupre dekstre"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Elekti koloron"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Tondujo"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Fermi"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Kopiita al tondujo"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "Kopii"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Propra"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Forigi"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Borda interspaco"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": "Redakti"
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "Flosi"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": "glita"
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Fokusita fenestro"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Tipara grando"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Helpo"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": "Alte"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "Historio"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Bildo"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Bildo kopiita al la tondujo"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "Klavo"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Maldekstre"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": "Hela"
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "Malalte"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Meza"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Sen fono"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Neniu"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": ""
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Sciigoj"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Opakeco"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Malfermi"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "Paŭzigi"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "Rastrumigi"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Pozicio"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "Antaŭrigardo"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Ĉefa"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": ""
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Refreŝigi"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Rekomencigi"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Daŭrigi"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Dekstre"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "Ruli"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Rulado"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "Elekti"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Agordoj"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Mallongigoj"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1242,7 +1242,7 @@
     "Specific Output": ""
   },
   "Spotlight": {
-    "Spotlight": "Spotlight"
+    "Spotlight": "spoto"
   },
   "Spotlight (D)": {
     "Spotlight (D)": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "Sistema defaŭlto"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "Teksto"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "Tekst-koloro"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Dikeco"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": ""
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Supre"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "Supre centre"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Supre maldekstre"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Supre dekstre"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "Tre Alta"
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "اقدام"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": ""
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "افزودن"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "کدک صوتی"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "خودکار"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "پس‌زمینه"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "متعادل"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "رنگ حاشیه"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "پهنای حاشیه"
   },
   "Both": {
     "Both": ""
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "پایین"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "پایین وسط"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "پایین چپ"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "پایین راست"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "انتخاب رنگ"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "کلیپ‌بورد"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "بستن"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "در کلیپ‌بورد کپی شد"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "کپی"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "سفارشی"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "حذف"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "فاصله لبه"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": ""
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "شناور"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": ""
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "پنجره فوکوس‌شده"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "اندازه قلم"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "راهنما"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": ""
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "تاریخچه"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "تصویر"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "تصویر در کلیپ‌بورد کپی شد"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "کلید"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "چپ"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": "کم‌رنگ"
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": ""
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "متوسط"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "بدون پس‌زمینه"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "هیچکدام"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": ""
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "اعلان‌ها"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "شفافیت"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "باز‌ کردن"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "توقف"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "پیکسلی کردن"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "مکان"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "پیش‌نمایش"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "اصلی"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": ""
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "تازه‌سازی"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "تنظیم مجدد"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "ازسرگیری"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "راست"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "اسکرول"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "اسکرولینگ"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "انتخاب"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "تنظیمات"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "میانبرها"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1242,7 +1242,7 @@
     "Specific Output": ""
   },
   "Spotlight": {
-    "Spotlight": "Spotlight"
+    "Spotlight": "اسپات‌لایت"
   },
   "Spotlight (D)": {
     "Spotlight (D)": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "پیش‌فرض سیستم"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "متن"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "رنگ متن"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "ضخامت"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": ""
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "بالا"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "بالا وسط"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "بالا چپ"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "بالا راست"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": ""
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -164,9 +164,6 @@
   "Callout, Background (Z, B)": {
     "Callout, Background (Z, B)": ""
   },
-  "Cancel": {
-    "Cancel": ""
-  },
   "Capture": {
     "Capture": ""
   },
@@ -244,6 +241,9 @@
   },
   "Container Format": {
     "Container Format": ""
+  },
+  "Contributors": {
+    "Contributors": ""
   },
   "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
     "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": ""
@@ -530,8 +530,8 @@
   "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
     "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": ""
   },
-  "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
-    "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
   },
   "Framerate": {
     "Framerate": ""
@@ -682,6 +682,9 @@
   },
   "Live Preview": {
     "Live Preview": ""
+  },
+  "Loading contributors...": {
+    "Loading contributors...": ""
   },
   "Low": {
     "Low": ""
@@ -834,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixeliser"
+    "Pixelate": "Pixelliser"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -1031,9 +1034,6 @@
   "Rounded Rectangle": {
     "Rounded Rectangle": ""
   },
-  "Save": {
-    "Save": ""
-  },
   "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
@@ -1144,6 +1144,9 @@
   },
   "Select Color Slots 5 - 8 (Q, W, E, R)": {
     "Select Color Slots 5 - 8 (Q, W, E, R)": ""
+  },
+  "Select Directory": {
+    "Select Directory": ""
   },
   "Select Image File": {
     "Select Image File": ""
@@ -1297,6 +1300,9 @@
   },
   "System Audio Device": {
     "System Audio Device": ""
+  },
+  "System Default": {
+    "System Default": "Paramètres par défaut"
   },
   "Target Output Name": {
     "Target Output Name": ""

--- a/translations/he.json
+++ b/translations/he.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "פעולה"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": "אדפטיבי"
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "הוספה"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "קודק אודיו"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "אוטומטי"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "רקע"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "מאוזן"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "צבע מסגרת"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "רוחב המסגרת"
   },
   "Both": {
     "Both": ""
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "למטה"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "במרכז למטה"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "שמאל למטה"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "ימין למטה"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "בחר/י צבע"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "לוח ההעתקה"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "סגירה"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "הועתק ללוח"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "העתקה"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "מותאם אישית"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "מחיקה"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "ריווח קצוות"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": "עריכה"
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "צף"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": "צף"
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "חלון ממוקד"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "גודל הגופן"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "עזרה"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": "גבוה"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "היסטוריה"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "תמונה"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "התמונה הועתקה ללוח ההעתקה"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "מקש"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "שמאל"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": "דק"
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "נמוך"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "בינוני"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "ללא רקע"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "ללא"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": "התראה"
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "התראות"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "שקיפות"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "פתח/י"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "השהיה"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "פיקסול"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "מיקום"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "תצוגה מקדימה"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "ראשי"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": "מוכנה"
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "רענון"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "איפוס"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "המשך"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "ימין"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "גלילה"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "גלילה"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "בחר/י"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "הגדרות"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "קיצורי דרך"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "ברירת מחדל של המערכת"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "טקסט"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "צבע טקסט"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "עובי"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": "התראה קופצת"
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "למעלה"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "במרכז למעלה"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "שמאל למעלה"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "ימין למעלה"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "גבוה מאוד"
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Művelet"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": "Adaptív"
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Hozzáadás"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Hangkodek"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "Automatikus"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "Háttér"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "Kiegyensúlyozott"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Szegély színe"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "Szegély szélessége"
   },
   "Both": {
-    "Both": ""
+    "Both": "Mindkettő"
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Alul"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "Alul középen"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Bal Lent"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Jobb Lent"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Szín választása"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Vágólap"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Bezárás"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Másolva a vágólapra"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "Másolás"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Egyéni"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Törlés"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Élek távolsága"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": "Szerkesztés"
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "Lebegő"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": "Lebegő"
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Fókuszált ablak"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Betűméret"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Súgó"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": "Magas"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "Előzmények"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Kép"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Kép másolva a vágólapra"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "Billentyű"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Bal"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": "Vékony"
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "Alacsony"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Közepes"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Nincs háttérkép"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Nincs"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": "Értesítés"
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Értesítések"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Átlátszatlanság"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Megnyitás"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "Szüneteltetés"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "Képpontosítás"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Pozíció"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "Előnézet"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Elsődleges"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": "Kész"
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Újratöltés"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Visszaállítás"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Folytatás"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Jobb"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "Görgetés"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Görgetés"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "Kiválasztás"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Beállítások"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Gyorsbillentyűk"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "Rendszer alapértelmezett"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "Szöveg"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "Szövegszín"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Vastagság"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": "Felugró értesítés"
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Felső"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "Fent középen"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Bal Felül"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Jobb Felül"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "Nagyon magas"
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/it.json
+++ b/translations/it.json
@@ -1,0 +1,1457 @@
+{
+  "%1 — %2": {
+    "%1 — %2": ""
+  },
+  "1 Connecting Line": {
+    "1 Connecting Line": "1 linea di collegamento"
+  },
+  "2 Connecting Lines": {
+    "2 Connecting Lines": "2 linee di collegamento"
+  },
+  "AUTO": {
+    "AUTO": "AUTO"
+  },
+  "Action": {
+    "Action": "Azione"
+  },
+  "Action when Enter": {
+    "Action when Enter": "Azione alla pressione di Invio"
+  },
+  "Active Window": {
+    "Active Window": "Finestra attiva"
+  },
+  "Adaptive": {
+    "Adaptive": "Adattivo"
+  },
+  "Adaptive (DMS Theme)": {
+    "Adaptive (DMS Theme)": "Adattivo (Tema DMS)"
+  },
+  "Add": {
+    "Add": "Aggiungi"
+  },
+  "Add Text Note": {
+    "Add Text Note": "Aggiungi nota di testo"
+  },
+  "All Combined Outputs": {
+    "All Combined Outputs": "Tutte le uscite combinate"
+  },
+  "All Outputs": {
+    "All Outputs": "Tutte le uscite"
+  },
+  "Annotating": {
+    "Annotating": "Annotazione in corso"
+  },
+  "Annotation Tools": {
+    "Annotation Tools": "Strumenti di annotazione"
+  },
+  "Anonymous Copy (stripped metadata)": {
+    "Anonymous Copy (stripped metadata)": "Copia anonima (metadati rimossi)"
+  },
+  "Arrow (3)": {
+    "Arrow (3)": "Freccia (3)"
+  },
+  "Arrow Color": {
+    "Arrow Color": "Colore della freccia"
+  },
+  "Arrow Thickness": {
+    "Arrow Thickness": "Spessore della freccia"
+  },
+  "Arrow Vector": {
+    "Arrow Vector": "Vettore della freccia"
+  },
+  "Audio & Overlay": {
+    "Audio & Overlay": "Audio e Overlay"
+  },
+  "Audio Codec": {
+    "Audio Codec": "Codec audio"
+  },
+  "Auto": {
+    "Auto": "Automatico"
+  },
+  "Auto Balance": {
+    "Auto Balance": "Bilanciamento automatico"
+  },
+  "Auto Detect": {
+    "Auto Detect": "Rilevamento automatico"
+  },
+  "Auto-apply background defaults": {
+    "Auto-apply background defaults": "Applica automaticamente le impostazioni predefinite dello sfondo"
+  },
+  "Auto-close the loop when ending near the start point.": {
+    "Auto-close the loop when ending near the start point.": "Chiudi automaticamente il tracciato quando termina vicino al punto di partenza."
+  },
+  "Auto-minimize": {
+    "Auto-minimize": "Riduzione automatica a icona"
+  },
+  "Auto-select a tool preset on hover, without releasing the mouse.": {
+    "Auto-select a tool preset on hover, without releasing the mouse.": "Seleziona automaticamente un preset dello strumento al passaggio del mouse, senza rilasciare il pulsante."
+  },
+  "Auto-tiling": {
+    "Auto-tiling": "Disposizione automatica a griglia"
+  },
+  "Automatically minimize the float window after a delay": {
+    "Automatically minimize the float window after a delay": "Riduce automaticamente a icona la finestra fluttuante dopo un ritardo"
+  },
+  "Automatically stack windows to avoid overlap": {
+    "Automatically stack windows to avoid overlap": "Impila automaticamente le finestre per evitare sovrapposizioni"
+  },
+  "Back to Annotation (B)": {
+    "Back to Annotation (B)": "Torna all'annotazione (B)"
+  },
+  "Background": {
+    "Background": "Sfondo"
+  },
+  "Background (B)": {
+    "Background (B)": "Sfondo (B)"
+  },
+  "Background Defaults": {
+    "Background Defaults": "Impostazioni predefinite dello sfondo"
+  },
+  "Background Image Folder": {
+    "Background Image Folder": "Cartella dell'immagini di sfondo"
+  },
+  "Background Images": {
+    "Background Images": "Immagini di sfondo"
+  },
+  "Background Presets": {
+    "Background Presets": "Preset di sfondo"
+  },
+  "Balanced": {
+    "Balanced": "Bilanciato"
+  },
+  "Bar Interactions": {
+    "Bar Interactions": "Interazioni con la barra"
+  },
+  "Blink Recording Dot": {
+    "Blink Recording Dot": "Fai lampeggiare il pallino di registrazione"
+  },
+  "Blur Background Image": {
+    "Blur Background Image": "Sfoca l'immagine di sfondo"
+  },
+  "Border Color": {
+    "Border Color": "Colore del bordo"
+  },
+  "Border Width": {
+    "Border Width": "Larghezza del bordo"
+  },
+  "Both": {
+    "Both": "Entrambi"
+  },
+  "Bottom": {
+    "Bottom": "In basso"
+  },
+  "Bottom Center": {
+    "Bottom Center": "In basso al centro"
+  },
+  "Bottom Left": {
+    "Bottom Left": "In basso a sinistra"
+  },
+  "Bottom Right": {
+    "Bottom Right": "In basso a destra"
+  },
+  "CUST": {
+    "CUST": "PERS"
+  },
+  "Callout": {
+    "Callout": "Richiamo"
+  },
+  "Callout (Z) | Hold G for Loupe": {
+    "Callout (Z) | Hold G for Loupe": "Richiamo (Z) | Tieni premuto G per la lente"
+  },
+  "Callout Zoom": {
+    "Callout Zoom": "Zoom richiamo"
+  },
+  "Callout, Background (Z, B)": {
+    "Callout, Background (Z, B)": "Richiamo, Sfondo (Z, B)"
+  },
+  "Capture": {
+    "Capture": "Cattura"
+  },
+  "Capture Actions": {
+    "Capture Actions": "Azioni di cattura"
+  },
+  "Capture Options": {
+    "Capture Options": "Opzioni di cattura"
+  },
+  "Capturing...": {
+    "Capturing...": "Cattura in corso..."
+  },
+  "Catppuccin": {
+    "Catppuccin": "Catppuccin"
+  },
+  "Center": {
+    "Center": "Centro"
+  },
+  "Center Left": {
+    "Center Left": "Centro sinistra"
+  },
+  "Center Right": {
+    "Center Right": "Centro destra"
+  },
+  "Choose Color": {
+    "Choose Color": "Scegli il colore"
+  },
+  "Choose notifications shown after copy or save.": {
+    "Choose notifications shown after copy or save.": "Scegli le notifiche mostrate dopo la copia o il salvataggio."
+  },
+  "Choose the editor shape for portrait or landscape screens.": {
+    "Choose the editor shape for portrait or landscape screens.": "Scegli la forma dell'editor per schermi verticali o orizzontali."
+  },
+  "Choose whether the editor opens as a modal overlay or a movable floating window.": {
+    "Choose whether the editor opens as a modal overlay or a movable floating window.": "Scegli se l'editor si apre come overlay modale o come finestra fluttuante spostabile."
+  },
+  "Choose which monitor to capture during full screen recording.": {
+    "Choose which monitor to capture during full screen recording.": "Scegli quale monitor catturare durante la registrazione a schermo intero."
+  },
+  "Classic (Tailwind)": {
+    "Classic (Tailwind)": "Classico (Tailwind)"
+  },
+  "Clean Text Eraser": {
+    "Clean Text Eraser": "Gomma testo pulita"
+  },
+  "Clear saved region selection before each capture": {
+    "Clear saved region selection before each capture": "Cancella la selezione della regione salvata prima di ogni cattura"
+  },
+  "Clipboard": {
+    "Clipboard": "Appunti"
+  },
+  "Close": {
+    "Close": "Chiudi"
+  },
+  "Close Annotator": {
+    "Close Annotator": "Chiudi l'annotatore"
+  },
+  "Color Palette": {
+    "Color Palette": "Palette dei colori"
+  },
+  "Color Picker (F for RGB | Eyedropper)": {
+    "Color Picker (F for RGB | Eyedropper)": "Selettore colori (F per RGB | Contagocce)"
+  },
+  "Color Picker, Eraser (F, T)": {
+    "Color Picker, Eraser (F, T)": "Selettore colori, Gomma (F, T)"
+  },
+  "Color copied to clipboard: %1": {
+    "Color copied to clipboard: %1": "Colore copiato negli appunti: %1"
+  },
+  "Configure up to 8 quick-access tool presets. Right-click during capture to open the radial menu.": {
+    "Configure up to 8 quick-access tool presets. Right-click during capture to open the radial menu.": "Configura fino a 8 preset degli strumenti ad accesso rapido. Fai clic destro durante la cattura per aprire il menu radiale."
+  },
+  "Conic Gradient": {
+    "Conic Gradient": "Gradiente conico"
+  },
+  "Container Format": {
+    "Container Format": "Formato del contenitore"
+  },
+  "Contributors": {
+    "Contributors": "Contributori"
+  },
+  "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
+    "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": "Controlla il budget di pixel dell'anteprima durante la modifica. Riducilo se noti rallentamenti. Non influisce sulla qualità dell'immagine salvata."
+  },
+  "Converting recording to GIF...": {
+    "Converting recording to GIF...": "Conversione della registrazione in GIF..."
+  },
+  "Copied": {
+    "Copied": "Copiato"
+  },
+  "Copied & saved": {
+    "Copied & saved": "Copiato e salvato"
+  },
+  "Copied Anonymously": {
+    "Copied Anonymously": "Copiato in modo anonimo"
+  },
+  "Copied to clipboard": {
+    "Copied to clipboard": "Copiato negli appunti"
+  },
+  "Copied:": {
+    "Copied:": "Copiato:"
+  },
+  "Copy": {
+    "Copy": "Copia"
+  },
+  "Copy & Save": {
+    "Copy & Save": "Copia e salva"
+  },
+  "Copy (Ctrl+C) | Anonymous Copy (Ctrl+Shift+C)": {
+    "Copy (Ctrl+C) | Anonymous Copy (Ctrl+Shift+C)": "Copia (Ctrl+C) | Copia anonima (Ctrl+Maiusc+C)"
+  },
+  "Copy Color": {
+    "Copy Color": "Copia il colore"
+  },
+  "Copy Current Palette": {
+    "Copy Current Palette": "Copia la palette corrente"
+  },
+  "Copy and customize this preset": {
+    "Copy and customize this preset": "Copia e personalizza questo preset"
+  },
+  "Copy vector / Paste / Duplicate": {
+    "Copy vector / Paste / Duplicate": "Copia vettore / Incolla / Duplica"
+  },
+  "Crop / Resize": {
+    "Crop / Resize": "Ritaglia / Ridimensiona"
+  },
+  "Crop / Resize Area": {
+    "Crop / Resize Area": "Area di ritaglio / ridimensionamento"
+  },
+  "Custom": {
+    "Custom": "Personalizzata"
+  },
+  "Custom Colors": {
+    "Custom Colors": "Colori personalizzati"
+  },
+  "Custom Tool": {
+    "Custom Tool": "Strumento personalizzato"
+  },
+  "Dank Violet": {
+    "Dank Violet": "Dank Violet"
+  },
+  "Dark": {
+    "Dark": "Scuro"
+  },
+  "Darken the image to improve foreground contrast": {
+    "Darken the image to improve foreground contrast": "Scurisci l'immagine per migliorare il contrasto del primo piano"
+  },
+  "Dashed Line": {
+    "Dashed Line": "Linea tratteggiata"
+  },
+  "Default Alignment": {
+    "Default Alignment": "Allineamento predefinito"
+  },
+  "Default Aspect Ratio": {
+    "Default Aspect Ratio": "Proporzioni predefinite"
+  },
+  "Default Background Image": {
+    "Default Background Image": "Immagine di sfondo predefinita"
+  },
+  "Default Background Mode": {
+    "Default Background Mode": "Modalità sfondo predefinita"
+  },
+  "Default Bold Text": {
+    "Default Bold Text": "Testo in grassetto predefinito"
+  },
+  "Default Corner Radius": {
+    "Default Corner Radius": "Raggio degli angoli predefinito"
+  },
+  "Default Gradient Angle": {
+    "Default Gradient Angle": "Gradiente dell'angolo predefinito"
+  },
+  "Default Gradient End": {
+    "Default Gradient End": "Fine gradiente predefinita"
+  },
+  "Default Gradient Start": {
+    "Default Gradient Start": "Inizio gradiente predefinito"
+  },
+  "Default Italic Text": {
+    "Default Italic Text": "Testo in corsivo predefinito"
+  },
+  "Default Microphone": {
+    "Default Microphone": "Microfono predefinito"
+  },
+  "Default Output": {
+    "Default Output": "Uscita predefinita"
+  },
+  "Default Padding": {
+    "Default Padding": "Spaziatura predefinita"
+  },
+  "Default Shadow Strength": {
+    "Default Shadow Strength": "Intensità dell'ombra predefinita"
+  },
+  "Default Solid Color": {
+    "Default Solid Color": "Colore pieno predefinito"
+  },
+  "Default Text Background": {
+    "Default Text Background": "Sfondo del testo predefinito"
+  },
+  "Default Text Font Size": {
+    "Default Text Font Size": "Dimensione del font del testo predefinita"
+  },
+  "Default Underline Text": {
+    "Default Underline Text": "Testo sottolineato predefinito"
+  },
+  "Default Watermark": {
+    "Default Watermark": "Filigrana predefinita"
+  },
+  "Delete": {
+    "Delete": "Elimina"
+  },
+  "Dim Background Image": {
+    "Dim Background Image": "Attenua l'immagine di sfondo"
+  },
+  "Dim Intensity": {
+    "Dim Intensity": "Attenua l'intensità"
+  },
+  "Dimming Opacity": {
+    "Dimming Opacity": "Opacità di attenuazione"
+  },
+  "Direct": {
+    "Direct": "Diretto"
+  },
+  "Discard & Close": {
+    "Discard & Close": "Scarta e chiudi"
+  },
+  "Discard & Close (Esc)": {
+    "Discard & Close (Esc)": "Scarta e chiudi (Esc)"
+  },
+  "Done": {
+    "Done": "Fatto"
+  },
+  "Done (Action based on settings)": {
+    "Done (Action based on settings)": "Fatto (azione basata sulle impostazioni)"
+  },
+  "Dotted Line": {
+    "Dotted Line": "Linea punteggiata"
+  },
+  "Dracula": {
+    "Dracula": "Dracula"
+  },
+  "Drag Image": {
+    "Drag Image": "Trascina immagine"
+  },
+  "Draw an outer ring using the stamp number color": {
+    "Draw an outer ring using the stamp number color": "Disegna un anello esterno usando il colore del numero del timbro"
+  },
+  "Drop image onto bar icon to annotate it": {
+    "Drop image onto bar icon to annotate it": "Trascina un'immagine sull'icona della barra per annotarla"
+  },
+  "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": {
+    "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": "Ogni comando accetta un'azione: <b>edit</b> (apre l'editor) o <b>float</b> (finestra sempre in primo piano)."
+  },
+  "Edge Spacing": {
+    "Edge Spacing": "Spaziatura dai bordi"
+  },
+  "Edit": {
+    "Edit": "Modifica"
+  },
+  "Edit Color Palette": {
+    "Edit Color Palette": "Modifica la palette dei colori"
+  },
+  "Edit Image from Clipboard": {
+    "Edit Image from Clipboard": ""
+  },
+  "Edit Text Note": {
+    "Edit Text Note": "Modifica nota di testo"
+  },
+  "Editor": {
+    "Editor": "Editor"
+  },
+  "Editor Aspect Ratio": {
+    "Editor Aspect Ratio": "Proporzioni dell'editor"
+  },
+  "Editor Display Mode": {
+    "Editor Display Mode": "Modalità di visualizzazione dell'editor"
+  },
+  "Editor Display Screen": {
+    "Editor Display Screen": "Schermo di visualizzazione dell'editor"
+  },
+  "Editor Preview Quality": {
+    "Editor Preview Quality": "Qualità dell'anteprima dell'editor"
+  },
+  "Ellipse": {
+    "Ellipse": "Ellisse"
+  },
+  "Ellipse / Circle": {
+    "Ellipse / Circle": "Ellisse / Cerchio"
+  },
+  "Ellipse / Circle (Q)": {
+    "Ellipse / Circle (Q)": "Ellisse / Cerchio (Q)"
+  },
+  "Ellipse Color": {
+    "Ellipse Color": "Colore dell'ellisse"
+  },
+  "Ellipse Thickness": {
+    "Ellipse Thickness": "Spessore dell'ellisse"
+  },
+  "Ellipse, Text, Pixelate, Redact (Q, W, E, R)": {
+    "Ellipse, Text, Pixelate, Redact (Q, W, E, R)": "Ellisse, Testo, Pixela, Oscura (Q, W, E, R)"
+  },
+  "Enable background automatically when opening the editor": {
+    "Enable background automatically when opening the editor": "Attiva automaticamente lo sfondo all'apertura dell'editor"
+  },
+  "Eraser": {
+    "Eraser": "Gomma"
+  },
+  "Everforest": {
+    "Everforest": "Everforest"
+  },
+  "Failed to convert recording to GIF.": {
+    "Failed to convert recording to GIF.": "Impossibile convertire la registrazione in GIF."
+  },
+  "Failed to copy screenshot to clipboard.": {
+    "Failed to copy screenshot to clipboard.": "Impossibile copiare lo screenshot negli appunti."
+  },
+  "Failed to generate blurred background image": {
+    "Failed to generate blurred background image": "Impossibile generare l'immagine di sfondo sfocata"
+  },
+  "Failed to save screenshot": {
+    "Failed to save screenshot": "Impossibile salvare lo screenshot"
+  },
+  "Failed to save screenshot file.": {
+    "Failed to save screenshot file.": "Impossibile salvare il file dello screenshot."
+  },
+  "Flip Horiz": {
+    "Flip Horiz": "Rifletti orizz"
+  },
+  "Flip Vert": {
+    "Flip Vert": "Rifletti vert"
+  },
+  "Float": {
+    "Float": "Fluttuante"
+  },
+  "Float Image": {
+    "Float Image": "Immagine fluttuante"
+  },
+  "Float Window": {
+    "Float Window": "Finestra fluttuante"
+  },
+  "Floating": {
+    "Floating": "Fluttuante"
+  },
+  "Focused Screen": {
+    "Focused Screen": "Schermo attivo"
+  },
+  "Focused Window": {
+    "Focused Window": "Finestra attiva"
+  },
+  "Font Size": {
+    "Font Size": "Dimensione del Font"
+  },
+  "Font family used for number stamp labels": {
+    "Font family used for number stamp labels": "Famiglia di font usata per le etichette numeriche del timbro"
+  },
+  "Force Copy & Save": {
+    "Force Copy & Save": "Forza copia e salvataggio"
+  },
+  "Force Copy to Clipboard": {
+    "Force Copy to Clipboard": "Forza la copia negli appunti"
+  },
+  "Force Save to File": {
+    "Force Save to File": "Forza il salvataggio su file"
+  },
+  "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
+    "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": "oken di formato: %Y (Anno), %y (Anno a 2 cifre), %m (Mese), %d (Giorno), %H (Ora), %M (Minuto), %S (Secondo), {zzz} (Ms)"
+  },
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": "Token di formato: {user} (Nome utente), \\n (Nuova riga), %Y (Anno), %y (Anno a 2 cifre), %m (Mese), %d (Giorno), %H (Ora), %M (Minuto), %S (Secondo)"
+  },
+  "Framerate": {
+    "Framerate": "Frequenza fotogrammi"
+  },
+  "Free": {
+    "Free": "Libero"
+  },
+  "Freehand Pen": {
+    "Freehand Pen": "Penna a mano libera"
+  },
+  "Freehand Pen (1)": {
+    "Freehand Pen (1)": "Penna a mano libera (1)"
+  },
+  "From Clipboard": {
+    "From Clipboard": "Dagli appunti"
+  },
+  "From File": {
+    "From File": "Da file"
+  },
+  "Full Screen": {
+    "Full Screen": "Schermo intero"
+  },
+  "Full Screen Target": {
+    "Full Screen Target": "Destinazione dello schermo intero"
+  },
+  "GIF Framerate": {
+    "GIF Framerate": "Frequenza fotogrammi della GIF"
+  },
+  "General Shortcuts": {
+    "General Shortcuts": "Scorciatoie generali"
+  },
+  "Gruvbox Material": {
+    "Gruvbox Material": "Gruvbox Material"
+  },
+  "Help": {
+    "Help": "Guida"
+  },
+  "Hide Control Center": {
+    "Hide Control Center": "Nascondi il centro di controllo"
+  },
+  "Hide Control Center by Default": {
+    "Hide Control Center by Default": "Nascondi il centro di controllo per impostazione predefinita"
+  },
+  "High": {
+    "High": "Alta"
+  },
+  "Highlighter": {
+    "Highlighter": "Evidenziatore"
+  },
+  "Highlighter (S)": {
+    "Highlighter (S)": "Evidenziatore (S)"
+  },
+  "Highlighter Color": {
+    "Highlighter Color": "Colore dell'evidenziatore"
+  },
+  "Highlighter Thickness": {
+    "Highlighter Thickness": "Colore dell'evidenziatore"
+  },
+  "History": {
+    "History": "Cronologia"
+  },
+  "Hover Trigger Delay": {
+    "Hover Trigger Delay": "Ritardo di attivazione al passaggio del mouse"
+  },
+  "IPC Commands": {
+    "IPC Commands": "Comandi IPC"
+  },
+  "Image": {
+    "Image": "Immagine"
+  },
+  "Image + Text": {
+    "Image + Text": "Immagine + Testo"
+  },
+  "Image Background": {
+    "Image Background": "Sfondo immagine"
+  },
+  "Image Error": {
+    "Image Error": "Errore immagine"
+  },
+  "Image Size": {
+    "Image Size": "Dimensione dell'immagine"
+  },
+  "Image copied to clipboard": {
+    "Image copied to clipboard": "Immagine copiata negli appunti"
+  },
+  "Image selected automatically when using Image Background mode": {
+    "Image selected automatically when using Image Background mode": "Immagine selezionata automaticamente quando si usa la modalità Sfondo immagine"
+  },
+  "Include Cursor": {
+    "Include Cursor": "Includi il cursore"
+  },
+  "Initial Width": {
+    "Initial Width": "Larghezza iniziale"
+  },
+  "Initial state for the Control Center toggle.": {
+    "Initial state for the Control Center toggle.": "Stato iniziale dell'interruttore del centro di controllo."
+  },
+  "Input Mode": {
+    "Input Mode": "Modalità di input"
+  },
+  "Insert Image": {
+    "Insert Image": "Inserisci l'immagine"
+  },
+  "Interaction / Result": {
+    "Interaction / Result": "Interazione / Risultato"
+  },
+  "Interactive Region": {
+    "Interactive Region": "Regione interattiva"
+  },
+  "JPEG Quality": {
+    "JPEG Quality": "Qualità JPEG"
+  },
+  "Kanagawa": {
+    "Kanagawa": "Kanagawa"
+  },
+  "Key": {
+    "Key": "Tasto"
+  },
+  "Landscape": {
+    "Landscape": "Orizzontale"
+  },
+  "Last Reg": {
+    "Last Reg": "Ultima reg."
+  },
+  "Last Region": {
+    "Last Region": "Ultima regione"
+  },
+  "Last Selected Region": {
+    "Last Selected Region": "Ultima regione selezionata"
+  },
+  "Left": {
+    "Left": "Sinistra"
+  },
+  "Left Click": {
+    "Left Click": "Clic sinistro"
+  },
+  "Light": {
+    "Light": "Chiaro"
+  },
+  "Line Color": {
+    "Line Color": "Colore della linea"
+  },
+  "Line Thickness": {
+    "Line Thickness": "Spessore della linea"
+  },
+  "Linear Gradient": {
+    "Linear Gradient": "Gradiente lineare"
+  },
+  "Live Preview": {
+    "Live Preview": "Anteprima dal vivo"
+  },
+  "Loading contributors...": {
+    "Loading contributors...": "Caricamento dei contributori..."
+  },
+  "Low": {
+    "Low": "Bassa"
+  },
+  "Magnifier Loupe": {
+    "Magnifier Loupe": "Lente d'ingrandimento"
+  },
+  "Max Height (0 = no limit)": {
+    "Max Height (0 = no limit)": "Altezza massima (0 = nessun limite)"
+  },
+  "Medium": {
+    "Medium": "Media"
+  },
+  "Menu Item Right Click": {
+    "Menu Item Right Click": "Clic destro sulla voce di menu"
+  },
+  "Merging audio tracks...": {
+    "Merging audio tracks...": "Unione delle tracce audio in corso..."
+  },
+  "Microphone Device": {
+    "Microphone Device": "Dispositivo microfono"
+  },
+  "Middle Click": {
+    "Middle Click": "Clic centrale"
+  },
+  "Middle Click Action": {
+    "Middle Click Action": "Azione del clic centrale"
+  },
+  "Minimize Delay": {
+    "Minimize Delay": "Ritardo di riduzione a icona"
+  },
+  "Modal": {
+    "Modal": "Modale"
+  },
+  "More Tools": {
+    "More Tools": "Altri strumenti"
+  },
+  "Niri Binding Example": {
+    "Niri Binding Example": "Esempio di associazione Niri"
+  },
+  "No Background": {
+    "No Background": "Nessuno sfondo"
+  },
+  "No Image Specified": {
+    "No Image Specified": "Nessuna immagine specificata"
+  },
+  "No output available": {
+    "No output available": "Nessuna uscita disponibile"
+  },
+  "No saved images yet": {
+    "No saved images yet": "Nessuna immagine salvata"
+  },
+  "No supported images found": {
+    "No supported images found": "Nessuna immagine supportata trovata"
+  },
+  "None": {
+    "None": "Nessuna"
+  },
+  "None / Disabled": {
+    "None / Disabled": "Nessuno / Disattivato"
+  },
+  "Nord": {
+    "Nord": "Nord"
+  },
+  "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": {
+    "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": "Nota: la modalità dello strumento iniziale sovrascrive lo spessore e il colore predefiniti se lo strumento iniziale corrisponde."
+  },
+  "Notification": {
+    "Notification": "Notifica"
+  },
+  "Notifications": {
+    "Notifications": "Notifiche"
+  },
+  "Number Stamp": {
+    "Number Stamp": "Timbro numerico"
+  },
+  "OCR": {
+    "OCR": "OCR"
+  },
+  "OCR Result": {
+    "OCR Result": "Risultato dell'OCR"
+  },
+  "OCR Text Recognition": {
+    "OCR Text Recognition": "Riconoscimento del testo tramite OCR"
+  },
+  "Opacity": {
+    "Opacity": "Opacità"
+  },
+  "Open": {
+    "Open": "Apri"
+  },
+  "Open Folder": {
+    "Open Folder": "Apri la cartella"
+  },
+  "Open Quick Capture menu (Popout)": {
+    "Open Quick Capture menu (Popout)": "Apri il menu Cattura rapida (Finestra a comparsa)"
+  },
+  "Open Specific Image Path": {
+    "Open Specific Image Path": ""
+  },
+  "Outline Variant": {
+    "Outline Variant": "Variante contorno"
+  },
+  "Output Format": {
+    "Output Format": "Formato di uscita"
+  },
+  "Output format applies only to disk saves. Clipboard copies are always PNG.": {
+    "Output format applies only to disk saves. Clipboard copies are always PNG.": "Il formato di uscita si applica solo ai salvataggi su disco. Le copie negli appunti sono sempre in PNG."
+  },
+  "Outputs": {
+    "Outputs": "Uscite"
+  },
+  "Overlay Opacity": {
+    "Overlay Opacity": "Opacità dell'overlay"
+  },
+  "PAUSED": {
+    "PAUSED": "IN PAUSA"
+  },
+  "PRIMARY": {
+    "PRIMARY": "PRIMARIO"
+  },
+  "Palette Preset": {
+    "Palette Preset": "Preset della palette"
+  },
+  "Pause": {
+    "Pause": "Pausa"
+  },
+  "Pause / Resume": {
+    "Pause / Resume": ""
+  },
+  "Pen Auto-Close": {
+    "Pen Auto-Close": "Chiusura automatica della penna"
+  },
+  "Pen Color": {
+    "Pen Color": "Colore della penna"
+  },
+  "Pen Thickness": {
+    "Pen Thickness": "Spessore della penna"
+  },
+  "Pen, Line, Arrow, Rect": {
+    "Pen, Line, Arrow, Rect": "Penna, Linea, Freccia, Rettangolo"
+  },
+  "Pick Color": {
+    "Pick Color": "Scegli colore"
+  },
+  "Pick a palette preset or customize individual color slots.": {
+    "Pick a palette preset or customize individual color slots.": "Scegli un preset di palette oppure personalizza i singoli slot colore."
+  },
+  "Pixel Intensity": {
+    "Pixel Intensity": "Intensità dei pixel"
+  },
+  "Pixelate": {
+    "Pixelate": "Mosaico"
+  },
+  "Pixelate (E)": {
+    "Pixelate (E)": "Pixela (E)"
+  },
+  "Pixelate Intensity": {
+    "Pixelate Intensity": "Intensità del pixela"
+  },
+  "Popup Input": {
+    "Popup Input": "Input popup"
+  },
+  "Portrait": {
+    "Portrait": "Verticale"
+  },
+  "Position": {
+    "Position": "Posizione"
+  },
+  "Post-Capture Notification": {
+    "Post-Capture Notification": "Notifica dopo la cattura"
+  },
+  "Preset %1": {
+    "Preset %1": "Preset %1"
+  },
+  "Preset 1": {
+    "Preset 1": "Preset 1"
+  },
+  "Preset 2": {
+    "Preset 2": "Preset 2"
+  },
+  "Preset 3": {
+    "Preset 3": "Preset 3"
+  },
+  "Preset 4": {
+    "Preset 4": "Preset 4"
+  },
+  "Preset 5": {
+    "Preset 5": "Preset 5"
+  },
+  "Preset 6": {
+    "Preset 6": "Preset 6"
+  },
+  "Preset 7": {
+    "Preset 7": "Preset 7"
+  },
+  "Preset 8": {
+    "Preset 8": "Preset 8"
+  },
+  "Preset Color": {
+    "Preset Color": "Colore del preset"
+  },
+  "Preset Thickness": {
+    "Preset Thickness": "Spessore del preset"
+  },
+  "Preset Tool": {
+    "Preset Tool": "Strumento preset"
+  },
+  "Preview": {
+    "Preview": "Anteprima"
+  },
+  "Primary": {
+    "Primary": "Primario"
+  },
+  "Primary Screen": {
+    "Primary Screen": "Schermo primario"
+  },
+  "QR Result": {
+    "QR Result": "Risultato QR"
+  },
+  "Quick Capture": {
+    "Quick Capture": "Cattura rapida"
+  },
+  "Quick Capture Error": {
+    "Quick Capture Error": "Errore cattura rapida"
+  },
+  "RECORDING": {
+    "RECORDING": "REGISTRAZIONE"
+  },
+  "Radial Gradient": {
+    "Radial Gradient": "Gradiente radiale"
+  },
+  "Radial Menu": {
+    "Radial Menu": "Menu radiale"
+  },
+  "Radial Menu Opacity": {
+    "Radial Menu Opacity": "Opacità del menu radiale"
+  },
+  "Radial Menu Settings": {
+    "Radial Menu Settings": "Impostazioni delmenu radiale"
+  },
+  "Radial Preset": {
+    "Radial Preset": "Preset del menu radiale"
+  },
+  "Ratio": {
+    "Ratio": "Preset radiale"
+  },
+  "Ready": {
+    "Ready": "Pronto"
+  },
+  "Recent Edits": {
+    "Recent Edits": "Modifiche recenti"
+  },
+  "Record Microphone": {
+    "Record Microphone": "Registra il microfono"
+  },
+  "Record Mouse Cursor": {
+    "Record Mouse Cursor": "Registra il cursore del mouse"
+  },
+  "Record System Audio": {
+    "Record System Audio": "Registra l'audio di sistema"
+  },
+  "Recording": {
+    "Recording": "Registrazione"
+  },
+  "Recording Folder": {
+    "Recording Folder": "Cartella delle registrazioni"
+  },
+  "Recording ended with error code %1.": {
+    "Recording ended with error code %1.": "La registrazione è terminata con codice di errore %1."
+  },
+  "Recording...": {
+    "Recording...": "Registrazione in corso..."
+  },
+  "Recordings Directory": {
+    "Recordings Directory": "Cartella delle registrazioni"
+  },
+  "Rectangle": {
+    "Rectangle": "Rettangolo"
+  },
+  "Rectangle Color": {
+    "Rectangle Color": "Colore del rettangolo"
+  },
+  "Rectangle Outline": {
+    "Rectangle Outline": "Contorno del rettangolo"
+  },
+  "Rectangle Outline (4)": {
+    "Rectangle Outline (4)": "Contorno del rettangolo (4)"
+  },
+  "Rectangle Thickness": {
+    "Rectangle Thickness": "Spessore del rettangolo"
+  },
+  "Redact": {
+    "Redact": "Oscura"
+  },
+  "Redact (R)": {
+    "Redact (R)": "Oscura (R)"
+  },
+  "Redact Thickness": {
+    "Redact Thickness": "Spessore dell'oscuramento"
+  },
+  "Redo (Ctrl+Y / Ctrl+Shift+Z)": {
+    "Redo (Ctrl+Y / Ctrl+Shift+Z)": "Ripeti (Ctrl+Y / Ctrl+Maiusc+Z)"
+  },
+  "Redo last undone stroke": {
+    "Redo last undone stroke": "Ripeti l'ultimo tratto annullato"
+  },
+  "Refresh": {
+    "Refresh": "Aggiorna"
+  },
+  "Region": {
+    "Region": "Regione"
+  },
+  "Reset": {
+    "Reset": "Reimposta"
+  },
+  "Reset Last Region": {
+    "Reset Last Region": "Reimposta l'ultima regione"
+  },
+  "Resume": {
+    "Resume": "Riprendi"
+  },
+  "Right": {
+    "Right": "Destra"
+  },
+  "Right Click": {
+    "Right Click": "Clic destro"
+  },
+  "Right Click Action": {
+    "Right Click Action": "Azione col clic destro"
+  },
+  "Rosé Pine": {
+    "Rosé Pine": "Rosé Pine"
+  },
+  "Rotate L": {
+    "Rotate L": "Ruota a sinistra"
+  },
+  "Rotate R": {
+    "Rotate R": "Ruota a destra"
+  },
+  "Round Highlighter Tips": {
+    "Round Highlighter Tips": "Punte dell'evidenziatore arrotondate"
+  },
+  "Round Rectangle Corners": {
+    "Round Rectangle Corners": "Arrotonda gli angoli del rettangolo"
+  },
+  "Rounded Rectangle": {
+    "Rounded Rectangle": "Rettangolo arrotondato"
+  },
+  "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
+    "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": "Salva con nome (Ctrl+Maiusc+S)"
+  },
+  "Save Directory": {
+    "Save Directory": "Cartella di salvataggio"
+  },
+  "Save Filename Pattern": {
+    "Save Filename Pattern": "Modello nome file di salvataggio"
+  },
+  "Save Screenshot As": {
+    "Save Screenshot As": "Salva screenshot con nome"
+  },
+  "Saved %1 (%2)": {
+    "Saved %1 (%2)": "Salvato %1 (%2)"
+  },
+  "Saving": {
+    "Saving": "Salvataggio in corso"
+  },
+  "Scale Editor to Screenshot Size": {
+    "Scale Editor to Screenshot Size": "Adatta l'editor alla dimensione dello screenshot"
+  },
+  "Scan QR": {
+    "Scan QR": "Scansiona QR"
+  },
+  "Screen": {
+    "Screen": "Schermo"
+  },
+  "Screen Recorder": {
+    "Screen Recorder": "Registratore schermo"
+  },
+  "Screen Recording (%1)": {
+    "Screen Recording (%1)": ""
+  },
+  "Screen Recording Error": {
+    "Screen Recording Error": "Errore registrazione dello schermo"
+  },
+  "Screen Recording Saved": {
+    "Screen Recording Saved": "Registrazione schermo salvata"
+  },
+  "Screen recording timed out or was cancelled.": {
+    "Screen recording timed out or was cancelled.": "La registrazione dello schermo è scaduta o è stata annullata."
+  },
+  "Screen: %1 (%2x%3)": {
+    "Screen: %1 (%2x%3)": "Schermo: %1 (%2x%3)"
+  },
+  "Screenshot (%1) — %2": {
+    "Screenshot (%1) — %2": ""
+  },
+  "Screenshot Copied": {
+    "Screenshot Copied": "Screenshot copiato"
+  },
+  "Screenshot Folder": {
+    "Screenshot Folder": "Cartella degli screenshot"
+  },
+  "Screenshot Saved": {
+    "Screenshot Saved": "Screenshot salvato"
+  },
+  "Screenshot copied anonymously with randomized name and stripped metadata.": {
+    "Screenshot copied anonymously with randomized name and stripped metadata.": "Screenshot copiato in modo anonimo con nome casuale e metadati rimossi."
+  },
+  "Screenshot copied to clipboard and saved to %1": {
+    "Screenshot copied to clipboard and saved to %1": "Screenshot copiato negli appunti e salvato in %1"
+  },
+  "Screenshot copied to clipboard but failed to save file: %1": {
+    "Screenshot copied to clipboard but failed to save file: %1": "Screenshot copiato negli appunti ma impossibile salvare il file: %1"
+  },
+  "Screenshot copied to clipboard.": {
+    "Screenshot copied to clipboard.": "Screenshot copiato negli appunti."
+  },
+  "Screenshot copied with randomized name.": {
+    "Screenshot copied with randomized name.": "Screenshot copiato con nome casuale."
+  },
+  "Screenshot failed (mode: %1).": {
+    "Screenshot failed (mode: %1).": "Screenshot non riuscito (modalità: %1)."
+  },
+  "Screenshot saved": {
+    "Screenshot saved": "Screenshot salvato"
+  },
+  "Screenshot saved to %1": {
+    "Screenshot saved to %1": "Screenshot salvato in %1"
+  },
+  "Screenshot saved to %1/%2": {
+    "Screenshot saved to %1/%2": "Screenshot salvato in %1/%2"
+  },
+  "Scroll": {
+    "Scroll": "Scorrimento"
+  },
+  "Scroll Interval": {
+    "Scroll Interval": "Intervallo di scorrimento"
+  },
+  "Scroll capture: select a region, scroll content, then press Enter to finish.": {
+    "Scroll capture: select a region, scroll content, then press Enter to finish.": "Cattura a scorrimento: seleziona una regione, scorri il contenuto, poi premi Invio per terminare."
+  },
+  "Scrolling": {
+    "Scrolling": "Scorrimento"
+  },
+  "Scrolling Capture": {
+    "Scrolling Capture": "Cattura a scorrimento"
+  },
+  "Select": {
+    "Select": "Seleziona"
+  },
+  "Select / Move stroke": {
+    "Select / Move stroke": "Seleziona / Sposta tratto"
+  },
+  "Select Color Slots 1 - 4": {
+    "Select Color Slots 1 - 4": "Seleziona slot colore 1 - 4"
+  },
+  "Select Color Slots 5 - 8 (Q, W, E, R)": {
+    "Select Color Slots 5 - 8 (Q, W, E, R)": "Seleziona slot colore 5 - 8 (Q, W, E, R)"
+  },
+  "Select Directory": {
+    "Select Directory": "Seleziona cartella"
+  },
+  "Select Image File": {
+    "Select Image File": ""
+  },
+  "Select Image to Annotate": {
+    "Select Image to Annotate": "Seleziona immagine da annotare"
+  },
+  "Selected Tool / Action": {
+    "Selected Tool / Action": "Strumento / Azione selezionati"
+  },
+  "Settings": {
+    "Settings": "Impostazioni"
+  },
+  "Shapes": {
+    "Shapes": "Forme"
+  },
+  "Shortcut Action": {
+    "Shortcut Action": "Azione della scorciatoia"
+  },
+  "Shortcuts": {
+    "Shortcuts": "Scorciatoie"
+  },
+  "Show Control Center": {
+    "Show Control Center": "Mostra il centro di controllo"
+  },
+  "Show Keyboard Shortcut Hints": {
+    "Show Keyboard Shortcut Hints": "Mostra suggerimenti per le scorciatoie da tastiera"
+  },
+  "Show Pill Border": {
+    "Show Pill Border": "Mostra il bordo della pillola"
+  },
+  "Show Recent Edits History": {
+    "Show Recent Edits History": "Mostra cronologia delle modifiche recenti"
+  },
+  "Show Region Border": {
+    "Show Region Border": "Mostra il bordo della regione"
+  },
+  "Show Screenshot Border": {
+    "Show Screenshot Border": "Mostra il bordo dello screenshot"
+  },
+  "Show Toolbar": {
+    "Show Toolbar": "Mostra la barra degli strumenti"
+  },
+  "Show Toolbar Border": {
+    "Show Toolbar Border": "Mostra il bordo della barra degli strumenti"
+  },
+  "Show only the image on a transparent background": {
+    "Show only the image on a transparent background": "Mostra solo l'immagine su sfondo trasparente"
+  },
+  "Skip Confirmation": {
+    "Skip Confirmation": "Salta conferma"
+  },
+  "Slot 1": {
+    "Slot 1": "Slot 1"
+  },
+  "Slot 2": {
+    "Slot 2": "Slot 2"
+  },
+  "Slot 3": {
+    "Slot 3": "Slot 3"
+  },
+  "Slot 4": {
+    "Slot 4": "Slot 4"
+  },
+  "Slot 5": {
+    "Slot 5": "Slot 5"
+  },
+  "Slot 6": {
+    "Slot 6": "Slot 6"
+  },
+  "Slot 7": {
+    "Slot 7": "Slot 7"
+  },
+  "Slot 8": {
+    "Slot 8": "Slot 8"
+  },
+  "Soften image details so screenshot content stands out": {
+    "Soften image details so screenshot content stands out": "Attenua i dettagli dell'immagine per mettere in risalto il contenuto dello screenshot"
+  },
+  "Solid Color": {
+    "Solid Color": "Colore pieno"
+  },
+  "Solid Fill": {
+    "Solid Fill": "Riempimento pieno"
+  },
+  "Solid Line": {
+    "Solid Line": "Linea piena"
+  },
+  "Spawn Position": {
+    "Spawn Position": "Posizione di apertura"
+  },
+  "Specific Output": {
+    "Specific Output": "Uscita specifica"
+  },
+  "Spotlight": {
+    "Spotlight": "Spotlight"
+  },
+  "Spotlight (D)": {
+    "Spotlight (D)": "Spotlight (D)"
+  },
+  "Spotlight Opacity": {
+    "Spotlight Opacity": "Opacità di spotlight"
+  },
+  "Stamp (A)": {
+    "Stamp (A)": "Timbro (A)"
+  },
+  "Stamp Color": {
+    "Stamp Color": "Colore del timbro"
+  },
+  "Stamp Contrast Ring": {
+    "Stamp Contrast Ring": "Anello di contrasto del timbro"
+  },
+  "Stamp Number Font": {
+    "Stamp Number Font": "Font del numero del timbro"
+  },
+  "Stamp Size": {
+    "Stamp Size": "Dimensione del timbro"
+  },
+  "Stamp, Highlighter, Spotlight (A, S, D)": {
+    "Stamp, Highlighter, Spotlight (A, S, D)": "Timbro, Evidenziatore, Riflettore (A, S, D)"
+  },
+  "Starting Preset": {
+    "Starting Preset": "Preset iniziale"
+  },
+  "Starting Tool": {
+    "Starting Tool": "Strumento iniziale"
+  },
+  "Starting Tool Mode": {
+    "Starting Tool Mode": "Modalità dello strumento iniziale"
+  },
+  "Stop & Save": {
+    "Stop & Save": "Ferma e salva"
+  },
+  "Straight Line": {
+    "Straight Line": "Linea retta"
+  },
+  "Straight Line (2)": {
+    "Straight Line (2)": "Linea retta (2)"
+  },
+  "Surface Container Highest": {
+    "Surface Container Highest": "Contenitore superficie più alto"
+  },
+  "Switch to Select Tool": {
+    "Switch to Select Tool": "Passa allo strumento di selezione"
+  },
+  "Switch to your custom preset": {
+    "Switch to your custom preset": "Passa al tuo preset personalizzato"
+  },
+  "Synthwave Electric": {
+    "Synthwave Electric": "Synthwave Electric"
+  },
+  "System Audio Device": {
+    "System Audio Device": "Dispositivo audio di sistema"
+  },
+  "System Default": {
+    "System Default": "Predefinito di sistema"
+  },
+  "Target Output Name": {
+    "Target Output Name": "Nome uscita di destinazione"
+  },
+  "Text": {
+    "Text": "Testo"
+  },
+  "Text (W)": {
+    "Text (W)": "Testo (W)"
+  },
+  "Text Background Roundness": {
+    "Text Background Roundness": "Arrotondamento dello sfondo del testo"
+  },
+  "Text Color": {
+    "Text Color": "Colore del testo"
+  },
+  "Text Font": {
+    "Text Font": "Font del testo"
+  },
+  "Text Note": {
+    "Text Note": "Nota di testo"
+  },
+  "Text Size": {
+    "Text Size": "Dimensione del testo"
+  },
+  "Theme Primary Color": {
+    "Theme Primary Color": "Colore primario del tema"
+  },
+  "Thickness": {
+    "Thickness": "Spessore"
+  },
+  "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
+    "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": "Questo preset di palette è di sola lettura. Seleziona una delle opzioni seguenti per passare alla palette personalizzata e modificare i colori:\nToggle Hide/Show Annotations → Attiva/disattiva nascondi/mostra annotazioni"
+  },
+  "Toast": {
+    "Toast": "Toast"
+  },
+  "Toggle Hide/Show Annotations": {
+    "Toggle Hide/Show Annotations": "Attiva/disattiva nascondi/mostra annotazioni"
+  },
+  "Toggle Start / Stop": {
+    "Toggle Start / Stop": ""
+  },
+  "Toggle between 2 latest presets": {
+    "Toggle between 2 latest presets": "Alterna tra gli ultimi 2 preset"
+  },
+  "Tokyo Night": {
+    "Tokyo Night": "Tokyo Night"
+  },
+  "Tool Defaults": {
+    "Tool Defaults": "Impostazioni predefinite dello strumento"
+  },
+  "Toolbar": {
+    "Toolbar": "Barra degli strumenti"
+  },
+  "Toolbar Palette": {
+    "Toolbar Palette": "Palette della barra degli strumenti"
+  },
+  "Toolbar Position": {
+    "Toolbar Position": "Posizione della barra degli strumenti"
+  },
+  "Top": {
+    "Top": "In alto"
+  },
+  "Top Center": {
+    "Top Center": "In alto al centro"
+  },
+  "Top Left": {
+    "Top Left": "In alto a sinistra"
+  },
+  "Top Right": {
+    "Top Right": "In alto a destra"
+  },
+  "Transparent": {
+    "Transparent": "Trasparente"
+  },
+  "Transparent Background": {
+    "Transparent Background": "Sfondo trasparente"
+  },
+  "Trigger Middle-Click Action (Default: Interactive Region)": {
+    "Trigger Middle-Click Action (Default: Interactive Region)": "Attiva azione clic centrale (predefinito: Regione interattiva)"
+  },
+  "Trigger Right-Click Action (Default: Clipboard Annotate)": {
+    "Trigger Right-Click Action (Default: Clipboard Annotate)": "Attiva azione clic destro (predefinito: Annota appunti)"
+  },
+  "Trigger on Hover": {
+    "Trigger on Hover": "Attiva al passaggio del mouse"
+  },
+  "Type note...": {
+    "Type note...": "Scrivi una nota..."
+  },
+  "Undo (Ctrl+Z)": {
+    "Undo (Ctrl+Z)": "Annulla (Ctrl+Z)"
+  },
+  "Undo last stroke": {
+    "Undo last stroke": "Annulla l'ultimo tratto"
+  },
+  "Usage Guide": {
+    "Usage Guide": "Guida all'uso"
+  },
+  "Use Existing Custom": {
+    "Use Existing Custom": "Usa personalizzato esistente"
+  },
+  "Use Floating Editor": {
+    "Use Floating Editor": "Usa l'editor fluttuante"
+  },
+  "Use Modal Editor": {
+    "Use Modal Editor": "Usa l'editor a finestra modale"
+  },
+  "Very High": {
+    "Very High": "Molto alta"
+  },
+  "Video Codec": {
+    "Video Codec": "Codec video"
+  },
+  "Video Quality": {
+    "Video Quality": "Qualità dei video"
+  },
+  "Video Settings": {
+    "Video Settings": "Impostazioni dei video"
+  },
+  "Watermark": {
+    "Watermark": "Filigrana"
+  },
+  "Watermark Image": {
+    "Watermark Image": "Immagine di filigrana"
+  },
+  "Watermark Text": {
+    "Watermark Text": "Testo della filigrana"
+  },
+  "Watermark Type": {
+    "Watermark Type": "Tipo di filigrana"
+  },
+  "WebP Quality": {
+    "WebP Quality": "Qualità WebP"
+  },
+  "When enabled, the editor shrinks to match the captured region instead of filling 90% of the screen.": {
+    "When enabled, the editor shrinks to match the captured region instead of filling 90% of the screen.": "Se attivato, l'editor si riduce per adattarsi alla regione catturata invece di riempire il 90% dello schermo."
+  },
+  "Window": {
+    "Window": "Finestra"
+  },
+  "Window / Portal": {
+    "Window / Portal": ""
+  },
+  "Zoom Level": {
+    "Zoom Level": "Livello di zoom"
+  },
+  "gpu-screen-recorder is not installed. Please install it first.": {
+    "gpu-screen-recorder is not installed. Please install it first.": "gpu-screen-recorder non è installato. Installalo prima di continuare."
+  }
+}

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -164,9 +164,6 @@
   "Callout, Background (Z, B)": {
     "Callout, Background (Z, B)": ""
   },
-  "Cancel": {
-    "Cancel": ""
-  },
   "Capture": {
     "Capture": ""
   },
@@ -244,6 +241,9 @@
   },
   "Container Format": {
     "Container Format": ""
+  },
+  "Contributors": {
+    "Contributors": ""
   },
   "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
     "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": ""
@@ -530,8 +530,8 @@
   "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
     "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": ""
   },
-  "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
-    "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
   },
   "Framerate": {
     "Framerate": ""
@@ -682,6 +682,9 @@
   },
   "Live Preview": {
     "Live Preview": ""
+  },
+  "Loading contributors...": {
+    "Loading contributors...": ""
   },
   "Low": {
     "Low": "低"
@@ -1031,9 +1034,6 @@
   "Rounded Rectangle": {
     "Rounded Rectangle": ""
   },
-  "Save": {
-    "Save": ""
-  },
   "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
@@ -1144,6 +1144,9 @@
   },
   "Select Color Slots 5 - 8 (Q, W, E, R)": {
     "Select Color Slots 5 - 8 (Q, W, E, R)": ""
+  },
+  "Select Directory": {
+    "Select Directory": ""
   },
   "Select Image File": {
     "Select Image File": ""
@@ -1298,6 +1301,9 @@
   "System Audio Device": {
     "System Audio Device": ""
   },
+  "System Default": {
+    "System Default": "システム既定"
+  },
   "Target Output Name": {
     "Target Output Name": ""
   },
@@ -1326,7 +1332,7 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "厚さ"
+    "Thickness": "太さ"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -164,9 +164,6 @@
   "Callout, Background (Z, B)": {
     "Callout, Background (Z, B)": ""
   },
-  "Cancel": {
-    "Cancel": ""
-  },
   "Capture": {
     "Capture": ""
   },
@@ -244,6 +241,9 @@
   },
   "Container Format": {
     "Container Format": ""
+  },
+  "Contributors": {
+    "Contributors": ""
   },
   "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
     "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": ""
@@ -530,8 +530,8 @@
   "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
     "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": ""
   },
-  "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
-    "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
   },
   "Framerate": {
     "Framerate": ""
@@ -682,6 +682,9 @@
   },
   "Live Preview": {
     "Live Preview": ""
+  },
+  "Loading contributors...": {
+    "Loading contributors...": ""
   },
   "Low": {
     "Low": "낮음"
@@ -1031,9 +1034,6 @@
   "Rounded Rectangle": {
     "Rounded Rectangle": ""
   },
-  "Save": {
-    "Save": ""
-  },
   "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
@@ -1144,6 +1144,9 @@
   },
   "Select Color Slots 5 - 8 (Q, W, E, R)": {
     "Select Color Slots 5 - 8 (Q, W, E, R)": ""
+  },
+  "Select Directory": {
+    "Select Directory": ""
   },
   "Select Image File": {
     "Select Image File": ""
@@ -1297,6 +1300,9 @@
   },
   "System Audio Device": {
     "System Audio Device": ""
+  },
+  "System Default": {
+    "System Default": "시스템 기본값"
   },
   "Target Output Name": {
     "Target Output Name": ""

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Actie"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": "Adaptief"
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Toevoegen"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,13 +57,13 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Audio-codec"
   },
   "Auto": {
     "Auto": "Auto"
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "Achtergrond"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "Gebalanceerd"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Randkleur"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "Randdikte"
   },
   "Both": {
     "Both": ""
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Onder"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "Middenonder"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Linksonder"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Rechtsonder"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Kleur kiezen"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Klembord"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Sluiten"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Gekopieerd naar klembord"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "Kopiëren"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Aangepast"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Verwijderen"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Randafstand"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": "Bewerken"
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "Zweven"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": "Zwevend"
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Actieve venster"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Lettergrootte"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Hulp"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": "Hoog"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "Geschiedenis"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Afbeelding"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Afbeelding gekopieerd naar klembord"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "Toets"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Links"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": "Licht"
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "Laag"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Middel"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Geen achtergrond"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Geen"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": "Melding"
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Meldingen"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Dekking"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Openen"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "Pauzeren"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "Pixelvorming"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Positie"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "Voorbeeld"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Primair"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": "Gereed"
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Verversen"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Herstellen"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Hervatten"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Rechts"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "Scrollen"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Scrollen"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "Selecteren"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Instellingen"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Sneltoetsen"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "Systeemstandaard"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "Tekst"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "Tekstkleur"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Dikte"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": "Toast-melding"
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Boven"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "Middenboven"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Linksboven"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Rechtsboven"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "Zeer hoog"
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Działanie"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": "Adapcyjny"
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Dodaj"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Kodek audio"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "Automatycznie"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "Tło"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "Zbalansowane"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Kolor obramowania"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "Szerokość Obramowania"
   },
   "Both": {
-    "Both": ""
+    "Both": "Oba"
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Dół"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "Dół Środek"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Dolny Lewy"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Dolny Prawy"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Wybierz kolor"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Schowek"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Zamknij"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Skopiowano do schowka"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "Kopiuj"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Niestandardowy"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Usuń"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Odstępy między krawędziami"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": "Edytuj"
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": ""
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": ""
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Aktywne okno"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Rozmiar czcionki"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Pomoc"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": "Wysoka"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "Historia"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Zdjęcie"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Obraz skopiowany do schowka"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "Klawisz"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Lewa"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": ""
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "Niska"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Średni"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Brak tła"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Brak"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": "Powiadomienie"
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Powiadomienia"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Przezroczystość"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Otwórz"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "Wstrzymaj"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "Pikselacja"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Pozycja"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "Podgląd"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Główny"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": "Gotowe"
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Odśwież"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Resetuj"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Wznów"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Prawo"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "Przewijanie"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Przewijanie"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "Wybierz"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Ustawienia"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Skróty"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "Domyślne"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "Tekst"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "Kolor Tekstu"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Grubość"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": ""
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Góra"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "Góra Środek"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Górny Lewy"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Górny Prawy"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "Bardzo wysoka"
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -12,10 +12,10 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Ação"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
@@ -27,7 +27,7 @@
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Adicionar"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Codec de Áudio"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "Automático"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "Fundo"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "Balanceado"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Cor da Borda"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "Largura da Borda"
   },
   "Both": {
     "Both": ""
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Inferior"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "Centro Inferior"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Inferior Esquerdo"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Inferior Direito"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Escolha a Cor"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Área de transferência"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Fechar"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,7 +261,7 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Copiado para a área de transferência"
   },
   "Copied:": {
     "Copied:": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Customizado"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Excluir"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,7 +417,7 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Espaçamento de Bordas"
   },
   "Edit": {
     "Edit": "Editar"
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "Flutuante"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": "Flutuante"
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Janela Focada"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Tamanho da Fonte"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Ajuda"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -579,7 +579,7 @@
     "High": "Alto"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "Histórico"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Imagem"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Imagem copiada para a área de trabalho"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -663,7 +663,7 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Esquerda"
   },
   "Left Click": {
     "Left Click": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "Baixo"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Médio"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Sem fundo"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Nenhum"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": "Notificação"
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Notificações"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Opacidade"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Aberto"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "Pixelizar"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Posição"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "Pré-visualização"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Primário"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": "Pronto"
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Recarregar"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Resetar"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Resumir"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Direita"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "Rolagem"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Scrolling"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "Selecionar"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Configurações"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Atalhos"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,7 +1302,7 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "Padrão do Sistema"
   },
   "Target Output Name": {
     "Target Output Name": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "Cor do Texto"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Espessura"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": "Aviso"
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Topo"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "Centro Superior"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Superior Esquerdo"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Superior Direito"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "Muito Alto"
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -164,9 +164,6 @@
   "Callout, Background (Z, B)": {
     "Callout, Background (Z, B)": ""
   },
-  "Cancel": {
-    "Cancel": ""
-  },
   "Capture": {
     "Capture": ""
   },
@@ -244,6 +241,9 @@
   },
   "Container Format": {
     "Container Format": ""
+  },
+  "Contributors": {
+    "Contributors": ""
   },
   "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
     "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": ""
@@ -530,8 +530,8 @@
   "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
     "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": ""
   },
-  "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
-    "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
   },
   "Framerate": {
     "Framerate": ""
@@ -682,6 +682,9 @@
   },
   "Live Preview": {
     "Live Preview": ""
+  },
+  "Loading contributors...": {
+    "Loading contributors...": ""
   },
   "Low": {
     "Low": "Низкое"
@@ -834,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Пикселировать"
+    "Pixelate": "Пикселизация"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -1031,9 +1034,6 @@
   "Rounded Rectangle": {
     "Rounded Rectangle": ""
   },
-  "Save": {
-    "Save": ""
-  },
   "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
@@ -1144,6 +1144,9 @@
   },
   "Select Color Slots 5 - 8 (Q, W, E, R)": {
     "Select Color Slots 5 - 8 (Q, W, E, R)": ""
+  },
+  "Select Directory": {
+    "Select Directory": ""
   },
   "Select Image File": {
     "Select Image File": ""
@@ -1297,6 +1300,9 @@
   },
   "System Audio Device": {
     "System Audio Device": ""
+  },
+  "System Default": {
+    "System Default": "Системный по умолчанию"
   },
   "Target Output Name": {
     "Target Output Name": ""

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Åtgärd"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": ""
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Lägg till"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Ljudkodek"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "Automatisk"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "Bakgrund"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "Balanserad"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Färg på kantlinje"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": ""
   },
   "Both": {
     "Both": ""
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Nederkant"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "Nedre mitten"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Nedre vänster"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Nedre höger"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Välj färg"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Urklipp"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Stäng"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Kopierat till urklipp"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "Kopiera"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Anpassad"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Radera"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Avstånd från skärmkanter"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": ""
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "Flytande"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": ""
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Fönster i fokus"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Teckenstorlek"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Hjälp"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": ""
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "Historik"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Bild"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Bild kopierad till urklipp"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "Tangent"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Vänster"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": ""
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": ""
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Medel"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Ingen bakgrund"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Ingen"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": ""
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Notiser"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Opacitet"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Öppna"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "Pausa"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "Pixelera"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Position"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "Förhandsgranskning"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Primär"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": ""
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Uppdatera"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Återställ"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Återuppta"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Höger"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "Rulla"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Rullning"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "Välj"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Inställningar"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Genvägar"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1242,7 +1242,7 @@
     "Specific Output": ""
   },
   "Spotlight": {
-    "Spotlight": "Spotlight"
+    "Spotlight": ""
   },
   "Spotlight (D)": {
     "Spotlight (D)": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "Systemstandard"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "Text"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "Textfärg"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Tjocklek"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": ""
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Topp"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "Övre mitten"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Övre vänster"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Övre höger"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": ""
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Eylem"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": ""
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Ekle"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Ses Codec'i"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "Oto"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": ""
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": ""
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Kenarlık Rengi"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": ""
   },
   "Both": {
     "Both": ""
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Alt"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": ""
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Alt Sol"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Alt Sağ"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Renk Seç"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Pano"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Kapat"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Panoya kopyalandı"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": ""
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Özel"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Sil"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Kenar Aralığı"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": ""
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": ""
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": ""
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Odaklanılmış Pencere"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Yazı Tipi Boyutu"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Yardım"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": ""
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": ""
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Resim"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Görüntü panoya kopyalandı"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "Tuş"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Sol"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": ""
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": ""
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Orta"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Arkaplan Yok"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Hiçbiri"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": ""
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Bildirimler"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Opaklık"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Aç"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "Duraklat"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": ""
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Pozisyon"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": ""
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Birincil"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": ""
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Yenile"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Sıfırla"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Sürdür"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Sağ"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": ""
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Kaydırma"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": ""
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Ayarlar"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Kısayollar"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1242,7 +1242,7 @@
     "Specific Output": ""
   },
   "Spotlight": {
-    "Spotlight": "Spotlight"
+    "Spotlight": ""
   },
   "Spotlight (D)": {
     "Spotlight (D)": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": ""
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "Metin"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": ""
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Kalınlık"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": ""
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Üst"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": ""
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Üst Sol"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Üst Sağ"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": ""
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "Дія"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": "Адаптивний"
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "Додати"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "Аудіокодек"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "Авто"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "Фон"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "Збалансований"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "Колір контуру"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "Ширина контуру"
   },
   "Both": {
-    "Both": ""
+    "Both": "Обидва"
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "Знизу"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "Нижній центр"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "Нижній лівий"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "Нижній правий"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "Вибрати колір"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "Буфер обміну"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "Закрити"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "Скопійовано до буфера обміну"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "Копіювати"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "Власний"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "Видалити"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "Відступи від країв"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": "Редагувати"
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "Плавання"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": "Плавучий"
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "Активне вікно"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "Розмір шрифту"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "Допомога"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": "Високий"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "Історія"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "Зображення"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "Зображення скопійовано до буфера обміну"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "Клавіша"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "Зліва"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": "Світлий"
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "Низький"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "Середній"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "Без фону"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "Немає"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": "Сповіщення"
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "Сповіщення"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "Непрозорість"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "Відкрити"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "Призупинити"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "Пікселізація"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "Позиція"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "Попередній перегляд"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "Основний"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": "Готово"
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "Оновити"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "Скинути"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "Відновити"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "Праворуч"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "Прокрутка"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "Прокручування"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "Обрати"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "Налаштування"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "Комбінації"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "Системне значення за замовчуванням"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "Текст"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "Колір тексту"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "Товщина"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": "Спливаюче повідомлення"
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "Вгорі"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "Згори по центру"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "Зверху зліва"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "Згори справа"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "Дуже високий"
   },
   "Video Codec": {
     "Video Codec": ""

--- a/translations/vi.json
+++ b/translations/vi.json
@@ -164,9 +164,6 @@
   "Callout, Background (Z, B)": {
     "Callout, Background (Z, B)": ""
   },
-  "Cancel": {
-    "Cancel": ""
-  },
   "Capture": {
     "Capture": ""
   },
@@ -244,6 +241,9 @@
   },
   "Container Format": {
     "Container Format": ""
+  },
+  "Contributors": {
+    "Contributors": ""
   },
   "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
     "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": ""
@@ -530,8 +530,8 @@
   "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
     "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": ""
   },
-  "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
-    "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
   },
   "Framerate": {
     "Framerate": ""
@@ -682,6 +682,9 @@
   },
   "Live Preview": {
     "Live Preview": ""
+  },
+  "Loading contributors...": {
+    "Loading contributors...": ""
   },
   "Low": {
     "Low": "Thấp"
@@ -834,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelate"
+    "Pixelate": "Làm mờ điểm ảnh (Pixelate)"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -1031,9 +1034,6 @@
   "Rounded Rectangle": {
     "Rounded Rectangle": ""
   },
-  "Save": {
-    "Save": ""
-  },
   "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
@@ -1144,6 +1144,9 @@
   },
   "Select Color Slots 5 - 8 (Q, W, E, R)": {
     "Select Color Slots 5 - 8 (Q, W, E, R)": ""
+  },
+  "Select Directory": {
+    "Select Directory": ""
   },
   "Select Image File": {
     "Select Image File": ""
@@ -1298,6 +1301,9 @@
   "System Audio Device": {
     "System Audio Device": ""
   },
+  "System Default": {
+    "System Default": "Mặc định hệ thống"
+  },
   "Target Output Name": {
     "Target Output Name": ""
   },
@@ -1326,7 +1332,7 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "độ dày"
+    "Thickness": "Độ dày"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""

--- a/translations/zh_CN.json
+++ b/translations/zh_CN.json
@@ -164,9 +164,6 @@
   "Callout, Background (Z, B)": {
     "Callout, Background (Z, B)": ""
   },
-  "Cancel": {
-    "Cancel": ""
-  },
   "Capture": {
     "Capture": ""
   },
@@ -244,6 +241,9 @@
   },
   "Container Format": {
     "Container Format": ""
+  },
+  "Contributors": {
+    "Contributors": ""
   },
   "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": {
     "Controls the preview pixel budget while editing. Lower it if you experience lag. Does not affect the final saved image quality.": ""
@@ -530,8 +530,8 @@
   "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": {
     "Format tokens: %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second), {zzz} (Ms)": ""
   },
-  "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
-    "Format tokens: {user} (Username), \n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
+  "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": {
+    "Format tokens: {user} (Username), \\n (New Line), %Y (Year), %y (2-digit year), %m (Month), %d (Day), %H (Hour), %M (Minute), %S (Second)": ""
   },
   "Framerate": {
     "Framerate": ""
@@ -682,6 +682,9 @@
   },
   "Live Preview": {
     "Live Preview": ""
+  },
+  "Loading contributors...": {
+    "Loading contributors...": ""
   },
   "Low": {
     "Low": "低"
@@ -1031,9 +1034,6 @@
   "Rounded Rectangle": {
     "Rounded Rectangle": ""
   },
-  "Save": {
-    "Save": ""
-  },
   "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": {
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
@@ -1144,6 +1144,9 @@
   },
   "Select Color Slots 5 - 8 (Q, W, E, R)": {
     "Select Color Slots 5 - 8 (Q, W, E, R)": ""
+  },
+  "Select Directory": {
+    "Select Directory": ""
   },
   "Select Image File": {
     "Select Image File": ""
@@ -1298,6 +1301,9 @@
   "System Audio Device": {
     "System Audio Device": ""
   },
+  "System Default": {
+    "System Default": "系统默认"
+  },
   "Target Output Name": {
     "Target Output Name": ""
   },
@@ -1326,7 +1332,7 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "粗细"
+    "Thickness": "厚度"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""

--- a/translations/zh_TW.json
+++ b/translations/zh_TW.json
@@ -12,22 +12,22 @@
     "AUTO": ""
   },
   "Action": {
-    "Action": "Acción"
+    "Action": "動作"
   },
   "Action when Enter": {
-    "Action when Enter": "Acción al entrar"
+    "Action when Enter": ""
   },
   "Active Window": {
     "Active Window": ""
   },
   "Adaptive": {
-    "Adaptive": "Adaptativo"
+    "Adaptive": ""
   },
   "Adaptive (DMS Theme)": {
     "Adaptive (DMS Theme)": ""
   },
   "Add": {
-    "Add": "Añadir"
+    "Add": "新增"
   },
   "Add Text Note": {
     "Add Text Note": ""
@@ -57,16 +57,16 @@
     "Arrow Thickness": ""
   },
   "Arrow Vector": {
-    "Arrow Vector": "Vector de flecha"
+    "Arrow Vector": ""
   },
   "Audio & Overlay": {
     "Audio & Overlay": ""
   },
   "Audio Codec": {
-    "Audio Codec": "Códec de Audio"
+    "Audio Codec": "音訊編解碼器"
   },
   "Auto": {
-    "Auto": "Auto"
+    "Auto": "自動"
   },
   "Auto Balance": {
     "Auto Balance": ""
@@ -99,7 +99,7 @@
     "Back to Annotation (B)": ""
   },
   "Background": {
-    "Background": "Fondo"
+    "Background": "背景"
   },
   "Background (B)": {
     "Background (B)": ""
@@ -117,7 +117,7 @@
     "Background Presets": ""
   },
   "Balanced": {
-    "Balanced": "Equilibrado"
+    "Balanced": "平衡"
   },
   "Bar Interactions": {
     "Bar Interactions": ""
@@ -129,25 +129,25 @@
     "Blur Background Image": ""
   },
   "Border Color": {
-    "Border Color": "Color de borde"
+    "Border Color": "邊框顏色"
   },
   "Border Width": {
-    "Border Width": "Ancho del borde"
+    "Border Width": "邊框寬度"
   },
   "Both": {
     "Both": ""
   },
   "Bottom": {
-    "Bottom": "Abajo"
+    "Bottom": "下方"
   },
   "Bottom Center": {
-    "Bottom Center": "Centro inferior"
+    "Bottom Center": "底部中央"
   },
   "Bottom Left": {
-    "Bottom Left": "Abajo a la izquierda"
+    "Bottom Left": "左下"
   },
   "Bottom Right": {
-    "Bottom Right": "Abajo a la derecha"
+    "Bottom Right": "右下"
   },
   "CUST": {
     "CUST": ""
@@ -189,7 +189,7 @@
     "Center Right": ""
   },
   "Choose Color": {
-    "Choose Color": "Elegir color"
+    "Choose Color": "選擇顏色"
   },
   "Choose notifications shown after copy or save.": {
     "Choose notifications shown after copy or save.": ""
@@ -213,10 +213,10 @@
     "Clear saved region selection before each capture": ""
   },
   "Clipboard": {
-    "Clipboard": "Portapapeles"
+    "Clipboard": "剪貼簿"
   },
   "Close": {
-    "Close": "Cerrar"
+    "Close": "關閉"
   },
   "Close Annotator": {
     "Close Annotator": ""
@@ -261,13 +261,13 @@
     "Copied Anonymously": ""
   },
   "Copied to clipboard": {
-    "Copied to clipboard": "Copiado al portapapeles"
+    "Copied to clipboard": "複製到剪貼簿"
   },
   "Copied:": {
     "Copied:": ""
   },
   "Copy": {
-    "Copy": "Copiar"
+    "Copy": "複製"
   },
   "Copy & Save": {
     "Copy & Save": ""
@@ -288,13 +288,13 @@
     "Copy vector / Paste / Duplicate": ""
   },
   "Crop / Resize": {
-    "Crop / Resize": "Recortar / Cambiar tamaño"
+    "Crop / Resize": ""
   },
   "Crop / Resize Area": {
     "Crop / Resize Area": ""
   },
   "Custom": {
-    "Custom": "Personalizado"
+    "Custom": "自訂"
   },
   "Custom Colors": {
     "Custom Colors": ""
@@ -372,7 +372,7 @@
     "Default Watermark": ""
   },
   "Delete": {
-    "Delete": "Eliminar"
+    "Delete": "刪除"
   },
   "Dim Background Image": {
     "Dim Background Image": ""
@@ -417,10 +417,10 @@
     "Each command accepts action: <b>edit</b> (open editor) or <b>float</b> (always-on-top window).": ""
   },
   "Edge Spacing": {
-    "Edge Spacing": "Espacio entre bordes"
+    "Edge Spacing": "邊緣間距"
   },
   "Edit": {
-    "Edit": "Editar"
+    "Edit": ""
   },
   "Edit Color Palette": {
     "Edit Color Palette": ""
@@ -450,7 +450,7 @@
     "Ellipse": ""
   },
   "Ellipse / Circle": {
-    "Ellipse / Circle": "Elipse / Círculo"
+    "Ellipse / Circle": ""
   },
   "Ellipse / Circle (Q)": {
     "Ellipse / Circle (Q)": ""
@@ -468,7 +468,7 @@
     "Enable background automatically when opening the editor": ""
   },
   "Eraser": {
-    "Eraser": "Borrador"
+    "Eraser": ""
   },
   "Everforest": {
     "Everforest": ""
@@ -495,7 +495,7 @@
     "Flip Vert": ""
   },
   "Float": {
-    "Float": "Flotante"
+    "Float": "浮動"
   },
   "Float Image": {
     "Float Image": ""
@@ -504,16 +504,16 @@
     "Float Window": ""
   },
   "Floating": {
-    "Floating": "Flotante"
+    "Floating": "浮動"
   },
   "Focused Screen": {
     "Focused Screen": ""
   },
   "Focused Window": {
-    "Focused Window": "Ventana enfocada"
+    "Focused Window": "視窗對焦"
   },
   "Font Size": {
-    "Font Size": "Tamaño de fuente"
+    "Font Size": "字體大小"
   },
   "Font family used for number stamp labels": {
     "Font family used for number stamp labels": ""
@@ -540,7 +540,7 @@
     "Free": ""
   },
   "Freehand Pen": {
-    "Freehand Pen": "Pluma a mano alzada"
+    "Freehand Pen": ""
   },
   "Freehand Pen (1)": {
     "Freehand Pen (1)": ""
@@ -552,7 +552,7 @@
     "From File": ""
   },
   "Full Screen": {
-    "Full Screen": "Pantalla completa"
+    "Full Screen": ""
   },
   "Full Screen Target": {
     "Full Screen Target": ""
@@ -567,7 +567,7 @@
     "Gruvbox Material": ""
   },
   "Help": {
-    "Help": "Ayuda"
+    "Help": "說明"
   },
   "Hide Control Center": {
     "Hide Control Center": ""
@@ -576,10 +576,10 @@
     "Hide Control Center by Default": ""
   },
   "High": {
-    "High": "Alto"
+    "High": "高"
   },
   "Highlighter": {
-    "Highlighter": "resaltador"
+    "Highlighter": ""
   },
   "Highlighter (S)": {
     "Highlighter (S)": ""
@@ -591,7 +591,7 @@
     "Highlighter Thickness": ""
   },
   "History": {
-    "History": "Historial"
+    "History": "歷史記錄"
   },
   "Hover Trigger Delay": {
     "Hover Trigger Delay": ""
@@ -600,7 +600,7 @@
     "IPC Commands": ""
   },
   "Image": {
-    "Image": "Imagen"
+    "Image": "圖片"
   },
   "Image + Text": {
     "Image + Text": ""
@@ -615,7 +615,7 @@
     "Image Size": ""
   },
   "Image copied to clipboard": {
-    "Image copied to clipboard": "Imagen copiada al portapapeles"
+    "Image copied to clipboard": "影像已複製到剪貼簿"
   },
   "Image selected automatically when using Image Background mode": {
     "Image selected automatically when using Image Background mode": ""
@@ -648,7 +648,7 @@
     "Kanagawa": ""
   },
   "Key": {
-    "Key": "Tecla"
+    "Key": "按鍵"
   },
   "Landscape": {
     "Landscape": ""
@@ -663,13 +663,13 @@
     "Last Selected Region": ""
   },
   "Left": {
-    "Left": "Izquierda"
+    "Left": "左"
   },
   "Left Click": {
     "Left Click": ""
   },
   "Light": {
-    "Light": "Claro"
+    "Light": "細"
   },
   "Line Color": {
     "Line Color": ""
@@ -687,7 +687,7 @@
     "Loading contributors...": ""
   },
   "Low": {
-    "Low": "Bajo"
+    "Low": "低"
   },
   "Magnifier Loupe": {
     "Magnifier Loupe": ""
@@ -696,7 +696,7 @@
     "Max Height (0 = no limit)": ""
   },
   "Medium": {
-    "Medium": "Medio"
+    "Medium": "中"
   },
   "Menu Item Right Click": {
     "Menu Item Right Click": ""
@@ -726,7 +726,7 @@
     "Niri Binding Example": ""
   },
   "No Background": {
-    "No Background": "Sin fondo"
+    "No Background": "部件無背景"
   },
   "No Image Specified": {
     "No Image Specified": ""
@@ -741,10 +741,10 @@
     "No supported images found": ""
   },
   "None": {
-    "None": "Ninguna"
+    "None": "無"
   },
   "None / Disabled": {
-    "None / Disabled": "Ninguno / Desactivado"
+    "None / Disabled": ""
   },
   "Nord": {
     "Nord": ""
@@ -753,13 +753,13 @@
     "Note: Starting tool mode overrides tool thickness and color defaults if the starting tool matches it.": ""
   },
   "Notification": {
-    "Notification": "Notificación"
+    "Notification": ""
   },
   "Notifications": {
-    "Notifications": "Notificaciones"
+    "Notifications": "通知"
   },
   "Number Stamp": {
-    "Number Stamp": "Sello numérico"
+    "Number Stamp": ""
   },
   "OCR": {
     "OCR": ""
@@ -771,10 +771,10 @@
     "OCR Text Recognition": ""
   },
   "Opacity": {
-    "Opacity": "Opacidad"
+    "Opacity": "不透明度"
   },
   "Open": {
-    "Open": "Abrir"
+    "Open": "打開"
   },
   "Open Folder": {
     "Open Folder": ""
@@ -810,7 +810,7 @@
     "Palette Preset": ""
   },
   "Pause": {
-    "Pause": "Pausar"
+    "Pause": "暫停"
   },
   "Pause / Resume": {
     "Pause / Resume": ""
@@ -837,7 +837,7 @@
     "Pixel Intensity": ""
   },
   "Pixelate": {
-    "Pixelate": "Pixelar"
+    "Pixelate": "馬賽克"
   },
   "Pixelate (E)": {
     "Pixelate (E)": ""
@@ -852,7 +852,7 @@
     "Portrait": ""
   },
   "Position": {
-    "Position": "Posición"
+    "Position": "位置"
   },
   "Post-Capture Notification": {
     "Post-Capture Notification": ""
@@ -894,10 +894,10 @@
     "Preset Tool": ""
   },
   "Preview": {
-    "Preview": "Vista previa"
+    "Preview": "預覽"
   },
   "Primary": {
-    "Primary": "Primario"
+    "Primary": "主要"
   },
   "Primary Screen": {
     "Primary Screen": ""
@@ -933,7 +933,7 @@
     "Ratio": ""
   },
   "Ready": {
-    "Ready": "Listo"
+    "Ready": ""
   },
   "Recent Edits": {
     "Recent Edits": ""
@@ -969,7 +969,7 @@
     "Rectangle Color": ""
   },
   "Rectangle Outline": {
-    "Rectangle Outline": "Contorno del rectángulo"
+    "Rectangle Outline": ""
   },
   "Rectangle Outline (4)": {
     "Rectangle Outline (4)": ""
@@ -993,22 +993,22 @@
     "Redo last undone stroke": ""
   },
   "Refresh": {
-    "Refresh": "Recargar"
+    "Refresh": "重新整理"
   },
   "Region": {
     "Region": ""
   },
   "Reset": {
-    "Reset": "Reiniciar"
+    "Reset": "重設"
   },
   "Reset Last Region": {
     "Reset Last Region": ""
   },
   "Resume": {
-    "Resume": "Continuar"
+    "Resume": "恢復"
   },
   "Right": {
-    "Right": "Derecha"
+    "Right": "右方"
   },
   "Right Click": {
     "Right Click": ""
@@ -1038,7 +1038,7 @@
     "Save (Ctrl+S) | Save As (Ctrl+Shift+S)": ""
   },
   "Save Directory": {
-    "Save Directory": "Guardar directorio"
+    "Save Directory": ""
   },
   "Save Filename Pattern": {
     "Save Filename Pattern": ""
@@ -1119,7 +1119,7 @@
     "Screenshot saved to %1/%2": ""
   },
   "Scroll": {
-    "Scroll": "Desplazamiento"
+    "Scroll": "捲動"
   },
   "Scroll Interval": {
     "Scroll Interval": ""
@@ -1128,13 +1128,13 @@
     "Scroll capture: select a region, scroll content, then press Enter to finish.": ""
   },
   "Scrolling": {
-    "Scrolling": "Desplazamiento"
+    "Scrolling": "滾動"
   },
   "Scrolling Capture": {
     "Scrolling Capture": ""
   },
   "Select": {
-    "Select": "Seleccionar"
+    "Select": "選取"
   },
   "Select / Move stroke": {
     "Select / Move stroke": ""
@@ -1158,7 +1158,7 @@
     "Selected Tool / Action": ""
   },
   "Settings": {
-    "Settings": "Ajustes"
+    "Settings": "設定"
   },
   "Shapes": {
     "Shapes": ""
@@ -1167,7 +1167,7 @@
     "Shortcut Action": ""
   },
   "Shortcuts": {
-    "Shortcuts": "Atajos"
+    "Shortcuts": "快捷方式"
   },
   "Show Control Center": {
     "Show Control Center": ""
@@ -1242,7 +1242,7 @@
     "Specific Output": ""
   },
   "Spotlight": {
-    "Spotlight": "Spotlight"
+    "Spotlight": "聚焦"
   },
   "Spotlight (D)": {
     "Spotlight (D)": ""
@@ -1272,7 +1272,7 @@
     "Starting Preset": ""
   },
   "Starting Tool": {
-    "Starting Tool": "Herramienta de inicio"
+    "Starting Tool": ""
   },
   "Starting Tool Mode": {
     "Starting Tool Mode": ""
@@ -1281,7 +1281,7 @@
     "Stop & Save": ""
   },
   "Straight Line": {
-    "Straight Line": "Línea recta"
+    "Straight Line": ""
   },
   "Straight Line (2)": {
     "Straight Line (2)": ""
@@ -1302,13 +1302,13 @@
     "System Audio Device": ""
   },
   "System Default": {
-    "System Default": "Predeterminado del sistema"
+    "System Default": "系統預設"
   },
   "Target Output Name": {
     "Target Output Name": ""
   },
   "Text": {
-    "Text": "Texto"
+    "Text": "文字"
   },
   "Text (W)": {
     "Text (W)": ""
@@ -1317,13 +1317,13 @@
     "Text Background Roundness": ""
   },
   "Text Color": {
-    "Text Color": "Color de texto"
+    "Text Color": "文字顏色"
   },
   "Text Font": {
     "Text Font": ""
   },
   "Text Note": {
-    "Text Note": "Nota de texto"
+    "Text Note": ""
   },
   "Text Size": {
     "Text Size": ""
@@ -1332,13 +1332,13 @@
     "Theme Primary Color": ""
   },
   "Thickness": {
-    "Thickness": "Espesor"
+    "Thickness": "粗細"
   },
   "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": {
     "This palette preset is read-only. Select one of the options below to switch to the Custom Palette and edit colors:": ""
   },
   "Toast": {
-    "Toast": "Emergente"
+    "Toast": ""
   },
   "Toggle Hide/Show Annotations": {
     "Toggle Hide/Show Annotations": ""
@@ -1365,16 +1365,16 @@
     "Toolbar Position": ""
   },
   "Top": {
-    "Top": "Arriba"
+    "Top": "上方"
   },
   "Top Center": {
-    "Top Center": "Centro superior"
+    "Top Center": "頂端置中"
   },
   "Top Left": {
-    "Top Left": "Arriba a la izquierda"
+    "Top Left": "左上角"
   },
   "Top Right": {
-    "Top Right": "Arriba a la derecha"
+    "Top Right": "右上角"
   },
   "Transparent": {
     "Transparent": ""
@@ -1413,7 +1413,7 @@
     "Use Modal Editor": ""
   },
   "Very High": {
-    "Very High": "Muy alto"
+    "Very High": "非常高"
   },
   "Video Codec": {
     "Video Codec": ""


### PR DESCRIPTION
Translations synced from the DMS POEditor project, where this plugin's strings are tagged and translated alongside the shell.

Updated: ar.json, bg.json, de.json, eo.json, es.json, fa.json, fr.json, he.json, hu.json, it.json, ja.json, ko.json, nl.json, pl.json, pt.json, ru.json, sv.json, tr.json, uk.json, vi.json, zh_CN.json, zh_TW.json

Strings this repo already shipped were uploaded to POEditor before the export, so existing translations are preserved rather than overwritten.
